### PR TITLE
Added -internal-network option to auto discover local addresses

### DIFF
--- a/aircrew/utils.go
+++ b/aircrew/utils.go
@@ -132,7 +132,7 @@ func GetDarwinIPv4() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return osxIP, nil
+	return strings.TrimSuffix(osxIP, "\n"), nil
 }
 
 // GetPubIP retrieves current global IP address using https://checkip.amazonaws.com/

--- a/tests/e2e-scripts/create-aircrew-startup.sh
+++ b/tests/e2e-scripts/create-aircrew-startup.sh
@@ -28,7 +28,6 @@ aircrew \
 --private-key=${pvtkey}  \
 --controller=${redis}  \
 --local-endpoint-ip=${local_endpoint} \
---agent-mode \
 --zone=${zone} \
 --controller-password=${controller_passwd}
 EOF


### PR DESCRIPTION
- This is an alternative to the user having to manually add `--local-endpoint-ip` in scenarios where a public ingress port is unavailable.
- Made `--agent-mode` the default.
- Associated with #27