### PR TITLE
Add dynamic zone creation

### DIFF
--- a/supervisor/streamers.go
+++ b/supervisor/streamers.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+
 	"github.com/go-redis/redis/v8"
 	"github.com/google/uuid"
 	log "github.com/sirupsen/logrus"
@@ -18,8 +19,8 @@ func (s *streamer) dispose() {
 	s.client.Close()
 }
 
-// newPubsub create streamer instance
-func newPubsub(client *redis.Client) *streamer {
+// NewPubsub create streamer instance
+func NewPubsub(client *redis.Client) *streamer {
 	return &streamer{client: client}
 }
 
@@ -41,8 +42,8 @@ func (s *streamer) subscribe(ctx context.Context, channel string, msg chan strin
 	}()
 }
 
-// newRedisClient creates a new redis client instance
-func newRedisClient(streamerSocket, streamPasswd string) *redis.Client {
+// NewRedisClient creates a new redis client instance
+func NewRedisClient(streamerSocket, streamPasswd string) *redis.Client {
 	return redis.NewClient(&redis.Options{
 		Addr:     streamerSocket,
 		Password: streamPasswd,
@@ -53,7 +54,7 @@ func newRedisClient(streamerSocket, streamPasswd string) *redis.Client {
 // readyCheckRepsonder listens for any msg on healthcheckRequestChannel
 // replies on healthcheckReplyChannel to let the agents know it is available
 func readyCheckRepsonder(ctx context.Context, client *redis.Client) {
-	subHealthRequests := newPubsub(client)
+	subHealthRequests := NewPubsub(client)
 	msgRedChan := make(chan string)
 	go func() {
 		subHealthRequests.subscribe(ctx, healthcheckRequestChannel, msgRedChan)

--- a/supervisor/supervisor.go
+++ b/supervisor/supervisor.go
@@ -22,18 +22,23 @@ var (
 )
 
 const (
-	zoneChannelBlue           = "zone-blue"
-	zoneChannelRed            = "zone-red"
-	ipPrefixBlue              = "10.20.1.0/20"
-	ipPrefixRed               = "10.20.1.0/20"
-	BlueIpamSaveFile          = "ipam-blue.json"
-	RedIpamSaveFile           = "ipam-red.json"
+	zoneChannelController     = "controller"
+	zoneChannelDefault        = "default"
+	ipPrefixDefault           = "10.200.1.0/20"
+	DefaultIpamSaveFile       = "default-ipam.json"
+	DefaultZoneName           = "default"
 	streamPort                = 6379
 	restPort                  = "8080"
 	healthcheckRequestChannel = "supervisor-healthcheck-request"
 	healthcheckReplyChannel   = "supervisor-healthcheck-reply"
 	healthcheckReplyMsg       = "supervisor-healthy"
 	jwLogEnv                  = "JAYWALK_LOG_LEVEL"
+)
+
+// Message Events
+const (
+	registerNodeRequest = "register-node-request"
+	registerNodeReply   = "register-node-reply"
 )
 
 func init() {
@@ -46,12 +51,6 @@ func init() {
 		log.SetLevel(log.DebugLevel)
 	}
 }
-
-// Message Events
-const (
-	registerNodeRequest = "register-node-request"
-	registerNodeReply   = "register-node-reply"
-)
 
 // Peer represents data about a Peer's record.
 type Peer struct {
@@ -74,32 +73,38 @@ type MsgEvent struct {
 	Peer  Peer
 }
 
+type Zone struct {
+	NodeMap     map[string]Peer
+	Name        string `json:"Name"`
+	Description string `json:"Description"`
+	IpCidr      string `json:"CIDR"`
+	ZoneIpam    ipam.SupIpam
+}
+
 // Supervisor data specific to the supervisor
 type Supervisor struct {
-	Router         *gin.Engine
-	NodeMapRed     map[string]Peer
-	NodeMapBlue    map[string]Peer
-	ZoneConfigRed  map[string]ZoneConfig
-	ZoneConfigBlue map[string]ZoneConfig
-	stream         *redis.Client
-	streamSocket   string
-	streamPass     string
+	Router            *gin.Engine
+	Zones             []Zone
+	NodeMapDefault    map[string]Peer
+	ZoneConfigDefault map[string]ZoneConfig
+	ZoneConfigBlue    map[string]ZoneConfig
+	stream            *redis.Client
+	streamSocket      string
+	streamPass        string
 }
 
 func initApp() *Supervisor {
 	sup := new(Supervisor)
 	sup.Router = gin.Default()
-	sup.Router.GET("/peers", sup.GetPeers)                  // http://localhost:8080/peers
+	sup.Router.GET("/peers", sup.GetPeers)                  // http://localhost:8080/peers TODO: only functioning for zone:default atm
 	sup.Router.GET("/peers/:key", sup.GetPeerByKey)         // http://localhost:8080/peers/pubkey
+	sup.Router.GET("/ipam/leases/:zone", sup.GetIpamLeases) // http://localhost:8080/leases/:zone-name
 	sup.Router.GET("/zones", sup.GetZones)                  // http://localhost:8080/zones
-	sup.Router.GET("/ipam/leases/:zone", sup.GetIpamLeases) // http://localhost:8080/zones
-	sup.Router.POST("/peers", sup.PostPeers)                // TODO: not functioning
-	sup.NodeMapBlue = make(map[string]Peer)
-	sup.NodeMapRed = make(map[string]Peer)
-	sup.ZoneConfigRed = make(map[string]ZoneConfig)
+	sup.Router.POST("/zone", sup.PostZone)
+	sup.NodeMapDefault = make(map[string]Peer)
+	sup.ZoneConfigDefault = make(map[string]ZoneConfig)
 	sup.ZoneConfigBlue = make(map[string]ZoneConfig)
-	sup.setZoneDetails(zoneChannelRed)
-	sup.setZoneDetails(zoneChannelBlue)
+	sup.setZoneDefaultDetails(DefaultZoneName)
 	sup.streamSocket = fmt.Sprintf("%s:%d", *streamService, streamPort)
 	sup.streamPass = *streamPasswd
 
@@ -108,7 +113,7 @@ func initApp() *Supervisor {
 
 func main() {
 	sup := initApp()
-	client := newRedisClient(sup.streamSocket, sup.streamPass)
+	client := NewRedisClient(sup.streamSocket, sup.streamPass)
 	defer client.Close()
 
 	ctx := context.Background()
@@ -117,27 +122,36 @@ func main() {
 		log.Fatalf("Unable to connect to the redis instance at %s: %v", sup.streamSocket, err)
 	}
 
+	// respond to initial health check from agents initializing
 	readyCheckRepsonder(ctx, client)
-	// Initilize ipam for zone blue
-	ctxBlue := context.Background()
-	supIpamBlue, err := ipam.NewIPAM(ctxBlue, BlueIpamSaveFile, ipPrefixBlue)
+
+	// Handle all messages for zones other than the default zone
+	// TODO: assign each zone it's own channel for better multi-tenancy
+	go sup.MessageHandling(ctx)
+
+	// Initilize ipam for the default zone
+	ctxDefault := context.Background()
+	supIpamDefault, err := ipam.NewIPAM(ctx, DefaultIpamSaveFile, ipPrefixDefault)
 	if err != nil {
 		log.Warnf("failed to acquire an ipam address %v\n", err)
 	}
 
-	pubBlue := newPubsub(newRedisClient(sup.streamSocket, sup.streamPass))
-	subBlue := newPubsub(newRedisClient(sup.streamSocket, sup.streamPass))
+	pubDefault := NewPubsub(NewRedisClient(sup.streamSocket, sup.streamPass))
+	subDefault := NewPubsub(NewRedisClient(sup.streamSocket, sup.streamPass))
 
-	// channel for async messages from the zone subscription
-	msgChanBlue := make(chan string)
+	log.Debugf("Listening on channel: %s", zoneChannelDefault)
+
+	// channel for async messages from the zone subscription for the default zone
+	msgChanDefault := make(chan string)
 
 	go func() {
-		subBlue.subscribe(ctx, zoneChannelBlue, msgChanBlue)
+		subDefault.subscribe(ctx, zoneChannelDefault, msgChanDefault)
 		for {
-			msg := <-msgChanBlue
+			msg := <-msgChanDefault
 			msgEvent := handleMsg(msg)
 			switch msgEvent.Event {
 			case registerNodeRequest:
+				log.Debugf("Register node msg received on channel [ %s ]\n", zoneChannelDefault)
 				log.Debugf("Recieved registration request: %+v\n", msgEvent.Peer)
 				if msgEvent.Peer.PublicKey != "" {
 					nodeEvent := Peer{}
@@ -145,17 +159,17 @@ func main() {
 					// If this was a static address request
 					if msgEvent.Peer.NodeAddress != "" {
 						if err := ipam.ValidateIp(msgEvent.Peer.NodeAddress); err == nil {
-							ip, err = supIpamBlue.RequestSpecificIP(ctxBlue, msgEvent.Peer.NodeAddress, ipPrefixBlue)
+							ip, err = supIpamDefault.RequestSpecificIP(ctxDefault, msgEvent.Peer.NodeAddress, ipPrefixDefault)
 							if err != nil {
 								log.Errorf("failed to assign the requested address, assigning an address from the pool %v\n", err)
-								ip, err = supIpamBlue.RequestIP(ctxBlue, ipPrefixBlue)
+								ip, err = supIpamDefault.RequestIP(ctxDefault, ipPrefixDefault)
 								if err != nil {
 									log.Errorf("failed to acquire an IPAM assigned address %v\n", err)
 								}
 							}
 						}
 					} else {
-						ip, err = supIpamBlue.RequestIP(ctxBlue, ipPrefixBlue)
+						ip, err = supIpamDefault.RequestIP(ctxDefault, ipPrefixDefault)
 						if err != nil {
 							log.Errorf("failed to acquire an IPAM assigned address %v\n", err)
 						}
@@ -163,108 +177,30 @@ func main() {
 					// allocate a child prefix if requested
 					var childPrefix string
 					if msgEvent.Peer.ChildPrefix != "" {
-						childPrefix, err = supIpamBlue.RequestChildPrefix(ctxBlue, msgEvent.Peer.ChildPrefix)
+						childPrefix, err = supIpamDefault.RequestChildPrefix(ctxDefault, msgEvent.Peer.ChildPrefix)
 						if err != nil {
 							log.Errorf("%v\n", err)
 						}
 					}
 					// save the ipam to persistent storage
-					supIpamBlue.IpamSave(ctxBlue)
+					supIpamDefault.IpamSave(ctxDefault)
 					// construct the new node
 					nodeEvent = msgEvent.newNode(ip, childPrefix)
 					log.Debugf("node allocated: %+v\n", nodeEvent)
 					// delete the old k/v pair if one exists and replace it with the new registration data
-					if _, ok := sup.NodeMapBlue[msgEvent.Peer.PublicKey]; ok {
-						delete(sup.NodeMapBlue, msgEvent.Peer.PublicKey)
+					if _, ok := sup.NodeMapDefault[msgEvent.Peer.PublicKey]; ok {
+						delete(sup.NodeMapDefault, msgEvent.Peer.PublicKey)
 					}
-					sup.NodeMapBlue[msgEvent.Peer.PublicKey] = nodeEvent
+					sup.NodeMapDefault[msgEvent.Peer.PublicKey] = nodeEvent
 					// append all peers into the updated peer list to be published
 					var peerList []Peer
-					for pubKey, nodeElements := range sup.NodeMapBlue {
+					for pubKey, nodeElements := range sup.NodeMapDefault {
 						log.Printf("NodeState - PublicKey: [%s] EndpointIP [%s] AllowedIPs [%s] NodeAddress [%s] Zone [%s] ChildPrefix [%s]\n",
 							pubKey, nodeElements.EndpointIP, nodeElements.AllowedIPs, nodeElements.NodeAddress, nodeElements.Zone, nodeElements.ChildPrefix)
 						// append the new node to the updated peer listing
 						peerList = append(peerList, nodeElements)
 					}
-					// publishPeers the latest peer list
-					pubBlue.publishPeers(ctx, zoneChannelBlue, peerList)
-				}
-			}
-		}
-	}()
-
-	// Initilize ipam for zone red
-	// depending on how ctx background is being used a second instance may be unnecessary for multi-tenancy
-	ctxRed := context.Background()
-	supIpamRed, err := ipam.NewIPAM(ctxRed, RedIpamSaveFile, ipPrefixRed)
-	if err != nil {
-		log.Errorf("failed to acquire an ipam address %v\n", err)
-	}
-
-	pubRed := newPubsub(newRedisClient(sup.streamSocket, sup.streamPass))
-	subRed := newPubsub(newRedisClient(sup.streamSocket, sup.streamPass))
-
-	// channel for async messages from the zone subscription
-	msgChanRed := make(chan string)
-
-	go func() {
-		subRed.subscribe(ctx, zoneChannelRed, msgChanRed)
-		for {
-			msg := <-msgChanRed
-			msgEvent := handleMsg(msg)
-			switch msgEvent.Event {
-			case registerNodeRequest:
-				log.Debugf("Recieved registration request: %+v\n", msgEvent.Peer)
-				if msgEvent.Peer.PublicKey != "" {
-					nodeEvent := Peer{}
-					var ip string
-					// If this was a static address request
-					if msgEvent.Peer.NodeAddress != "" {
-						if err := ipam.ValidateIp(msgEvent.Peer.NodeAddress); err == nil {
-							ip, err = supIpamRed.RequestSpecificIP(ctxRed, msgEvent.Peer.NodeAddress, ipPrefixRed)
-							if err != nil {
-								log.Errorf("failed to assign the requested address, assigning an address from the pool %v\n", err)
-								ip, err = supIpamRed.RequestIP(ctxRed, ipPrefixRed)
-								if err != nil {
-									log.Errorf("failed to acquire an IPAM assigned address %v\n", err)
-								}
-							}
-						}
-					} else {
-						ip, err = supIpamRed.RequestIP(ctxRed, ipPrefixRed)
-						if err != nil {
-							log.Errorf("failed to acquire an IPAM assigned address %v\n", err)
-						}
-					}
-
-					// allocate a child prefix if requested
-					var childPrefix string
-					if msgEvent.Peer.ChildPrefix != "" {
-						childPrefix, err = supIpamRed.RequestChildPrefix(ctxRed, msgEvent.Peer.ChildPrefix)
-						if err != nil {
-							log.Errorf("%v\n", err)
-						}
-					}
-					// save the ipam to persistent storage
-					supIpamRed.IpamSave(ctxRed)
-					// construct the new node
-					nodeEvent = msgEvent.newNode(ip, childPrefix)
-					log.Debugf("node allocated: %+v\n", nodeEvent)
-					// delete the old k/v pair if one exists and replace it with the new registration data
-					if _, ok := sup.NodeMapRed[msgEvent.Peer.PublicKey]; ok {
-						delete(sup.NodeMapRed, msgEvent.Peer.PublicKey)
-					}
-					sup.NodeMapRed[msgEvent.Peer.PublicKey] = nodeEvent
-					// append all peers into the updated peer list to be published
-					var peerList []Peer
-					for pubKey, nodeElements := range sup.NodeMapRed {
-						log.Printf("NodeState - PublicKey: [%s] EndpointIP [%s] AllowedIPs [%s] NodeAddress [%s] Zone [%s] ChildPrefix [%s]\n",
-							pubKey, nodeElements.EndpointIP, nodeElements.AllowedIPs, nodeElements.NodeAddress, nodeElements.Zone, nodeElements.ChildPrefix)
-						// append the new node to the updated peer listing
-						peerList = append(peerList, nodeElements)
-					}
-					// publishPeers the latest peer list
-					pubRed.publishPeers(ctx, zoneChannelRed, peerList)
+					pubDefault.publishPeers(ctx, zoneChannelDefault, peerList)
 				}
 			}
 		}
@@ -303,21 +239,11 @@ func handleMsg(payload string) MsgEvent {
 }
 
 // setZoneDetails set general zone attributes
-func (sup *Supervisor) setZoneDetails(zone string) {
-	if zone == zoneChannelBlue {
-		zoneConfBlue := ZoneConfig{
-			Name:        zone,
-			Description: "Tenancy Zone Blue",
-			IpCidr:      ipPrefixBlue,
-		}
-		sup.ZoneConfigRed[zoneChannelBlue] = zoneConfBlue
+func (sup *Supervisor) setZoneDefaultDetails(zone string) {
+	zoneConfDefault := ZoneConfig{
+		Name:        zone,
+		Description: "Default Zone",
+		IpCidr:      ipPrefixDefault,
 	}
-	if zone == zoneChannelRed {
-		zoneConfRed := ZoneConfig{
-			Name:        zone,
-			Description: "Tenancy Zone Red",
-			IpCidr:      ipPrefixRed,
-		}
-		sup.ZoneConfigRed[zoneChannelRed] = zoneConfRed
-	}
+	sup.ZoneConfigDefault[zone] = zoneConfDefault
 }

--- a/supervisor/zones.go
+++ b/supervisor/zones.go
@@ -1,0 +1,165 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/redhat-et/jaywalking/supervisor/ipam"
+	log "github.com/sirupsen/logrus"
+)
+
+type MsgTypes struct {
+	ID    string
+	Event string
+	Zone  string
+	Peer  Peer
+}
+
+func (sup *Supervisor) AddPeer(ctx context.Context, msgEvent MsgEvent) error {
+
+	var nodeZone string
+	var ipamPrefix string
+	var err error
+	z := Zone{}
+	for _, zone := range sup.Zones {
+		if msgEvent.Peer.Zone == zone.Name {
+			nodeZone = msgEvent.Peer.Zone
+			ipamPrefix = zone.IpCidr
+			z = zone
+		}
+	}
+	if nodeZone == "" {
+		return fmt.Errorf("requested zone [ %s ] was not found, has it been created yet?\n", msgEvent.Peer.Zone)
+	}
+
+	peer := Peer{}
+	var ip string
+	// If this was a static address request
+	// TODO: handle a user requesting an IP not in the IPAM prefix
+	if msgEvent.Peer.NodeAddress != "" {
+		if err := ipam.ValidateIp(msgEvent.Peer.NodeAddress); err == nil {
+			ip, err = z.ZoneIpam.RequestSpecificIP(ctx, msgEvent.Peer.NodeAddress, ipamPrefix)
+			if err != nil {
+				log.Errorf("failed to assign the requested address %s, assigning an address from the pool %v\n", msgEvent.Peer.NodeAddress, err)
+				ip, err = z.ZoneIpam.RequestIP(ctx, ipamPrefix)
+				if err != nil {
+					log.Errorf("failed to acquire an IPAM assigned address %v\n", err)
+				}
+			}
+		}
+	} else {
+		ip, err = z.ZoneIpam.RequestIP(ctx, ipamPrefix)
+		if err != nil {
+			log.Errorf("failed to acquire an IPAM assigned address %v\n", err)
+		}
+	}
+	// allocate a child prefix if requested
+	var childPrefix string
+	if msgEvent.Peer.ChildPrefix != "" {
+		childPrefix, err = z.ZoneIpam.RequestChildPrefix(ctx, msgEvent.Peer.ChildPrefix)
+		if err != nil {
+			log.Errorf("%v\n", err)
+		}
+	}
+	// save the ipam to persistent storage
+	z.ZoneIpam.IpamSave(ctx)
+
+	// construct the new node
+	peer = msgEvent.newNode(ip, childPrefix)
+	log.Debugf("node allocated: %+v\n", peer)
+
+	for i, zone := range sup.Zones {
+		if zone.Name == nodeZone {
+			if sup.Zones[i].NodeMap == nil {
+				sup.Zones[i].NodeMap = make(map[string]Peer)
+			}
+			// delete the old k/v pair if one exists and replace it with the new registration data
+			if _, ok := sup.Zones[i].NodeMap[msgEvent.Peer.PublicKey]; ok {
+				delete(sup.Zones[i].NodeMap, msgEvent.Peer.PublicKey)
+			}
+			sup.Zones[i].NodeMap[msgEvent.Peer.PublicKey] = peer
+		}
+	}
+
+	return nil
+}
+
+func (sup *Supervisor) MessageHandling(ctx context.Context) {
+
+	pub := NewPubsub(NewRedisClient(sup.streamSocket, sup.streamPass))
+	sub := NewPubsub(NewRedisClient(sup.streamSocket, sup.streamPass))
+
+	// channel for async messages from the zone subscription
+	controllerChan := make(chan string)
+
+	go func() {
+		sub.subscribe(ctx, zoneChannelController, controllerChan)
+		log.Debugf("Listening on channel: %s", zoneChannelController)
+
+		for {
+			msg := <-controllerChan
+			msgEvent := msgHandler(msg)
+			switch msgEvent.Event {
+			// TODO implement error chans
+			case registerNodeRequest:
+				log.Debugf("Register node msg received on channel [ %s ]\n", zoneChannelController)
+				log.Debugf("Recieved registration request: %+v\n", msgEvent.Peer)
+				if msgEvent.Peer.PublicKey != "" {
+					err := sup.AddPeer(ctx, msgEvent)
+					// append all peers into the updated peer list to be published
+					if err == nil {
+						var peerList []Peer
+						for _, zone := range sup.Zones {
+							if zone.Name == msgEvent.Peer.Zone {
+								for pubKey, nodeElements := range zone.NodeMap {
+									log.Printf("NodeState - PublicKey: [%s] EndpointIP [%s] AllowedIPs [%s] NodeAddress [%s] Zone [%s] ChildPrefix [%s]\n",
+										pubKey, nodeElements.EndpointIP, nodeElements.AllowedIPs, nodeElements.NodeAddress, nodeElements.Zone, nodeElements.ChildPrefix)
+									// append the new node to the updated peer listing
+									peerList = append(peerList, nodeElements)
+								}
+							}
+							// publishPeers the latest peer list
+							pub.publishPeers(ctx, zoneChannelController, peerList)
+						}
+					} else {
+						log.Errorf("Peer was not added: %v", err)
+						// TODO: return an error to the agent on a message chan
+					}
+				}
+			}
+		}
+	}()
+}
+
+// handleMsg deals with streaming messages
+func msgHandler(payload string) MsgEvent {
+	var peer MsgEvent
+	err := json.Unmarshal([]byte(payload), &peer)
+	if err != nil {
+		log.Debugf("HandleMsg unmarshall error: %v\n", err)
+		return peer
+	}
+	return peer
+}
+
+func NewPubMessage(data string) (string, string) {
+	id := uuid.NewString()
+	msg, _ := json.Marshal(&MsgTypes{
+		ID:    id,
+		Event: data,
+	})
+	return id, string(msg)
+}
+
+// TODO example: do we want to implement a UUID with channel messages?
+func PubMessage(ctx context.Context, channel, data string) {
+	id, msg := NewPubMessage(data)
+	err := redisDB.Publish(ctx, channel, msg).Err()
+	if err != nil {
+		log.Errorf("Sending msg ID %s failed, %v\n", id, err)
+		return
+	}
+	log.Printf("Sent Message: %s\n", msg)
+}

--- a/tests/e2e-scripts/create-jaywalk-startup.sh
+++ b/tests/e2e-scripts/create-jaywalk-startup.sh
@@ -6,17 +6,19 @@ pvtkey=${2}
 redis=${3}
 local_endpoint=${4}
 controller_passwd=${5}
-script_output_name=${6}
+zone=${6}
+script_output_name=${7}
 
 echo "Public Key: ${pubkey}"
 echo "Private Key: ${pvtkey}"
 echo "Redis Instance: ${redis}"
 echo "Local Endpoint IP: ${local_endpoint}"
 echo "Controller Password ${controller_passwd}"
+echo "Zone Name: ${zone}"
 echo "Script Name: ${script_output_name}"
 
 # Create the script
-cat << EOF > ${6}
+cat << EOF > ${7}
 #!/bin/bash
 
 jaywalk \
@@ -25,7 +27,7 @@ jaywalk \
 --controller=${redis}  \
 --local-endpoint-ip=${local_endpoint} \
 --agent-mode \
---zone=zone-blue \
+--zone=${zone} \
 --controller-password=${controller_passwd}
 EOF
 

--- a/tests/e2e-scripts/init-containers.sh
+++ b/tests/e2e-scripts/init-containers.sh
@@ -81,6 +81,7 @@ copy_binaries() {
     # Shared controller address
     local controller=$(sudo docker inspect --format "{{ .NetworkSettings.IPAddress }}" redis)
     local controller_passwd=floofykittens
+    local zone=default
 
     # node1 specific details
     local node1_pubkey=AbZ1fPkCbjYAe9D61normbb7urAzMGaRMDVyR5Bmzz4=
@@ -94,9 +95,9 @@ copy_binaries() {
 
     chmod +x e2e-scripts/create-jaywalk-startup.sh
     # Create jaywalk startup script for node1
-    e2e-scripts/create-jaywalk-startup.sh ${node1_pubkey} ${node1_pvtkey} ${controller} ${node1_ip} ${controller_passwd} jaywalk-run-node1.sh
+    e2e-scripts/create-jaywalk-startup.sh ${node1_pubkey} ${node1_pvtkey} ${controller} ${node1_ip} ${controller_passwd} ${zone} jaywalk-run-node1.sh
     # Create jaywalk startup script for node2
-    e2e-scripts/create-jaywalk-startup.sh ${node2_pubkey} ${node2_pvtkey} ${controller} ${node2_ip} ${controller_passwd} jaywalk-run-node2.sh
+    e2e-scripts/create-jaywalk-startup.sh ${node2_pubkey} ${node2_pvtkey} ${controller} ${node2_ip} ${controller_passwd} ${zone} jaywalk-run-node2.sh
 
     # STDOUT the scripts for debugging
     cat jaywalk-run-node1.sh
@@ -148,10 +149,84 @@ verify_connectivity() {
     fi
 }
 
+setup_custom_zone_connectivity() {
+    ###########################################################################
+    # Description:                                                            #
+    # Verify the container can reach one another                              #
+    #                                                                         #
+    # Arguments:                                                              #
+    #   None                                                                  #
+    ###########################################################################
+    # Shared controller address
+    local controller=$(sudo docker inspect --format "{{ .NetworkSettings.IPAddress }}" redis)
+    local controller_passwd=floofykittens
+    local zone=zone-blue
+
+    # node1 specific details
+    local node1_pubkey=AbZ1fPkCbjYAe9D61normbb7urAzMGaRMDVyR5Bmzz4=
+    local node1_pvtkey=8GtvCMlUsFVoadj0B3Y3foy7QbKJB9vcq5R+Mpc7OlE=
+    local node1_ip=$(sudo docker inspect --format "{{ .NetworkSettings.IPAddress }}" node1)
+
+    # node2 specific details
+    local node2_pubkey=oJlDE1y9xxmR6CIEYCSJAN+8b/RK73TpBYixlFiBJDM=
+    local node2_pvtkey=cGXbnP3WKIYbIbEyFpQ+kziNk/kHBM8VJhslEG8Uj1c=
+    local node2_ip=$(sudo docker inspect --format "{{ .NetworkSettings.IPAddress }}" node2)
+
+    # Create the new zone
+    curl -L -X POST 'http://localhost:8080/zone' \
+    -H 'Content-Type: application/json' \
+    --data-raw '{
+        "Name": "zone-blue",
+        "Description": "Tenant - Zone Blue",
+        "CIDR": "10.140.0.0/20"
+    }'
+
+    # Create jaywalk startup script for node1
+    e2e-scripts/create-jaywalk-startup.sh ${node1_pubkey} ${node1_pvtkey} ${controller} ${node1_ip} ${controller_passwd} ${zone} jaywalk-run-node1.sh
+    # Create jaywalk startup script for node2
+    e2e-scripts/create-jaywalk-startup.sh ${node2_pubkey} ${node2_pvtkey} ${controller} ${node2_ip} ${controller_passwd} ${zone} jaywalk-run-node2.sh
+
+    # STDOUT the scripts for debugging
+    cat jaywalk-run-node1.sh
+    cat jaywalk-run-node2.sh
+
+    # Kill the jaywalk process on both nodes
+    sudo docker exec node1 killall jaywalk
+    sudo docker exec node2 killall jaywalk
+
+    sudo docker cp ./jaywalk-run-node1.sh node1:/bin/jaywalk-run-node1.sh
+    sudo docker cp ./jaywalk-run-node2.sh node2:/bin/jaywalk-run-node2.sh
+
+    # Set permissions in the container
+    sudo docker exec node1 chmod +x /bin/jaywalk-run-node1.sh
+    sudo docker exec node2 chmod +x /bin/jaywalk-run-node2.sh
+
+    # Start the agents on both nodes
+    sudo docker exec node1 /bin/jaywalk-run-node1.sh &
+    sudo docker exec node2 /bin/jaywalk-run-node2.sh &
+
+    # Allow one second for the wg0 interface to readdress
+    sleep 2
+
+    # Check connectivity between node1 -> node2
+    if sudo docker exec node1 ping -c 2 -w 2 $(sudo docker exec node2 ip --brief address show wg0 | awk '{print $3}' | cut -d "/" -f1); then
+        echo "peer nodes successfully communicated"
+    else
+        echo "node1 failed to reach node2, e2e failed"
+        exit 1
+    fi
+    # Check connectivity between node2 -> node1
+    if sudo docker exec node2 ping -c 2 -w 2 $(sudo docker exec node1 ip --brief address show wg0 | awk '{print $3}' | cut -d "/" -f1); then
+        echo "peer nodes successfully communicated"
+    else
+        echo "node2 failed to reach node1, e2e failed"
+        exit 1
+    fi
+}
 ###########################################################################
 # Description:                                                            #
 # Run the following functions to test end to end connectivity between     #
-# Wireguard interfaces in the container on intrerface wg0                 #
+# Wireguard interfaces in the container on interface wg0                 #
 #                                                                         #
 # Arguments:                                                              #
 #   None                                                                  #
@@ -160,4 +235,6 @@ install_docker
 start_containers
 start_supervisor
 copy_binaries
+verify_connectivity
+setup_custom_zone_connectivity
 verify_connectivity


### PR DESCRIPTION
- adds the ability to create a zone via the REST API.
- sets up a redis channel for custom created zone messaging.
- left one default zone and default channel for agent joins. that do not include a zone
- added IT for custom zones and updated demos.

Signed-off-by: Brent Salisbury <bsalisbu@redhat.com>