### PR TITLE
Added hub/spoke support for peers unable to expose ports

### DIFF
--- a/cmd/aircrew/main.go
+++ b/cmd/aircrew/main.go
@@ -27,6 +27,7 @@ type flags struct {
 	childPrefix            string
 	agentMode              bool
 	internalNetwork        bool
+	hubRouter              bool
 }
 
 var (
@@ -130,6 +131,12 @@ func main() {
 				Value:       false,
 				Destination: &cliFlags.internalNetwork,
 				EnvVars:     []string{"AIRCREW_INTERNAL_NETWORK"},
+			},
+			&cli.BoolFlag{Name: "hub-router",
+				Usage:       "set if this node is to be the hub in a hub and spoke deployment",
+				Value:       false,
+				Destination: &cliFlags.hubRouter,
+				EnvVars:     []string{"AIRCREW_HUB_ROUTER"},
 			},
 		},
 	}
@@ -249,6 +256,7 @@ func runInit() {
 		RequestedIP:       cliFlags.requestedIP,
 		ChildPrefix:       cliFlags.childPrefix,
 		UserEndpointIP:    cliFlags.userProvidedEndpointIP,
+		HubRouter:         cliFlags.hubRouter,
 	}
 
 	controller := fmt.Sprintf("%s:6379", cliFlags.controllerIP)
@@ -286,8 +294,10 @@ func runInit() {
 		as.NodePubKey,
 		endpointSocket,
 		as.RequestedIP,
-		as.ChildPrefix)
-
+		as.ChildPrefix,
+		"",
+		false,
+		as.HubRouter)
 	// Agent only needs to subscribe
 	if as.Zone == "default" {
 		as.AgentChannel = messages.ZoneChannelDefault

--- a/internal/aircrew/configure-hub.go
+++ b/internal/aircrew/configure-hub.go
@@ -1,0 +1,132 @@
+package aircrew
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/redhat-et/jaywalking/internal/messages"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	hubPostUp   = "iptables -A FORWARD -i wg0 -o wg0 -j ACCEPT"
+	hubPostDown = "iptables -D FORWARD -i wg0 -o wg0 -j ACCEPT"
+)
+
+// parseControlTowerHubWireguardConfig parse peerlisting to build the wireguard [Interface] and [Peer] sections
+func (as *AircrewState) parseControlTowerHubWireguardConfig(listenPort int, peerListing []messages.Peer) {
+
+	var peers []wgPeerConfig
+	var hubRouterIP string
+	var localInterface wgLocalConfig
+	var zonePrefix string
+
+	for _, value := range peerListing {
+		if value.PublicKey == as.NodePubKey {
+			as.NodePubKeyInConfig = true
+		}
+		if value.HubRouter {
+			hubRouterIP = value.AllowedIPs
+			if as.Zone == value.ZoneID {
+				zonePrefix = value.ZonePrefix
+			}
+		}
+	}
+	// zonePrefix will be empty if a hub-router is not defined in the zone
+	// TODO: replace with an error message from the controller before it reaches this point
+	if zonePrefix == "" {
+		log.Error("This zone is a hub zone and requires a hub-router `--hub-router` node before provisioning spokes nodes")
+		os.Exit(1)
+	}
+	if !as.NodePubKeyInConfig {
+		log.Printf("Public Key for this node %s was not found in the control tower update\n", as.NodePubKey)
+	}
+	// Get a valid netmask from the zone prefix
+	zoneCidr, err := ParseIPNet(zonePrefix)
+	if err != nil {
+		log.Errorf("Failed to parse a valid network the zone prefix %s: %v", zonePrefix, err)
+		os.Exit(1)
+	}
+	zoneMask, _ := zoneCidr.Mask.Size()
+	// Parse the [Peers] section of the wg config if this node is a zone-router
+	for _, value := range peerListing {
+		// Build the wg config for all peers
+		if as.HubRouter {
+			// Config if the node is a bouncer hub
+			if value.PublicKey != as.NodePubKey {
+				peer := wgPeerConfig{
+					value.PublicKey,
+					value.EndpointIP,
+					value.AllowedIPs,
+					persistentKeepalive,
+				}
+				peers = append(peers, peer)
+				log.Printf("Peer Node Configuration - Peer AllowedIPs [ %s ] Peer Endpoint IP [ %s ] Peer Public Key [ %s ] NodeAddress [ %s ] Zone [ %s ]\n",
+					value.AllowedIPs,
+					value.EndpointIP,
+					value.PublicKey,
+					value.NodeAddress,
+					value.ZoneID)
+			}
+		}
+		// Build the wg config for all peers that are not zone routers (1 peer entry to the router)
+		if !as.HubRouter && value.HubRouter {
+			if value.PublicKey != as.NodePubKey {
+				var allowedIPs string
+				if value.ChildPrefix != "" {
+					log.Warnf("Ignoring the child prefix since this is a hub zone")
+				} else {
+					allowedIPs = value.AllowedIPs
+				}
+				peer := wgPeerConfig{
+					value.PublicKey,
+					value.EndpointIP,
+					fmt.Sprintf("%s/%d", hubRouterIP, zoneMask),
+					persistentKeepalive,
+				}
+				peers = append(peers, peer)
+				log.Printf("Peer Node Configuration - Peer AllowedIPs [ %s ] Peer Endpoint IP [ %s ] Peer Public Key [ %s ] NodeAddress [ %s ] Zone [ %s ]\n",
+					allowedIPs,
+					value.EndpointIP,
+					value.PublicKey,
+					value.NodeAddress,
+					value.ZoneID)
+			}
+		}
+		// Parse the [Interface] section of the wg config if this node is a zone-router
+		if value.PublicKey == as.NodePubKey && as.HubRouter {
+			localInterface = wgLocalConfig{
+				as.NodePvtKey,
+				fmt.Sprintf("%s/%d", value.AllowedIPs, zoneMask),
+				listenPort,
+				false,
+				hubPostUp,
+				hubPostDown,
+			}
+			log.Printf("Local Node Configuration - Wireguard Local IP [ %s ] Wireguard Port [ %v ] HubZone Hub [ %t ]\n",
+				localInterface.Address,
+				listenPort,
+				as.HubRouter)
+			// set the node unique local interface configuration
+			as.WgConf.Interface = localInterface
+		}
+		// Parse the [Interface] section of the wg config if this node is not a zone router
+		if value.PublicKey == as.NodePubKey && !as.HubRouter {
+			localInterface = wgLocalConfig{
+				as.NodePvtKey,
+				value.AllowedIPs,
+				listenPort,
+				false,
+				"",
+				"",
+			}
+			log.Printf("Local Node Configuration - Wireguard Local IP [ %s ] Wireguard Port [ %v ] HubZone Hub [ %t ]\n",
+				localInterface.Address,
+				listenPort,
+				as.HubRouter)
+			// set the node unique local interface configuration
+			as.WgConf.Interface = localInterface
+		}
+	}
+	as.WgConf.Peer = peers
+}

