### PR TITLE
Terminate agent if it tries to register to unregistered zone

### DIFF
--- a/cmd/aircrew/main.go
+++ b/cmd/aircrew/main.go
@@ -2,362 +2,132 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"os"
-	"time"
+	"os/signal"
+	"syscall"
 
-	"github.com/go-redis/redis/v8"
 	"github.com/redhat-et/jaywalking/internal/aircrew"
-	"github.com/redhat-et/jaywalking/internal/messages"
 	log "github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
 )
 
-type flags struct {
-	wireguardPubKey        string
-	wireguardPvtKey        string
-	wireguardPvtKeyFile    string
-	controllerIP           string
-	controllerPasswd       string
-	listenPort             int
-	configFile             string
-	zone                   string
-	requestedIP            string
-	userProvidedEndpointIP string
-	childPrefix            string
-	agentMode              bool
-	internalNetwork        bool
-	hubRouter              bool
-}
-
-var (
-	cliFlags flags
-)
-
 const (
-	readyRequestTimeout = 10
 	aircrewLogEnv       = "AIRCREW_LOG_LEVEL"
 )
 
-// Message Events
-const (
-	registerNodeRequest = "register-node-request"
-)
-
-func init() {
+func main() {
 	// set the log level
 	env := os.Getenv(aircrewLogEnv)
 	if env == "debug" {
 		log.SetLevel(log.DebugLevel)
 	}
-}
-
-func main() {
 	// flags are stored in the global flags variable
 	app := &cli.App{
+		Name: "aircrew",
+		Usage: "Node agent to configure encrypted mesh networking.",
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:        "public-key",
 				Value:       "",
 				Usage:       "public key for the local host (required)",
-				Destination: &cliFlags.wireguardPubKey,
 				EnvVars:     []string{"AIRCREW_PUB_KEY"},
+				Required: true,
 			},
 			&cli.StringFlag{
 				Name:        "private-key-file",
 				Value:       "",
 				Usage:       "private key for the local host (recommended - but alternatively pass through --private-key",
-				Destination: &cliFlags.wireguardPvtKeyFile,
 				EnvVars:     []string{"AIRCREW_PRIVATE_KEY_FILE"},
+				Required: true,
 			},
 			&cli.StringFlag{
 				Name:        "private-key",
 				Value:       "",
 				Usage:       "private key for the local host (demo purposes only - alternatively pass through --private-key-file",
-				Destination: &cliFlags.wireguardPvtKey,
 				EnvVars:     []string{"AIRCREW_PRIVATE_KEY"},
 			},
 			&cli.IntFlag{
 				Name:        "listen-port",
 				Value:       51820,
 				Usage:       "port wireguard is to listen for incoming peers on",
-				Destination: &cliFlags.listenPort,
 				EnvVars:     []string{"AIRCREW_LISTEN_PORT"},
 			},
 			&cli.StringFlag{
 				Name:        "controller",
 				Value:       "",
 				Usage:       "address of the controller (required)",
-				Destination: &cliFlags.controllerIP,
 				EnvVars:     []string{"AIRCREW_CONTROLLER"},
+				Required: true,
 			},
 			&cli.StringFlag{
 				Name:        "controller-password",
 				Value:       "",
 				Usage:       "password for the controller (required)",
-				Destination: &cliFlags.controllerPasswd,
 				EnvVars:     []string{"AIRCREW_CONTROLLER_PASSWD"},
+				Required: true,
 			},
 			&cli.StringFlag{
 				Name:        "zone",
-				Value:       "00000000-0000-0000-0000-000000000000",
+				Value:       "controller",
 				Usage:       "the tenancy zone the peer is to join - zone needs to be created before joining (optional)",
-				Destination: &cliFlags.zone,
 				EnvVars:     []string{"AIRCREW_ZONE"},
 			},
 			&cli.StringFlag{
 				Name:        "request-ip",
 				Value:       "",
 				Usage:       "request a specific IP address from Ipam if available (optional)",
-				Destination: &cliFlags.requestedIP,
 				EnvVars:     []string{"AIRCREW_REQUESTED_IP"},
 			},
 			&cli.StringFlag{
 				Name:        "local-endpoint-ip",
 				Value:       "",
 				Usage:       "specify the endpoint address of this node instead of being discovered (optional)",
-				Destination: &cliFlags.userProvidedEndpointIP,
 				EnvVars:     []string{"AIRCREW_LOCAL_ENDPOINT_IP"},
 			},
 			&cli.StringFlag{
 				Name:        "child-prefix",
 				Value:       "",
 				Usage:       "request a CIDR range of addresses that will be advertised from this node (optional)",
-				Destination: &cliFlags.childPrefix,
 				EnvVars:     []string{"AIRCREW_REQUESTED_CHILD_PREFIX"},
 			},
 			&cli.BoolFlag{Name: "internal-network",
 				Usage:       "do not discover the public address for this host, use the local address for peering",
 				Value:       false,
-				Destination: &cliFlags.internalNetwork,
 				EnvVars:     []string{"AIRCREW_INTERNAL_NETWORK"},
 			},
 			&cli.BoolFlag{Name: "hub-router",
 				Usage:       "set if this node is to be the hub in a hub and spoke deployment",
 				Value:       false,
-				Destination: &cliFlags.hubRouter,
 				EnvVars:     []string{"AIRCREW_HUB_ROUTER"},
 			},
 		},
-	}
-	app.Name = "aircrew"
-	app.Usage = "encrypted mesh networking"
-	// clean up any pre-existing interfaces
-	app.Before = func(c *cli.Context) error {
-		if c.IsSet("clean") {
-			log.Print("Cleaning up any existing interfaces")
-			// todo: implement a cleanup function
-		}
-		return nil
-	}
-	app.Action = func(c *cli.Context) error {
-		// call the applications function
-		runInit()
-		return nil
+		Before: func(c *cli.Context) error {
+			if c.IsSet("clean") {
+				log.Print("Cleaning up any existing interfaces")
+				// todo: implement a cleanup function
+			}
+			return nil
+		},
+		Action: func(c *cli.Context) error {
+			aircrew, err := aircrew.NewAircrew(
+				context.Background(), c)
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			aircrew.Run()
+
+			ch := make(chan os.Signal, 1)
+			signal.Notify(ch, syscall.SIGTERM, syscall.SIGQUIT, syscall.SIGINT)
+			<-ch
+
+			if err := aircrew.Shutdown(context.Background()); err != nil {
+				log.Fatal(err)
+			}
+			return nil
+		},
 	}
 	if err := app.Run(os.Args); err != nil {
 		log.Fatal(err)
 	}
