### PR TITLE
Handle a peer when it is modified

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@ default-ipam.json
 *.idea
 .DS_Store
 
+#vscode
+.vscode/*
+
 #tests
 ./tests/*.json
 ./tests/apex-*.sh

--- a/tests/e2e-scripts/init-containers.sh
+++ b/tests/e2e-scripts/init-containers.sh
@@ -331,20 +331,22 @@ setup_child_prefix_connectivity() {
     local node_pvtkey_file=/etc/wireguard/private.key
 
     # node1 specific details
-    local requested_ip_node1=192.168.200.100
+    local requested_ip_node1=192.168.200.101
     local child_prefix_node1=172.20.1.0/24
+    local node1_loopback=172.20.1.10
     local node1_pubkey=M+BTP8LbMikKLufoTTI7tPL5Jf3SHhNki6SXEXa5Uic=
     local node1_pvtkey=4OXhMZdzodfOrmWvZyJRfiDEm+FJSwaEMI4co0XRP18=
     local node1_ip=$($DOCKER inspect --format "{{ .NetworkSettings.Networks.apex_default.IPAddress }}" node1)
 
     # node2 specific details
-    local requested_ip_node2=192.168.200.200
-    local child_prefix_node2=172.20.3.0/24
+    local requested_ip_node2=192.168.200.102
+    local child_prefix_node2=172.20.2.0/24
+    local node2_loopback=172.20.2.10
     local node2_pubkey=DUQ+TxqMya3YgRd1eXW/Tcg2+6wIX5uwEKqv6lOScAs=
     local node2_pvtkey=WBydF4bEIs/uSR06hrsGa4vhgNxgR6rmR68CyOHMK18=
     local node2_ip=$($DOCKER inspect --format "{{ .NetworkSettings.Networks.apex_default.IPAddress }}" node2)
 
-    # Create the new zone with a CGNAT range
+    # Create the new zone with a RFC1918 prefix
     local zone=$(curl -L -X POST 'http://localhost:8080/zones' \
     -H 'Content-Type: application/json' \
     --data-raw '{
@@ -404,8 +406,8 @@ EOF
     $DOCKER exec node2 chmod +x /bin/apex-run-node2.sh
 
     # Add loopback addresses the are in the child-prefix cidr range
-    $DOCKER exec node1 ip addr add 172.20.1.10/32 dev lo
-    $DOCKER exec node2 ip addr add 172.20.3.10/32 dev lo
+    $DOCKER exec node1 ip addr add ${node1_loopback}/32 dev lo
+    $DOCKER exec node2 ip addr add ${node2_loopback}/32 dev lo
 
     # Start the agents on both nodes
     $DOCKER exec node1 /bin/apex-run-node1.sh &
@@ -415,17 +417,131 @@ EOF
     sleep 4
     
     # Check connectivity between node1  child prefix loopback-> node2 child prefix loopback
-    if $DOCKER exec node1 ping -c 2 -w 2 172.20.3.10; then
+    if $DOCKER exec node1 ping -c 2 -w 2 ${node2_loopback}; then
         echo "peer node loopbacks successfully communicated"
     else
         echo "node1 failed to reach node2 loopback, e2e failed"
         exit 1
     fi
     # Check connectivity between node2 child prefix loopback -> node1 child prefix loopback
-    if $DOCKER exec node2 ping -c 2 -w 2 172.20.1.10; then
+    if $DOCKER exec node2 ping -c 2 -w 2 ${node1_loopback}; then
         echo "peer node loopbacks successfully communicated"
     else
         echo "node2 failed to reach node1 loopback, e2e failed"
+        exit 1
+    fi
+
+    # Check connectivity between node1 requested-ip -> node2 requested-ip
+    if $DOCKER exec node1 ping -c 2 -w 2 ${requested_ip_node2}; then
+        echo "peer node loopbacks successfully communicated"
+    else
+        echo "node1 failed to reach node2 loopback, e2e failed"
+        exit 1
+    fi
+    # Check connectivity between node2 requested-ip -> node1 requested-ip
+    if $DOCKER exec node2 ping -c 2 -w 2 ${requested_ip_node1}; then
+        echo "peer node loopbacks successfully communicated"
+    else
+        echo "node2 failed to reach node1 loopback, e2e failed"
+        exit 1
+    fi
+
+    ###########################################################################
+    # Description:                                                            #
+    # This next section changes elements in the node and ensures the nodes    #
+    # properly update one each others peer record in the wg config            #                                                             #
+    ###########################################################################
+    # Kill the apex process on both nodes
+    $DOCKER exec node1 killall apex
+    $DOCKER exec node2 killall apex
+
+    # Now change out some elements and make sure the controller updates the device's configuration to the peers
+    local new_child_prefix_node1=172.21.220.0/24
+    local new_child_prefix_node2=172.21.221.0/24
+    local new_requested_ip_node1=192.168.200.220
+    local new_requested_ip_node2=192.168.200.221
+    local new_node1_loopback=172.21.220.10
+    local new_node2_loopback=172.21.221.10
+
+    # Node-1 apex run
+    cat <<EOF > apex-run-node1-cycle2.sh
+#!/bin/bash
+    apex --public-key=${node1_pubkey} \
+    --private-key-file=/etc/wireguard/private.key  \
+    --controller=${controller} \
+    --controller-password=${controller_passwd} \
+    --child-prefix=${new_child_prefix_node1} \
+    --local-endpoint-ip=${node1_ip} \
+    --request-ip=${new_requested_ip_node1} \
+    --zone=${zone}
+EOF
+
+    # Node-2 apex run
+    cat <<EOF > apex-run-node2-cycle2.sh
+#!/bin/bash
+    apex --public-key=${node2_pubkey} \
+    --private-key-file=/etc/wireguard/private.key  \
+    --controller=${controller} \
+    --controller-password=${controller_passwd} \
+    --child-prefix=${new_child_prefix_node2} \
+    --request-ip=${new_requested_ip_node2} \
+    --local-endpoint-ip=${node2_ip} \
+    --zone=${zone}
+EOF
+
+    # STDOUT the run scripts for debugging
+    echo "=== Displaying apex-run-node1.sh ==="
+    cat apex-run-node1-cycle2.sh
+    echo "=== Displaying apex-run-node2.sh ==="
+    cat apex-run-node2-cycle2.sh
+
+    # Copy files to the containers
+    $DOCKER cp ./apex-run-node1-cycle2.sh node1:/bin/apex-run-node1-cycle2.sh
+    $DOCKER cp ./apex-run-node2-cycle2.sh node2:/bin/apex-run-node2-cycle2.sh
+    $DOCKER cp ./node1-private.key node1:/etc/wireguard/private.key
+    $DOCKER cp ./node2-private.key node2:/etc/wireguard/private.key
+
+    # Set permissions in the container
+    $DOCKER exec node1 chmod +x /bin/apex-run-node1-cycle2.sh
+    $DOCKER exec node2 chmod +x /bin/apex-run-node2-cycle2.sh
+
+    # Add loopback addresses the are in the child-prefix cidr range
+    $DOCKER exec node1 ip addr add ${new_node1_loopback}/32 dev lo
+    $DOCKER exec node2 ip addr add ${new_node2_loopback}/32 dev lo
+
+    # Start the agents on both nodes
+    $DOCKER exec node1 /bin/apex-run-node1-cycle2.sh &
+    $DOCKER exec node2 /bin/apex-run-node2-cycle2.sh &
+
+    # Allow five seconds for the wg0 interface to readdress
+    sleep 5
+
+    # Check connectivity between node1  child prefix loopback-> node2 child prefix loopback
+    if $DOCKER exec node1 ping -c 2 -w 2 ${new_node1_loopback}; then
+        echo "peer node loopbacks successfully communicated"
+    else
+        echo "node1 failed to reach the updated node2 loopback, e2e failed"
+        exit 1
+    fi
+    # Check connectivity between node2 child prefix loopback -> node1 child prefix loopback
+    if $DOCKER exec node2 ping -c 2 -w 2 ${new_node2_loopback}; then
+        echo "peer node loopbacks successfully communicated"
+    else
+        echo "node2 failed to reach the updated node1 loopback, e2e failed"
+        exit 1
+    fi
+    # Check connectivity between node1 new_requested-ip -> node2 new_requested-ip
+    if $DOCKER exec node1 ping -c 2 -w 2 ${new_requested_ip_node2}; then
+        echo "peer node wg0 successfully communicated"
+    else
+        echo "node1 failed to reach node2 wg0, e2e failed"
+        exit 1
+    fi
+    # Check connectivity between node2 new_requested-ip -> node1 new_requested-ip
+    if $DOCKER exec node2 ping -c 2 -w 2 ${new_requested_ip_node1}; then
+        echo "peer node wg0 successfully communicated"
+    else
+        echo "node2 failed to reach node1 wg0, e2e failed"
         exit 1
     fi
 }
@@ -583,6 +699,198 @@ EOF
 
 ###########################################################################
 # Description:                                                            #
+# This test will cycle configurations to ensure database entries are      #
+# work as expected and the configuration parsing works as intended        #
+                                                                          #
+###########################################################################
+cycle_configurations(){
+    local controller=redis
+    local controller_passwd=floofykittens
+    local node_pvtkey_file=/etc/wireguard/private.key
+
+    # node1 specific details
+    local node1_pubkey=bBAtxEphKIl8lXR3SU88d9slSxlyxmHxLQpHw3oBegc=
+    local node1_pvtkey=wLN//bU622CxzFRH3t2V40aHurYW7Ad/8pc7wCMlS2g=
+    local node1_ip=$(sudo $DOCKER inspect --format "{{ .NetworkSettings.Networks.apex_default.IPAddress }}" node1)
+
+    # node2 specific details
+    local node2_pubkey=J6SnyIt2cCgPLGEWvoZ6+OB4uNnl9QKejCE+HU9qn2Q=
+    local node2_pvtkey=0NcaqbRNfixztY6izBC2B2NNrIpjj+hAlZLbp8H0NXI=
+    local node2_ip=$(sudo $DOCKER inspect --format "{{ .NetworkSettings.Networks.apex_default.IPAddress }}" node2)
+
+    # node3 specific details
+    local node3_pubkey=oJlDE1y9xxmR6CIEYCSJAN+8b/RK73TpBYixlFiBJDM=
+    local node3_pvtkey=cGXbnP3WKIYbIbEyFpQ+kziNk/kHBM8VJhslEG8Uj1c=
+    local node3_ip=$(sudo $DOCKER inspect --format "{{ .NetworkSettings.Networks.apex_default.IPAddress }}" node3)
+
+    echo -e  "$node1_pvtkey" | tee node1-private.key
+    echo -e  "$node2_pvtkey" | tee node2-private.key
+    echo -e  "$node3_pvtkey" | tee node3-private.key
+
+    # Copy key file to the nodes
+    sudo $DOCKER cp ./node1-private.key node1:/etc/wireguard/private.key
+    sudo $DOCKER cp ./node2-private.key node2:/etc/wireguard/private.key
+    sudo $DOCKER cp ./node3-private.key node3:/etc/wireguard/private.key
+
+    # Create the new zone
+    local zone=$(curl -L -X POST 'http://localhost:8080/zones' \
+    -H 'Content-Type: application/json' \
+    --data-raw '{
+        "Name": "cycle-zone",
+        "Description": "stress tester",
+        "CIDR": "10.220.0.0/24"
+    }' | jq -r '.ID')
+
+    # Create configurations for three nodes
+    for i in {1..2}
+    do
+        cat <<EOF > apex-run-node1-cycle${i}.sh
+#!/bin/bash
+    apex --public-key=${node1_pubkey} \
+    --private-key-file=/etc/wireguard/private.key \
+    --controller=${controller} \
+    --controller-password=${controller_passwd} \
+    --local-endpoint-ip=${node1_ip} \
+    --request-ip=10.220.10.${i} \
+    --zone=${zone}
+EOF
+
+        cat <<EOF > apex-run-node2-cycle${i}.sh
+#!/bin/bash
+    apex --public-key=${node2_pubkey} \
+    --private-key-file=/etc/wireguard/private.key \
+    --controller=${controller} \
+    --controller-password=${controller_passwd} \
+    --local-endpoint-ip=${node2_ip} \
+    --request-ip=10.220.20.${i} \
+    --zone=${zone}
+EOF
+
+        cat <<EOF > apex-run-node3-cycle${i}.sh
+#!/bin/bash
+    apex --public-key=${node3_pubkey} \
+    --private-key-file=/etc/wireguard/private.key \
+    --controller=${controller} \
+    --controller-password=${controller_passwd} \
+    --local-endpoint-ip=${node3_ip} \
+    --request-ip=10.220.30.${i} \
+    --zone=${zone}
+EOF
+    done
+
+    # Copy files to the containers
+    sudo $DOCKER cp ./apex-run-node1-cycle1.sh node1:/bin/apex-run-node1-cycle1.sh
+    sudo $DOCKER cp ./apex-run-node2-cycle1.sh node2:/bin/apex-run-node2-cycle1.sh
+    sudo $DOCKER cp ./apex-run-node3-cycle1.sh node3:/bin/apex-run-node3-cycle1.sh
+
+    # Set permissions in the container
+    sudo $DOCKER exec node1 chmod +x /bin/apex-run-node1-cycle1.sh
+    sudo $DOCKER exec node2 chmod +x /bin/apex-run-node2-cycle1.sh
+    sudo $DOCKER exec node3 chmod +x /bin/apex-run-node3-cycle1.sh
+
+    # Start the agents on all 3 nodes nodes (currently the hub-router needs to be spun up first)
+    sudo $DOCKER exec node1 /bin/apex-run-node1-cycle1.sh &
+    sudo $DOCKER exec node2 /bin/apex-run-node2-cycle1.sh &
+    sudo $DOCKER exec node3 /bin/apex-run-node3-cycle1.sh &
+
+    sleep 10
+    # Check connectivity between node3 -> node1
+    if sudo $DOCKER exec node3 ping -c 2 -w 2 $(sudo $DOCKER exec node1 ip --brief address show wg0 | awk '{print $3}' | cut -d "/" -f1); then
+        echo "peer nodes successfully communicated"
+    else
+        echo "node3 failed to reach node1, e2e failed"
+        exit 1
+    fi
+    # Check connectivity between node3 -> node2
+    if sudo $DOCKER exec node3 ping -c 2 -w 2 $(sudo $DOCKER exec node2 ip --brief address show wg0 | awk '{print $3}' | cut -d "/" -f1); then
+        echo "peer nodes successfully communicated"
+    else
+        echo "node3 failed to reach node2, e2e failed"
+        exit 1
+    fi
+    # Check connectivity between node1 -> node3
+    if sudo $DOCKER exec node1 ping -c 2 -w 2 $(sudo $DOCKER exec node3 ip --brief address show wg0 | awk '{print $3}' | cut -d "/" -f1); then
+        echo "peer nodes successfully communicated"
+    else
+        echo "node1 failed to reach node3, e2e failed"
+        exit 1
+    fi
+    sudo $DOCKER exec node1 killall apex
+    sudo $DOCKER exec node2 killall apex
+    sudo $DOCKER exec node3 killall apex
+
+    # Count the occurrences of [Peer] in wg0.conf (should be 2 for a 3 node peering)
+    wg_conf_peer_count=$(sudo $DOCKER exec node1 grep Peer /etc/wireguard/wg0.conf | wc -l)
+    if ((wg_conf_peer_count != 2)); then
+      echo "The peer count in wg0.conf  on node1 should be 2"
+    fi
+    wg_conf_peer_count=$(sudo $DOCKER exec node2 grep Peer /etc/wireguard/wg0.conf | wc -l)
+    if ((wg_conf_peer_count != 2)); then
+      echo "The peer count in wg0.conf  on node2 should be 2"
+    fi
+    wg_conf_peer_count=$(sudo $DOCKER exec node2 grep Peer /etc/wireguard/wg0.conf | wc -l)
+    if ((wg_conf_peer_count != 2)); then
+      echo "The peer count in wg0.conf on node3 should be 2"
+    fi
+
+    # Copy files to the containers
+    sudo $DOCKER cp ./apex-run-node1-cycle2.sh node1:/bin/apex-run-node1-cycle2.sh
+    sudo $DOCKER cp ./apex-run-node2-cycle2.sh node2:/bin/apex-run-node2-cycle2.sh
+    sudo $DOCKER cp ./apex-run-node3-cycle2.sh node3:/bin/apex-run-node3-cycle2.sh
+
+    # Set permissions in the container
+    sudo $DOCKER exec node1 chmod +x /bin/apex-run-node1-cycle2.sh
+    sudo $DOCKER exec node2 chmod +x /bin/apex-run-node2-cycle2.sh
+    sudo $DOCKER exec node3 chmod +x /bin/apex-run-node3-cycle2.sh
+
+    # Start the agents on all 3 nodes nodes (currently the hub-router needs to be spun up first)
+    sudo $DOCKER exec node1 /bin/apex-run-node1-cycle2.sh &
+    sudo $DOCKER exec node2 /bin/apex-run-node2-cycle2.sh &
+    sudo $DOCKER exec node3 /bin/apex-run-node3-cycle2.sh &
+
+    sleep 10
+    # Check connectivity between node3 -> node1
+    if sudo $DOCKER exec node3 ping -c 2 -w 2 $(sudo $DOCKER exec node1 ip --brief address show wg0 | awk '{print $3}' | cut -d "/" -f1); then
+        echo "peer nodes successfully communicated"
+    else
+        echo "node3 failed to reach node1, e2e failed"
+        exit 1
+    fi
+    # Check connectivity between node3 -> node2
+    if sudo $DOCKER exec node3 ping -c 2 -w 2 $(sudo $DOCKER exec node2 ip --brief address show wg0 | awk '{print $3}' | cut -d "/" -f1); then
+        echo "peer nodes successfully communicated"
+    else
+        echo "node3 failed to reach node2, e2e failed"
+        exit 1
+    fi
+    # Check connectivity between node1 -> node3
+    if sudo $DOCKER exec node1 ping -c 2 -w 2 $(sudo $DOCKER exec node3 ip --brief address show wg0 | awk '{print $3}' | cut -d "/" -f1); then
+        echo "peer nodes successfully communicated"
+    else
+        echo "node1 failed to reach node3, e2e failed"
+        exit 1
+    fi
+    sudo $DOCKER exec node1 killall apex
+    sudo $DOCKER exec node2 killall apex
+    sudo $DOCKER exec node3 killall apex
+
+    # Count the occurrences of [Peer] in wg0.conf (should be 2 for a 3 node peering)
+    wg_conf_peer_count=$(sudo $DOCKER exec node1 grep Peer /etc/wireguard/wg0.conf | wc -l)
+    if ((wg_conf_peer_count != 2)); then
+      echo "The peer count in wg0.conf  on node1 should be 2"
+    fi
+    wg_conf_peer_count=$(sudo $DOCKER exec node2 grep Peer /etc/wireguard/wg0.conf | wc -l)
+    if ((wg_conf_peer_count != 2)); then
+      echo "The peer count in wg0.conf  on node2 should be 2"
+    fi
+    wg_conf_peer_count=$(sudo $DOCKER exec node2 grep Peer /etc/wireguard/wg0.conf | wc -l)
+    if ((wg_conf_peer_count != 2)); then
+      echo "The peer count in wg0.conf on node3 should be 2"
+    fi
+}
+
+###########################################################################
+# Description:                                                            #
 # Run the following functions to test end to end connectivity between     #
 # Wireguard interfaces in the container on interface wg0                  #
                                                                           #
@@ -618,6 +926,8 @@ verify_connectivity
 clean_nodes
 setup_hub_spoke_connectivity
 verify_connectivity
+clean_nodes
+cycle_configurations
 clean_nodes
 
 echo "e2e completed"


### PR DESCRIPTION
- If a node changes its attributes such as an endpoint
  ip or child prefix, update the peer listing slice.
- Delete the public key entry in the peers table if
  a new join comes in with it (temporary fix)
- Resolved a `--request-ip` bug and added IT for it.
- Resolves #85 and #77

Signed-off-by: Brent Salisbury <bsalisbu@redhat.com>
Co-authored-by: Anil Kumar Vishnoi <avishnoi@redhat.com>