--- a/internal/aircrew/utils.go
+++ b/internal/aircrew/utils.go
@@ -188,3 +188,12 @@ func ReadKeyFileToString(s string) (string, error) {
 	rawStr := string(buf)
 	return strings.Replace(rawStr, "\n", "", -1), nil
 }
+
+// ParseIPNet return an IPNet from a string
+func ParseIPNet(s string) (*net.IPNet, error) {
+	ip, ipNet, err := net.ParseCIDR(s)
+	if err != nil {
+		return nil, err
+	}
+	return &net.IPNet{IP: ip, Mask: ipNet.Mask}, nil
+}

--- a/internal/controltower/handlers.go
+++ b/internal/controltower/handlers.go
@@ -15,6 +15,7 @@ type ZoneRequest struct {
 	Name        string `json:"name"`
 	Description string `json:"description"`
 	IpCidr      string `json:"cidr"`
+	HubZone     bool   `json:"hub-zone"`
 }
 
 // PostZone creates a new zone via a REST call
@@ -35,7 +36,7 @@ func (ct *ControlTower) handlePostZones(c *gin.Context) {
 	}
 
 	// Create the zone
-	newZone, err := ct.NewZone(uuid.New().String(), request.Name, request.Description, request.IpCidr)
+	newZone, err := ct.NewZone(uuid.New().String(), request.Name, request.Description, request.IpCidr, request.HubZone)
 	if err != nil {
 		c.IndentedJSON(http.StatusInternalServerError, gin.H{"message": "unable to create zone"})
 		return
@@ -50,6 +51,7 @@ type ZoneJSON struct {
 	Name        string   `json:"name"`
 	Description string   `json:"description"`
 	IpCidr      string   `json:"cidr"`
+	HubZone     bool     `json:"hub-zone"`
 }
 
 // GetZones responds with the list of all peers as JSON.
@@ -69,6 +71,7 @@ func (ct *ControlTower) handleListZones(c *gin.Context) {
 			Name:        z.Name,
 			Description: z.Description,
 			IpCidr:      z.IpCidr,
+			HubZone:     z.HubZone,
 		})
 	}
 	// For pagination