-}
-
-func runInit() {
-	if !aircrew.IsCommandAvailable("wg") {
-		log.Fatal("wg command not found, is wireguard installed?")
-	}
-	// PublicKey is the unique identifier for a node and required
-	if cliFlags.wireguardPubKey == "" {
-		log.Fatal("the public key for this host is required to run")
-	}
-	ctx := context.Background()
-	var err error
-	var nodeOS string
-	switch aircrew.GetOS() {
-	case "windows":
-		log.Fatalf("OS [%s] is not currently supported\n", aircrew.GetOS())
-	case aircrew.Darwin.String():
-		log.Printf("[%s] operating system detected", aircrew.Darwin.String())
-		nodeOS = aircrew.Darwin.String()
-		// ensure the osx wireguard directory exists
-		if err := aircrew.CreateDirectory(aircrew.WgLinuxConfPath); err != nil {
-			log.Fatalf("Unable to create the wireguard config directory [%s]: %v", aircrew.WgDarwinConfPath, err)
-		}
-	case aircrew.Linux.String():
-		log.Printf("[%s] operating system detected", aircrew.Linux.String())
-		nodeOS = aircrew.Linux.String()
-		// ensure the wireguard directory exists
-		if err := aircrew.CreateDirectory(aircrew.WgLinuxConfPath); err != nil {
-			log.Fatalf("Unable to create the wireguard config directory [%s]: %v", aircrew.WgDarwinConfPath, err)
-		}
-	default:
-		log.Fatalf("OS [%s] is not supported\n", aircrew.GetOS())
-	}
-
-	// parse the private key for the local configuration from file or CLI
-	var pvtKey string
-	if cliFlags.wireguardPvtKey != "" && cliFlags.wireguardPvtKeyFile != "" {
-		log.Fatalf("Please use either --private-key or --private-key-file but not both")
-	}
-	if cliFlags.wireguardPvtKey == "" && cliFlags.wireguardPvtKeyFile == "" {
-		log.Fatalf("Private key or key file location is required: use either --private-key or --private-key-file")
-	}
-	if cliFlags.wireguardPvtKey != "" {
-		pvtKey = cliFlags.wireguardPvtKey
-	}
-	if cliFlags.wireguardPvtKeyFile != "" {
-		if !aircrew.FileExists(cliFlags.wireguardPvtKeyFile) {
-			log.Fatalf("Failed to retrieve the private key from file: %s", cliFlags.wireguardPvtKeyFile)
-		}
-		pvtKey, err = aircrew.ReadKeyFileToString(cliFlags.wireguardPvtKeyFile)
-		if err != nil {
-			log.Fatalf("Failed to retrieve the private key from file %s: %v", cliFlags.wireguardPvtKeyFile, err)
-		}
-	}
-
-	// If the user supplied what they want the local endpoint IP to be, use that (enables privateIP <--> privateIP peering).
-	// Otherwise, discover what the public of the node is and provide that to the peers unless the --internal flag was set,
-	// in which case the endpoint address will be set to an existing address on the host.
-	var localEndpointIP string
-	if cliFlags.internalNetwork && nodeOS == aircrew.Darwin.String() {
-		localEndpointIP, err = aircrew.GetDarwinIPv4()
-		if err != nil {
-			log.Fatalf("unable to determine the ip address of the OSX host en0, please specify using --local-endpoint-ip: %v", err)
-		}
-	}
-	if cliFlags.internalNetwork && nodeOS == aircrew.Linux.String() {
-		localEndpointIP, err = aircrew.GetIPv4Linux()
-		if err != nil {
-			log.Fatalf("unable to determine the ip address, please specify using --local-endpoint-ip")
-		}
-	}
-	// User provided --local-endpoint-ip overrides --internal-network
-	if cliFlags.userProvidedEndpointIP != "" {
-		if err := aircrew.ValidateIp(cliFlags.userProvidedEndpointIP); err != nil {
-			log.Fatalf("the IP address passed in --local-endpoint-ip %s was not valid: %v",
-				cliFlags.userProvidedEndpointIP, err)
-		}
-		localEndpointIP = cliFlags.userProvidedEndpointIP
-	}
-	// this conditional is last since it is expensive to do the public address lookup
-	if !cliFlags.internalNetwork && cliFlags.userProvidedEndpointIP == "" {
-		localEndpointIP, err = aircrew.GetPubIP()
-		if err != nil {
-			log.Warn("Unable to determine the public facing address")
-		}
-	}
-	log.Debugf("This node's endpoint address will be [ %s ]", localEndpointIP)
-
-	as := &aircrew.AircrewState{
-		NodePubKey:        cliFlags.wireguardPubKey,
-		NodePvtKey:        pvtKey,
-		AircrewConfigFile: cliFlags.configFile,
-		Daemon:            cliFlags.agentMode,
-		NodeOS:            nodeOS,
-		Zone:              cliFlags.zone,
-		RequestedIP:       cliFlags.requestedIP,
-		ChildPrefix:       cliFlags.childPrefix,
-		UserEndpointIP:    cliFlags.userProvidedEndpointIP,
-		HubRouter:         cliFlags.hubRouter,
-	}
-
-	controller := fmt.Sprintf("%s:6379", cliFlags.controllerIP)
-	rc := redis.NewClient(&redis.Options{
-		Addr:     controller,
-		Password: cliFlags.controllerPasswd,
-	})
-
-	// TODO: move to a redis package used by both server and agent
-	_, err = rc.Ping(ctx).Result()
-	if err != nil {
-		log.Fatalf("Unable to connect to the redis instance at %s: %v", controller, err)
-	}
-
-	// ping the control-tower to see if it is responding via the broker, exit the agent on timeout
-	if err := controlTowerReadyCheck(ctx, rc); err != nil {
-		log.Fatal(err)
-	}
-
-	defer rc.Close()
-
-	subChannel := messages.ZoneChannelDefault
-	if as.Zone != messages.ZoneChannelDefault {
-		subChannel = messages.ZoneChannelController
-	}
-
-	sub := rc.Subscribe(ctx, subChannel)
-	defer sub.Close()
-
-	endpointSocket := fmt.Sprintf("%s:%d", localEndpointIP, aircrew.WgListenPort)
-	// Create the message describing this peer to be published
-	peerRegister := messages.NewPublishPeerMessage(
-		registerNodeRequest,
-		as.Zone,
-		as.NodePubKey,
-		endpointSocket,
-		as.RequestedIP,
-		as.ChildPrefix,
-		"",
-		false,
-		as.HubRouter)
-	// Agent only needs to subscribe
-	if as.Zone == "default" {
-		as.AgentChannel = messages.ZoneChannelDefault
-	} else {
-		as.AgentChannel = messages.ZoneChannelController
-	}
-
-	err = rc.Publish(ctx, as.AgentChannel, peerRegister).Err()
-	if err != nil {
-		log.Errorf("failed to publish subscriber message: %v", err)
-	}
-	defer rc.Close()
-	for {
-		msg, err := sub.ReceiveMessage(ctx)
-		if err != nil {
-			log.Fatalf("Failed to subscribe to the controller: %v", err)
-			os.Exit(1)
-		}
-		// Switch based on the streaming channel
-		switch msg.Channel {
-		case messages.ZoneChannelController:
-			peerListing := messages.HandlePeerList(msg.Payload)
-			if len(peerListing) > 0 {
-				// Only update the peer list if this node is a member of the zone update
-				if peerListing[0].ZoneID == as.Zone {
-					log.Debugf("Received message: %+v\n", peerListing)
-					as.ParseAircrewControlTowerConfig(cliFlags.listenPort, peerListing)
-					as.DeployControlTowerWireguardConfig()
-				}
-			}
-		case messages.ZoneChannelDefault:
-			peerListing := messages.HandlePeerList(msg.Payload)
-			if peerListing != nil {
-				log.Debugf("Received message: %+v\n", peerListing)
-				as.ParseAircrewControlTowerConfig(cliFlags.listenPort, peerListing)
-				as.DeployControlTowerWireguardConfig()
-			}
-		}
-	}
-}
-
-// controlTowerReadyCheck blocks until the control-tower responds or the request times out
-func controlTowerReadyCheck(ctx context.Context, client *redis.Client) error {
-	log.Println("Checking the readiness of the control tower")
-	healthCheckReplyChan := make(chan string)
-	sub := client.Subscribe(ctx, messages.HealthcheckReplyChannel)
-	go func() {
-		for {
-			output, _ := sub.ReceiveMessage(ctx)
-			healthCheckReplyChan <- output.Payload
-		}
-	}()
-	if _, err := client.Publish(ctx, messages.HealthcheckRequestChannel, messages.HealthcheckRequestMsg).Result(); err != nil {
-		return err
-	}
-	select {
-	case <-healthCheckReplyChan:
-	case <-time.After(readyRequestTimeout * time.Second):
-		return fmt.Errorf("control tower was not reachable, ensure it is running and attached to the broker")
-	}
-	log.Println("Control tower is available")
-	return nil
 }