@@ -98,6 +101,7 @@ func (ct *ControlTower) handleGetZones(c *gin.Context) {
 		Name:        zone.Name,
 		Description: zone.Description,
 		IpCidr:      zone.IpCidr,
+		HubZone:     zone.HubZone,
 	}
 	c.JSON(http.StatusOK, results)
 }

--- a/internal/controltower/models.go
+++ b/internal/controltower/models.go
@@ -24,6 +24,9 @@ type Peer struct {
 	AllowedIPs  string `json:"allowed-ips"`
 	NodeAddress string `json:"node-address"`
 	ChildPrefix string `json:"child-prefix"`
+	HubRouter   bool   `json:"hub-router"`
+	HubZone     bool   `json:"hub-zone"`
+	ZonePrefix  string `json:"zone-prefix"`
 }
 
 // Zone is a collection of devices that are connected together.
@@ -33,11 +36,12 @@ type Zone struct {
 	Name        string
 	Description string
 	IpCidr      string
+	HubZone     bool
 }
 
 // NewZone creates a new Zone since we also need to create a database for zone IPAM.
 // TODO: Investigate moving the IPAM service out of controltower and access it over grpc.
-func (ct *ControlTower) NewZone(id, name, description, cidr string) (*Zone, error) {
+func (ct *ControlTower) NewZone(id, name, description, cidr string, hubZone bool) (*Zone, error) {
 	dbName := fmt.Sprintf("ipam_%s", strings.ReplaceAll(id, "-", "_"))
 	log.Debugf("creating db %s", dbName)
 
@@ -70,6 +74,7 @@ func (ct *ControlTower) NewZone(id, name, description, cidr string) (*Zone, erro
 		Name:        name,
 		Description: description,
 		IpCidr:      cidr,
+		HubZone:     hubZone,
 	}
 	res := ct.db.Create(zone)
 	if res.Error != nil {

--- a/internal/messages/types.go
+++ b/internal/messages/types.go
@@ -31,9 +31,12 @@ type Peer struct {
 	AllowedIPs  string `json:"allowed-ips"`
 	NodeAddress string `json:"node-address"`
 	ChildPrefix string `json:"child-prefix"`
+	HubRouter   bool   `json:"hub-router"`
+	HubZone     bool   `json:"hub-zone"`
+	ZonePrefix  string `json:"zone-prefix"`
 }
 
-func NewPublishPeerMessage(event, zone, pubKey, endpointIP, requestedIP, childPrefix string) string {
+func NewPublishPeerMessage(event, zone, pubKey, endpointIP, requestedIP, childPrefix, zonePrefix string, hubZone, hubRouter bool) string {
 	msg := Message{}
 	msg.Event = event
 	peer := Peer{
@@ -42,6 +45,9 @@ func NewPublishPeerMessage(event, zone, pubKey, endpointIP, requestedIP, childPr
 		ZoneID:      zone,
 		NodeAddress: requestedIP,
 		ChildPrefix: childPrefix,
+		ZonePrefix:  zonePrefix,
+		HubZone:     hubZone,
+		HubRouter:   hubRouter,
 	}
 	msg.Peer = peer
 	jMsg, _ := json.Marshal(&msg)

--- a/tests/e2e-scripts/init-containers.sh
+++ b/tests/e2e-scripts/init-containers.sh
@@ -36,6 +36,15 @@ start_containers() {
         --cap-add=NET_ADMIN \
         --cap-add=NET_RAW \
         ${node_image}
+
+    # Start node3post
+    $DOCKER run -itd \
+        --name=node3 \
+        --net=jaywalking_default \
+        --cap-add=SYS_MODULE \
+        --cap-add=NET_ADMIN \
+        --cap-add=NET_RAW \
+        ${node_image}
 }
 
 copy_binaries() {
@@ -92,8 +101,9 @@ EOF
     # Copy binaries and scripts (copying the controltower even though we are running it on the VM instead of in a container)
     $DOCKER cp $(which aircrew) node1:/bin/aircrew
     $DOCKER cp $(which aircrew) node2:/bin/aircrew
-    $DOCKER cp $(which controltower) node1:/bin/controltower
-    $DOCKER cp $(which controltower) node2:/bin/controltower
+    $DOCKER cp $(which aircrew) node3:/bin/aircrew
+
+    # Deploy run scripts to nodes
     $DOCKER cp ./aircrew-run-node1.sh node1:/bin/aircrew-run-node1.sh
     $DOCKER cp ./aircrew-run-node2.sh node2:/bin/aircrew-run-node2.sh
 
@@ -334,9 +344,6 @@ setup_child_prefix_connectivity() {
     local node2_pvtkey=WBydF4bEIs/uSR06hrsGa4vhgNxgR6rmR68CyOHMK18=
     local node2_ip=$($DOCKER inspect --format "{{ .NetworkSettings.Networks.jaywalking_default.IPAddress }}" node2)
 
-    # Delete the ipam storage in the case the run has re-run since we dont overwrite existing child-prefix
-    rm -rf prefix-test.json
-
     # Create the new zone with a CGNAT range
     local zone=$(curl -L -X POST 'http://localhost:8080/zones' \
     -H 'Content-Type: application/json' \
@@ -438,6 +445,142 @@ clean_nodes() {
 }
 
 
+setup_hub_spoke_connectivity() {
+    ###########################################################################
+    # Description:                                                            #
+    # Verify a child-prefix and request-ip can be created and add a loopback  #
+    # on each node in the child prefix cidr and verify connectivity           #
+    # Arguments:                                                              #
+    #   None                                                                  #
+    ###########################################################################
+    # Shared controller address
+    local controller=redis
+    local controller_passwd=floofykittens
+    local zone=hub-spoke-zone
+    local node_pvtkey_file=/etc/wireguard/private.key
+
+    # node1 specific details
+    local node1_pubkey=M+BTP8LbMikKLufoTTI7tPL5Jf3SHhNki6SXEXa5Uic=
+    local node1_pvtkey=4OXhMZdzodfOrmWvZyJRfiDEm+FJSwaEMI4co0XRP18=
+    local node1_ip=$(sudo $DOCKER inspect --format "{{ .NetworkSettings.Networks.jaywalking_default.IPAddress }}" node1)
+
+    # node2 specific details
+    local node2_pubkey=DUQ+TxqMya3YgRd1eXW/Tcg2+6wIX5uwEKqv6lOScAs=
+    local node2_pvtkey=WBydF4bEIs/uSR06hrsGa4vhgNxgR6rmR68CyOHMK18=
+    local node2_ip=$(sudo $DOCKER inspect --format "{{ .NetworkSettings.Networks.jaywalking_default.IPAddress }}" node2)
+
+    # node3 specific details
+    local node3_pubkey=305lmZr0lFYy3E1S6e/GLCup300W5T4mOMnF9SKjmzc=
+    local node3_pvtkey=CCWJ1RfGdFxq9nBCYLa33I6B6IR9EPkMGnyb5gnJ+FI=
+    local node3_ip=$(sudo $DOCKER inspect --format "{{ .NetworkSettings.Networks.jaywalking_default.IPAddress }}" node3)
+
+    # Create the new zone
+    local zone=$(curl -L -X POST 'http://localhost:8080/zones' \
+    -H 'Content-Type: application/json' \
+    --data-raw '{
+        "Name": "hub-spoke-zone",
+        "Description": "Hub/Spoke Zone",
+        "CIDR": "10.89.0.0/27",
+        "Hub-Zone": true
+    }' | jq -r '.ID')
+
+    # Create private key files for both nodes
+    echo -e  "$node1_pvtkey" | tee node1-private.key
+    echo -e  "$node2_pvtkey" | tee node2-private.key
+    echo -e  "$node3_pvtkey" | tee node3-private.key
+
+    # Kill the aircrew process on both nodes (no process running on node3 yet)
+    sudo $DOCKER exec node1 killall aircrew
+    sudo $DOCKER exec node2 killall aircrew
+
+    # Node-1 aircrew run
+    cat <<EOF > aircrew-run-node1.sh
+#!/bin/bash
+    aircrew --public-key=${node1_pubkey} \
+    --private-key-file=/etc/wireguard/private.key \
+    --controller=${controller} \
+    --controller-password=${controller_passwd} \
+    --internal-network \
+    --hub-router \
+    --zone=${zone}
+EOF
+
+    # Node-2 aircrew run
+    cat <<EOF > aircrew-run-node2.sh
+#!/bin/bash
+    aircrew --public-key=${node2_pubkey} \
+    --private-key-file=/etc/wireguard/private.key \
+    --controller=${controller} \
+    --controller-password=${controller_passwd} \
+    --internal-network \
+    --zone=${zone}
+EOF
+
+    # Node-3 aircrew run
+    cat <<EOF > aircrew-run-node3.sh
+#!/bin/bash
+    aircrew --public-key=${node3_pubkey} \
+    --private-key-file=/etc/wireguard/private.key \
+    --controller=${controller} \
+    --controller-password=${controller_passwd} \
+    --internal-network \
+    --zone=${zone}
+EOF
+
+    # STDOUT the run scripts for debugging
+    echo "=== Displaying aircrew-run-node1.sh ==="
+    cat aircrew-run-node1.sh
+    echo "=== Displaying aircrew-run-node2.sh ==="
+    cat aircrew-run-node2.sh
+    echo "=== Displaying aircrew-run-node3.sh ==="
+    cat aircrew-run-node3.sh
+
+    # Copy files to the containers
+    sudo $DOCKER cp ./aircrew-run-node1.sh node1:/bin/aircrew-run-node1.sh
+    sudo $DOCKER cp ./aircrew-run-node2.sh node2:/bin/aircrew-run-node2.sh
+    sudo $DOCKER cp ./aircrew-run-node3.sh node3:/bin/aircrew-run-node3.sh
+    sudo $DOCKER cp ./node1-private.key node1:/etc/wireguard/private.key
+    sudo $DOCKER cp ./node2-private.key node2:/etc/wireguard/private.key
+    sudo $DOCKER cp ./node3-private.key node3:/etc/wireguard/private.key
+
+    # Set permissions in the container
+    sudo $DOCKER exec node1 chmod +x /bin/aircrew-run-node1.sh
+    sudo $DOCKER exec node2 chmod +x /bin/aircrew-run-node2.sh
+    sudo $DOCKER exec node3 chmod +x /bin/aircrew-run-node3.sh
+
+    # Start the agents on all 3 nodes nodes (currently the hub-router needs to be spun up first)
+    sudo $DOCKER exec node1 /bin/aircrew-run-node1.sh &
+    sleep 5
+    sudo $DOCKER exec node2 /bin/aircrew-run-node2.sh &
+    sudo $DOCKER exec node3 /bin/aircrew-run-node3.sh &
+
+    # Allow four seconds for the wg0 interface to readdress
+    sleep 4
+
+    # Check connectivity between node3 -> node1
+    if sudo $DOCKER exec node3 ping -c 2 -w 2 $(sudo $DOCKER exec node1 ip --brief address show wg0 | awk '{print $3}' | cut -d "/" -f1); then
+        echo "peer nodes successfully communicated"
+    else
+        echo "node3 failed to reach node1, e2e failed"
+        exit 1
+    fi
+    # Check connectivity between node3 -> node2
+    if sudo $DOCKER exec node3 ping -c 2 -w 2 $(sudo $DOCKER exec node2 ip --brief address show wg0 | awk '{print $3}' | cut -d "/" -f1); then
+        echo "peer nodes successfully communicated"
+    else
+        echo "node3 failed to reach node2, e2e failed"
+        exit 1
+    fi
+
+    # Check connectivity between node1 -> node3
+    if sudo $DOCKER exec node1 ping -c 2 -w 2 $(sudo $DOCKER exec node3 ip --brief address show wg0 | awk '{print $3}' | cut -d "/" -f1); then
+        echo "peer nodes successfully communicated"
+    else
+        echo "node1 failed to reach node3, e2e failed"
+        exit 1
+    fi
+}
+
 ###########################################################################
 # Description:                                                            #
 # Run the following functions to test end to end connectivity between     #
@@ -471,6 +614,9 @@ setup_custom_second_zone_connectivity
 verify_connectivity
 clean_nodes
 setup_child_prefix_connectivity
+verify_connectivity
+clean_nodes
+setup_hub_spoke_connectivity
 verify_connectivity
 clean_nodes
 


### PR DESCRIPTION
- This features enables natted spokes from any location to connect to a public bouncer acting as a hub. As traffic comes from a spoke, it will decrypt on the hub and then re-encrypt again as it gets forwarded to the destination spoke.
- Adds the --zone-router flag to declare a hub-router for a zone
- The hub-router must be provisioned on a node before spokes can be deployed. Currently the agent will exit with a message. That would likely be replaced with an admin definition via REST/UX.

Signed-off-by: Brent Salisbury <bsalisbu@redhat.com>