--- a/internal/aircrew/configure-hub.go
+++ b/internal/aircrew/configure-hub.go
@@ -14,7 +14,7 @@ const (
 )
 
 // parseControlTowerHubWireguardConfig parse peerlisting to build the wireguard [Interface] and [Peer] sections
-func (as *AircrewState) parseControlTowerHubWireguardConfig(listenPort int, peerListing []messages.Peer) {
+func (ac *Aircrew) parseControlTowerHubWireguardConfig(listenPort int, peerListing []messages.Peer) {
 
 	var peers []wgPeerConfig
 	var hubRouterIP string
@@ -22,12 +22,12 @@ func (as *AircrewState) parseControlTowerHubWireguardConfig(listenPort int, peer
 	var zonePrefix string
 
 	for _, value := range peerListing {
-		if value.PublicKey == as.NodePubKey {
-			as.NodePubKeyInConfig = true
+		if value.PublicKey == ac.wireguardPubKey {
+			ac.wireguardPubKeyInConfig = true
 		}
 		if value.HubRouter {
 			hubRouterIP = value.AllowedIPs
-			if as.Zone == value.ZoneID {
+			if ac.zone == value.ZoneID {
 				zonePrefix = value.ZonePrefix
 			}
 		}
@@ -38,8 +38,8 @@ func (as *AircrewState) parseControlTowerHubWireguardConfig(listenPort int, peer
 		log.Error("This zone is a hub zone and requires a hub-router `--hub-router` node before provisioning spokes nodes")
 		os.Exit(1)
 	}
-	if !as.NodePubKeyInConfig {
-		log.Printf("Public Key for this node %s was not found in the control tower update\n", as.NodePubKey)
+	if !ac.wireguardPubKeyInConfig {
+		log.Printf("Public Key for this node %s was not found in the control tower update\n", ac.wireguardPubKey)
 	}
 	// Get a valid netmask from the zone prefix
 	zoneCidr, err := ParseIPNet(zonePrefix)
@@ -51,9 +51,9 @@ func (as *AircrewState) parseControlTowerHubWireguardConfig(listenPort int, peer
 	// Parse the [Peers] section of the wg config if this node is a zone-router
 	for _, value := range peerListing {
 		// Build the wg config for all peers
-		if as.HubRouter {
+		if ac.hubRouter {
 			// Config if the node is a bouncer hub
-			if value.PublicKey != as.NodePubKey {
+			if value.PublicKey != ac.wireguardPubKey {
 				peer := wgPeerConfig{
 					value.PublicKey,
 					value.EndpointIP,
@@ -70,8 +70,8 @@ func (as *AircrewState) parseControlTowerHubWireguardConfig(listenPort int, peer
 			}
 		}
 		// Build the wg config for all peers that are not zone routers (1 peer entry to the router)
-		if !as.HubRouter && value.HubRouter {
-			if value.PublicKey != as.NodePubKey {
+		if !ac.hubRouter && value.HubRouter {
+			if value.PublicKey != ac.wireguardPubKey {
 				var allowedIPs string
 				if value.ChildPrefix != "" {
 					log.Warnf("Ignoring the child prefix since this is a hub zone")
@@ -94,9 +94,9 @@ func (as *AircrewState) parseControlTowerHubWireguardConfig(listenPort int, peer
 			}
 		}
 		// Parse the [Interface] section of the wg config if this node is a zone-router
-		if value.PublicKey == as.NodePubKey && as.HubRouter {
+		if value.PublicKey == ac.wireguardPubKey && ac.hubRouter {
 			localInterface = wgLocalConfig{
-				as.NodePvtKey,
+				ac.wireguardPvtKey,
 				fmt.Sprintf("%s/%d", value.AllowedIPs, zoneMask),
 				listenPort,
 				false,
@@ -106,14 +106,14 @@ func (as *AircrewState) parseControlTowerHubWireguardConfig(listenPort int, peer
 			log.Printf("Local Node Configuration - Wireguard Local IP [ %s ] Wireguard Port [ %v ] HubZone Hub [ %t ]\n",
 				localInterface.Address,
 				listenPort,
-				as.HubRouter)
+				ac.hubRouter)
 			// set the node unique local interface configuration
-			as.WgConf.Interface = localInterface
+			ac.wgConfig.Interface = localInterface
 		}
 		// Parse the [Interface] section of the wg config if this node is not a zone router
-		if value.PublicKey == as.NodePubKey && !as.HubRouter {
+		if value.PublicKey == ac.wireguardPubKey && !ac.hubRouter {
 			localInterface = wgLocalConfig{
-				as.NodePvtKey,
+				ac.wireguardPvtKey,
 				value.AllowedIPs,
 				listenPort,
 				false,
@@ -123,10 +123,10 @@ func (as *AircrewState) parseControlTowerHubWireguardConfig(listenPort int, peer
 			log.Printf("Local Node Configuration - Wireguard Local IP [ %s ] Wireguard Port [ %v ] HubZone Hub [ %t ]\n",
 				localInterface.Address,
 				listenPort,
-				as.HubRouter)
+				ac.hubRouter)
 			// set the node unique local interface configuration
-			as.WgConf.Interface = localInterface
+			ac.wgConfig.Interface = localInterface
 		}
 	}
-	as.WgConf.Peer = peers
+	ac.wgConfig.Peer = peers
 }

--- a/internal/aircrew/configure-pull.go
+++ b/internal/aircrew/configure-pull.go
@@ -14,71 +14,33 @@ const (
 	persistentKeepalive = "25"
 )
 
-type AircrewState struct {
-	NodePubKey         string
-	NodePvtKey         string
-	NodePubKeyInConfig bool
-	AircrewConfigFile  string
-	Daemon             bool
-	HubRouter          bool
-	NodeOS             string
-	Zone               string
-	RequestedIP        string
-	ChildPrefix        string
-	AgentChannel       string
-	UserEndpointIP     string
-	WgConf             wgConfig
-}
-
-type wgConfig struct {
-	Interface wgLocalConfig
-	Peer      []wgPeerConfig `ini:",nonunique"`
-}
-
-type wgPeerConfig struct {
-	PublicKey           string
-	Endpoint            string
-	AllowedIPs          string
-	PersistentKeepAlive string
-	// AllowedIPs []string `delim:","` TODO: support an AllowedIPs slice here
-}
-
-type wgLocalConfig struct {
-	PrivateKey string
-	Address    string
-	ListenPort int
-	SaveConfig bool
-	PostUp     string
-	PostDown   string
-}
-
 // ParseAircrewControlTowerConfig parse peerlisting to build the wireguard [Interface] and [Peer] sections
-func (as *AircrewState) ParseAircrewControlTowerConfig(listenPort int, peerListing []messages.Peer) {
+func (ac *Aircrew) ParseAircrewControlTowerConfig(listenPort int, peerListing []messages.Peer) {
 
 	var peers []wgPeerConfig
 	var localInterface wgLocalConfig
 	var hubRouterExists bool
 
 	for _, value := range peerListing {
-		if value.PublicKey == as.NodePubKey {
-			as.NodePubKeyInConfig = true
+		if value.PublicKey == ac.wireguardPubKey {
+			ac.wireguardPubKeyInConfig = true
 		}
 		if value.HubRouter {
 			hubRouterExists = true
 		}
 	}
-	if !as.NodePubKeyInConfig {
-		log.Printf("Public Key for this node %s was not found in the control tower update\n", as.NodePubKey)
+	if !ac.wireguardPubKeyInConfig {
+		log.Printf("Public Key for this node %s was not found in the control tower update\n", ac.wireguardPubKey)
 	}
 	// determine if the peer listing for this node is a hub zone or hub-router
 	for _, value := range peerListing {
-		if value.PublicKey == as.NodePubKey && value.HubRouter {
+		if value.PublicKey == ac.wireguardPubKey && value.HubRouter {
 			log.Debug("This node is a hub-router")
-			if as.NodeOS == Darwin.String() {
+			if ac.os == Darwin.String() {
 				log.Fatalf("OSX nodes are not supported as bouncer hubs")
 			} else {
 				// Build a hub-router wireguard configuration
-				as.parseControlTowerHubWireguardConfig(listenPort, peerListing)
+				ac.parseControlTowerHubWireguardConfig(listenPort, peerListing)
 				return
 			}
 		}
@@ -89,14 +51,14 @@ func (as *AircrewState) ParseAircrewControlTowerConfig(listenPort int, peerListi
 				os.Exit(1)
 			}
 			// build a hub-zone wireguard configuration
-			as.parseControlTowerHubWireguardConfig(listenPort, peerListing)
+			ac.parseControlTowerHubWireguardConfig(listenPort, peerListing)
 			return
 		}
 	}
 	// Parse the [Peers] section of the wg config
 	for _, value := range peerListing {
 		// Build the wg config for all peers
-		if value.PublicKey != as.NodePubKey {
+		if value.PublicKey != ac.wireguardPubKey {
 
 			var allowedIPs string
 			if value.ChildPrefix != "" {
@@ -119,9 +81,9 @@ func (as *AircrewState) ParseAircrewControlTowerConfig(listenPort int, peerListi
 				value.ZoneID)
 		}
 		// Parse the [Interface] section of the wg config
-		if value.PublicKey == as.NodePubKey {
+		if value.PublicKey == ac.wireguardPubKey {
 			localInterface = wgLocalConfig{
-				as.NodePvtKey,
+				ac.wireguardPvtKey,
 				value.AllowedIPs,
 				listenPort,
 				false,
@@ -132,16 +94,16 @@ func (as *AircrewState) ParseAircrewControlTowerConfig(listenPort int, peerListi
 				localInterface.Address,
 				WgListenPort)
 			// set the node unique local interface configuration
-			as.WgConf.Interface = localInterface
+			ac.wgConfig.Interface = localInterface
 		}
 	}
-	as.WgConf.Peer = peers
+	ac.wgConfig.Peer = peers
 }
 
-func (as *AircrewState) DeployControlTowerWireguardConfig() {
+func (ac *Aircrew) DeployControlTowerWireguardConfig() {
 	latestCfg := &wgConfig{
-		Interface: as.WgConf.Interface,
-		Peer:      as.WgConf.Peer,
+		Interface: ac.wgConfig.Interface,
+		Peer:      ac.wgConfig.Peer,
 	}
 	cfg := ini.Empty(ini.LoadOptions{
 		AllowNonUniqueSections: true,
@@ -150,13 +112,13 @@ func (as *AircrewState) DeployControlTowerWireguardConfig() {
 	if err != nil {
 		log.Fatal("load ini configuration from struct error")
 	}
-	switch as.NodeOS {
+	switch ac.os {
 	case Linux.String():
 		latestConfig := filepath.Join(WgLinuxConfPath, wgConfLatestRev)
 		if err = cfg.SaveTo(latestConfig); err != nil {
 			log.Fatalf("Save latest configuration error: %v\n", err)
 		}
-		if as.NodePubKeyInConfig {
+		if ac.wireguardPubKeyInConfig {
 			// If no config exists, copy the latest config rev to /etc/wireguard/wg0.tomlConf
 			activeConfig := filepath.Join(WgLinuxConfPath, wgConfActive)
 			if _, err = os.Stat(activeConfig); err != nil {
@@ -174,7 +136,7 @@ func (as *AircrewState) DeployControlTowerWireguardConfig() {
 		if err = cfg.SaveTo(activeDarwinConfig); err != nil {
 			log.Fatalf("Save latest configuration error: %v\n", err)
 		}
-		if as.NodePubKeyInConfig {
+		if ac.wireguardPubKeyInConfig {
 			// this will throw an error that can be ignored if an existing interface doesn't exist
 			wgOut, err := RunCommand("wg-quick", "down", wgIface)
 			if err != nil {

--- a/internal/controltower/controltower.go
+++ b/internal/controltower/controltower.go
@@ -143,15 +143,23 @@ func (ct *ControlTower) Run() {
 				log.Debugf("Register node msg received on channel [ %s ]\n", messages.ZoneChannelDefault)
 				log.Debugf("Received registration request: %+v\n", msgEvent.Peer)
 				if msgEvent.Peer.PublicKey != "" {
-					peers, err := ct.AddPeer(ctx, msgEvent)
-					if err == nil {
-						// publishPeers the latest peer list
-						if _, err := pubDefault.publishPeers(ctx, messages.ZoneChannelDefault, peers); err != nil {
-							log.Errorf("unable to publish peer list: %s", err)
+					zone, err := ct.zoneExists(ctx, msgEvent.Peer.ZoneID)
+					if err != nil {
+						log.Error(err)
+						if _, err = pubDefault.publishErrorMessage(
+							ctx, msgEvent.Peer.ZoneID, messages.Error, messages.ChannelNotRegistered, err.Error()); err != nil{
+							log.Errorf("Unable to publish error message %s", err)
 						}
 					} else {
-						log.Errorf("Peer was not added: %v", err)
-						// TODO: return an error to the agent on a message chan
+						peers, err := ct.AddPeer(ctx, msgEvent, zone)
+						if err == nil {
+							// publishPeers the latest peer list
+							if _, err := pubDefault.publishPeers(ctx, messages.ZoneChannelDefault, peers); err != nil {
+								log.Errorf("unable to publish peer list: %s", err)
+							}
+						} else {
+							log.Errorf("Peer was not added: %v", err)
+						}
 					}
 				}
 			}
@@ -217,15 +225,18 @@ type MsgTypes struct {
 	Peer  Peer
 }
 
-func (ct *ControlTower) AddPeer(ctx context.Context, msgEvent messages.Message) ([]messages.Peer, error) {
-	tx := ct.db.Begin()
-
+func (ct *ControlTower) zoneExists (ctx context.Context, zoneId string) (*Zone, error) {
 	var zone Zone
-	res := ct.db.Preload("Peers").First(&zone, "id = ?", msgEvent.Peer.ZoneID)
-	// todo, the needs to go over an err channal to the agent
+	res := ct.db.Preload("Peers").First(&zone, "id = ?", zoneId)
+	// todo, the needs to go over an err channel to the agent
 	if res.Error != nil && errors.Is(res.Error, gorm.ErrRecordNotFound) {
-		return nil, fmt.Errorf("requested zone [ %s ] was not found, has it been created yet?", msgEvent.Peer.ZoneID)
+		return &zone, fmt.Errorf("requested zone [ %s ] was not found.", zoneId)
 	}
+	return &zone, nil
+
+}
+ func (ct *ControlTower) AddPeer(ctx context.Context, msgEvent messages.Message, zone *Zone) ([]messages.Peer, error) {
+	tx := ct.db.Begin()
 
 	ipamPrefix := zone.IpCidr
 	var hubZone bool
@@ -239,7 +250,7 @@ func (ct *ControlTower) AddPeer(ctx context.Context, msgEvent messages.Message) 
 	}
 
 	var key Device
-	res = ct.db.First(&key, "id = ?", msgEvent.Peer.PublicKey)
+	res := ct.db.First(&key, "id = ?", msgEvent.Peer.PublicKey)
 	if res.Error != nil {
 		if errors.Is(res.Error, gorm.ErrRecordNotFound) {
 			log.Debug("Public Key Not Found. Adding A New One")
@@ -352,18 +363,28 @@ func (ct *ControlTower) MessageHandling(ctx context.Context) {
 			// TODO implement error chans
 			case messages.RegisterNodeRequest:
 				log.Debugf("Register node msg received on channel [ %s ]\n", messages.ZoneChannelController)
-				log.Debugf("Recieved registration request: %+v\n", msgEvent.Peer)
+				log.Debugf("Received registration request: %+v\n", msgEvent.Peer)
 				if msgEvent.Peer.PublicKey != "" {
-					peers, err := ct.AddPeer(ctx, msgEvent)
-					if err == nil {
-						// publishPeers the latest peer list
-						if _, err := pub.publishPeers(ctx, messages.ZoneChannelController, peers); err != nil {
-							log.Errorf("unable to publish peer updates: %s", err)
+					zone, err := ct.zoneExists(ctx, msgEvent.Peer.ZoneID)
+					if err != nil {
+						log.Error(err)
+						if _, err = pub.publishErrorMessage(
+							ctx, msgEvent.Peer.ZoneID, messages.Error, messages.ChannelNotRegistered, err.Error()); err != nil{
+							log.Errorf("failed to publish error message %s", err)
 						}
 					} else {
-						// TODO: return an error to the agent on a message chan
-						log.Errorf("Peer was not added: %v", err)
+						peers, err := ct.AddPeer(ctx, msgEvent, zone)
+						if err == nil {
+							// publishPeers the latest peer list
+							if _, err := pub.publishPeers(ctx, msgEvent.Peer.ZoneID, peers); err != nil {
+								log.Errorf("failed to publish peer updates: %s", err)
+							}
+						} else {
+							
+							log.Errorf("Peer was not added: %v", err)
+						}
 					}
+
 				}
 			}
 		}

--- a/internal/controltower/streamers.go
+++ b/internal/controltower/streamers.go
@@ -76,3 +76,19 @@ func createAllPeerMessage(postData []messages.Peer) (string, string) {
 	msg, _ := json.Marshal(postData)
 	return id, string(msg)
 }
+
+func (s *streamer) publishErrorMessage(ctx context.Context, channel string, event messages.EventType, code messages.ErrorCode, msg string) (int64, error) {
+	jsonMsg := createErrorMessage(event, code, msg)
+	log.Printf("Published new error message: %s\n", jsonMsg)
+	return s.client.Publish(ctx, channel, jsonMsg).Result()
+}
+
+func createErrorMessage(event messages.EventType, code messages.ErrorCode, msg string) string {
+	errMsg := messages.ErrorMessage{}
+	errMsg.Event = event
+	errMsg.Code = code
+	errMsg.Msg = msg
+	jMsg, _ := json.Marshal(&errMsg)
+	return string(jMsg)
+}
+

--- a/internal/messages/types.go
+++ b/internal/messages/types.go
@@ -23,6 +23,24 @@ type Message struct {
 	Peer  Peer
 }
 
+type EventType string
+
+const (
+	Error EventType	= "error"
+	Warn EventType = "warn"
+)
+
+type ErrorCode string
+
+const (
+	ChannelNotRegistered ErrorCode = "E404"
+)
+
+type ErrorMessage struct {
+	Event EventType
+	Code ErrorCode
+	Msg string
+}
 // Peer pub/sub struct
 type Peer struct {
 	PublicKey   string `json:"public-key"`
@@ -57,14 +75,14 @@ func NewPublishPeerMessage(event, zone, pubKey, endpointIP, requestedIP, childPr
 type PeerListing []Peer
 
 // handleMsg deal with streaming messages
-func HandlePeerList(payload string) []Peer {
+func HandlePeerList(payload string) ([]Peer, error) {
 	var peerListing []Peer
 	err := json.Unmarshal([]byte(payload), &peerListing)
 	if err != nil {
 		log.Debugf("HandlePeerList: unmarshal error: %v\n", err)
-		return nil
+		return nil, err
 	}
-	return peerListing
+	return peerListing, nil
 }
 
 func HandleMessage(payload string) Message {
@@ -75,4 +93,14 @@ func HandleMessage(payload string) Message {
 		return msg
 	}
 	return msg
+}
+
+func HandleErrorMessage(payload string) (ErrorMessage, error) {
+	var errMsg ErrorMessage
+	err := json.Unmarshal([]byte(payload), &errMsg)
+	if err != nil {
+		log.Debugf("failed to unmarshal error message payload %v\n", err)
+		return ErrorMessage{}, err
+	}
+	return errMsg, nil
 }


### PR DESCRIPTION
When aircrew use specific zone using --zone option, it start listening to that zone, but it sends the registration request over control channel. ControlTower receives the request and if it doesn't find the peer zone, it sends and error message on the channel that agent specified.
Agent receives the message and terminate.

Signed-off-by: Anil Kumar Vishnoi <avishnoi@redhat.com>