### PR TITLE
 Added basic peer discovery to determine what to mesh and what to bounce

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       - "--db-address=postgres"
       - "--db-password=floofykittens"
     environment:
-      CONTROLLER_LOG_LEVEL: debug
+      APEX_CONTROLLER_LOGLEVEL: debug
 
   ui:
     image: quay.io/apex/controller-ui

--- a/internal/apex/apex.go
+++ b/internal/apex/apex.go
@@ -33,9 +33,11 @@ type Apex struct {
 	zone                    string
 	requestedIP             string
 	userProvidedEndpointIP  string
+	localEndpointIP         string
 	childPrefix             string
 	publicNetwork           bool
 	hubRouter               bool
+	hubRouterWgIP           string
 	os                      string
 	wgConfig                wgConfig
 }
@@ -132,7 +134,8 @@ func (ax *Apex) Run() {
 			log.Fatalf("unable to determine the ip address of the host, please specify using --local-endpoint-ip: %v", err)
 		}
 	}
-	log.Infof("This node's endpoint address for building tunnels is [ %s ]", localEndpointIP)
+	ax.localEndpointIP = localEndpointIP
+	log.Infof("This node's endpoint address for building tunnels is [ %s ]", ax.localEndpointIP)
 
 	controller := fmt.Sprintf("%s:%d", ax.controllerIP, pubSubPort)
 	rc := redis.NewClient(&redis.Options{

--- a/internal/apex/configure-pull.go
+++ b/internal/apex/configure-pull.go
@@ -5,13 +5,15 @@ import (
 	"gopkg.in/ini.v1"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/redhat-et/apex/internal/messages"
 	log "github.com/sirupsen/logrus"
 )
 
 const (
-	persistentKeepalive = "25"
+	persistentKeepalive    = "25"
+	persistentHubKeepalive = "0"
 )
 
 // ParseWireguardConfig parse peerlisting to build the wireguard [Interface] and [Peer] sections
@@ -135,6 +137,20 @@ func (ax *Apex) DeployWireguardConfig() {
 				}
 			}
 		}
+		// initiate some traffic to peers, not necessary for p2p only due to PersistentKeepalive
+		if ax.hubRouter {
+			var wgPeerIPs []string
+			for _, peer := range ax.wgConfig.Peer {
+				wgPeerIPs = append(wgPeerIPs, peer.AllowedIPs)
+			}
+			if ax.hubRouterWgIP != "" {
+				wgPeerIPs = append(wgPeerIPs, ax.hubRouterWgIP)
+			}
+			// give the wg0 a second to renegotiate the peering before probing again
+			time.Sleep(time.Second * 1)
+			probePeers(wgPeerIPs)
+		}
+
 	case Darwin.String():
 		activeDarwinConfig := filepath.Join(WgDarwinConfPath, wgConfActive)
 		if err = cfg.SaveTo(activeDarwinConfig); err != nil {
@@ -153,6 +169,20 @@ func (ax *Apex) DeployWireguardConfig() {
 			}
 			log.Debugf("%v", wgOut)
 		}
+		// initiate some traffic to peers, not necessary for p2p only due to PersistentKeepalive
+		if ax.hubRouter {
+			var wgPeerIPs []string
+			for _, peer := range ax.wgConfig.Peer {
+				wgPeerIPs = append(wgPeerIPs, peer.AllowedIPs)
+			}
+			if ax.hubRouterWgIP != "" {
+				wgPeerIPs = append(wgPeerIPs, ax.hubRouterWgIP)
+			}
+			// give the wg0 a second to renegotiate the peering before probing again
+			time.Sleep(time.Second * 1)
+			probePeers(wgPeerIPs)
+		}
+
 	case Windows.String():
 		activeWindowsConfig := filepath.Join(WgWindowsConfPath, wgConfActive)
 		if err = cfg.SaveTo(activeWindowsConfig); err != nil {
@@ -172,6 +202,19 @@ func (ax *Apex) DeployWireguardConfig() {
 				log.Errorf("failed to start the wireguard interface: %v\n", err)
 			}
 			log.Debugf("%v\n", wgOut)
+		}
+		// initiate some traffic to peers, not necessary for p2p only due to PersistentKeepalive
+		if ax.hubRouter {
+			var wgPeerIPs []string
+			for _, peer := range ax.wgConfig.Peer {
+				wgPeerIPs = append(wgPeerIPs, peer.AllowedIPs)
+			}
+			if ax.hubRouterWgIP != "" {
+				wgPeerIPs = append(wgPeerIPs, ax.hubRouterWgIP)
+			}
+			// give the wg0 a second to renegotiate the peering before probing again
+			time.Sleep(time.Second * 1)
+			probePeers(wgPeerIPs)
 		}
 	}
 	log.Printf("Peer setup complete")

--- a/internal/apex/discovery.go
+++ b/internal/apex/discovery.go
@@ -1,0 +1,150 @@
+package apex
+
+import (
+	"encoding/binary"
+	"fmt"
+	"net"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
+type probeResults struct {
+	peer   string
+	status bool
+}
+
+type dialer struct {
+	dial func(string, string) (net.Conn, error)
+}
+
+const (
+	iterations                         = 1
+	interval                           = 600
+	timeWait                           = 1000
+	PACKETSIZE                         = 64
+	ICMP_TYPE_ECHO_REQUEST             = 8
+	ICMP_ECHO_REPLY_HEADER_IPV4_OFFSET = 20
+)
+
+// probePeers initial simple proofing of a peer discovery
+func probePeers(peers []string) []string {
+	c := make(chan probeResults)
+	for _, peer := range peers {
+		go runProbe(peer, c)
+	}
+	var reachablePeers []string
+	result := make([]probeResults, len(peers))
+	for i := range result {
+		result[i] = <-c
+		if result[i].status {
+			reachablePeers = append(reachablePeers, result[i].peer)
+			log.Debugf("peer [ %s ] is reachable", result[i].peer)
+		} else {
+			log.Debugf("peer [ %s ] is not reachable", result[i].peer)
+		}
+	}
+	return reachablePeers
+}
+
+func runProbe(peer string, c chan probeResults) {
+	err := ping(peer)
+	if err != nil {
+		// peer is not replying
+		c <- probeResults{peer, false}
+	} else {
+		// peer is replying
+		c <- probeResults{peer, true}
+	}
+}
+
+func newPinger() *dialer {
+	return &dialer{
+		dial: net.Dial,
+	}
+}
+
+func cksum(bs []byte) uint16 {
+	sum := uint32(0)
+	for k := 0; k < len(bs)/2; k++ {
+		sum += uint32(bs[k*2]) << 8
+		sum += uint32(bs[k*2+1])
+	}
+	if len(bs)%2 != 0 {
+		sum += uint32(bs[len(bs)-1]) << 8
+	}
+	sum = (sum >> 16) + (sum & 0xffff)
+	sum = (sum >> 16) + (sum & 0xffff)
+	if sum == 0xffff {
+		sum = 0
+	}
+
+	return ^uint16(sum)
+}
+
+func (p *dialer) ping(host string, i uint64, waitFor time.Duration) (string, error) {
+	netname := "ip4:icmp"
+	c, err := p.dial(netname, host)
+	if err != nil {
+		return "", fmt.Errorf("net.Dial(%v %v) failed: %v", netname, host, err)
+	}
+	defer c.Close()
+	// send echo request
+	if err = c.SetDeadline(time.Now().Add(waitFor)); err != nil {
+		log.Debugf("probe error: %v", err)
+	}
+
+	msg := make([]byte, PACKETSIZE)
+	msg[0] = ICMP_TYPE_ECHO_REQUEST
+	msg[1] = 0
+	binary.BigEndian.PutUint16(msg[6:], uint16(i))
+	binary.BigEndian.PutUint16(msg[4:], uint16(i>>16))
+	binary.BigEndian.PutUint16(msg[2:], cksum(msg))
+	if _, err := c.Write(msg[:]); err != nil {
+		return "", fmt.Errorf("write failed: %v", err)
+	}
+	// get echo reply
+	if err = c.SetDeadline(time.Now().Add(waitFor)); err != nil {
+		log.Debugf("probe error: %v", err)
+	}
+	rmsg := make([]byte, PACKETSIZE+256)
+	before := time.Now()
+	amt, err := c.Read(rmsg[:])
+	if err != nil {
+		return "", fmt.Errorf("read failed: %v", err)
+	}
+	latency := time.Since(before)
+
+	rmsg = rmsg[ICMP_ECHO_REPLY_HEADER_IPV4_OFFSET:]
+	cks := binary.BigEndian.Uint16(rmsg[2:])
+	binary.BigEndian.PutUint16(rmsg[2:], 0)
+	if cks != cksum(rmsg) {
+		return "", fmt.Errorf("bad ICMP checksum: %v (expected %v)", cks, cksum(rmsg))
+	}
+	id := binary.BigEndian.Uint16(rmsg[4:])
+	seq := binary.BigEndian.Uint16(rmsg[6:])
+	rseq := uint64(id)<<16 + uint64(seq)
+	if rseq != i {
+		return "", fmt.Errorf("wrong sequence number %v (expected %v)", rseq, i)
+	}
+
+	return fmt.Sprintf("%d bytes from %v: icmp_seq=%v, time=%v", amt, host, i, latency), nil
+}
+
+func ping(host string) error {
+	if PACKETSIZE < 8 {
+		return fmt.Errorf("packet size too small (must be >= 8): %v", PACKETSIZE)
+	}
+	interval := time.Duration(interval)
+	p := newPinger()
+	waitFor := time.Duration(timeWait) * time.Millisecond
+	for i := uint64(0); i <= iterations; i++ {
+		_, err := p.ping(host, i+1, waitFor)
+		if err != nil {
+			return fmt.Errorf("ping failed: %v", err)
+		}
+		// TODO: this is probably irrelevant on one iteration
+		time.Sleep(time.Millisecond * interval)
+	}
+	return nil
+}

--- a/internal/apex/utils.go
+++ b/internal/apex/utils.go
@@ -213,6 +213,14 @@ func ParseIPNet(s string) (*net.IPNet, error) {
 	return &net.IPNet{IP: ip, Mask: ipNet.Mask}, nil
 }
 
+func parseNetworkStr(cidr string) (string, error) {
+	_, nw, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return "", err
+	}
+	return nw.String(), nil
+}
+
 // sanitizeWindowsConfig removes incompatible fields from the wg Interface section
 func sanitizeWindowsConfig(file string) {
 	b, err := ioutil.ReadFile(file)

--- a/tests/e2e-scripts/init-containers.sh
+++ b/tests/e2e-scripts/init-containers.sh
@@ -87,7 +87,7 @@ copy_binaries() {
     # Node-1 apex run default zone
     cat <<EOF > apex-run-node1.sh
 #!/bin/bash
-apex \
+APEX_LOGLEVEL=debug apex \
 --public-key=${node1_pubkey} \
 --private-key=${node1_pvtkey} \
 --controller=${controller} \
@@ -98,7 +98,7 @@ EOF
     # Node-2 apex run default zone
     cat <<EOF > apex-run-node2.sh
 #!/bin/bash
-apex \
+APEX_LOGLEVEL=debug apex \
 --public-key=${node2_pubkey} \
 --private-key=${node2_pvtkey} \
 --controller=${controller} \
@@ -192,7 +192,7 @@ setup_custom_zone_connectivity() {
     # Node-1 apex run
     cat <<EOF > apex-run-node1.sh
 #!/bin/bash
-apex \
+APEX_LOGLEVEL=debug apex \
 --public-key=${node1_pubkey} \
 --private-key-file=/etc/wireguard/private.key \
 --controller=${controller} \
@@ -204,7 +204,7 @@ EOF
     # Node-2 apex run
     cat <<EOF > apex-run-node2.sh
 #!/bin/bash
-apex \
+APEX_LOGLEVEL=debug apex \
 --public-key=${node2_pubkey} \
 --private-key-file=/etc/wireguard/private.key \
 --controller=${controller} \
@@ -281,7 +281,7 @@ setup_requested_ip_connectivity() {
     # Node-1 cycle-1 apex run
     cat <<EOF > apex-cycle1-node1.sh
 #!/bin/bash
-apex \
+APEX_LOGLEVEL=debug apex \
 --public-key=${node1_pubkey} \
 --private-key-file=/etc/wireguard/private.key \
 --controller=${controller} \
@@ -294,7 +294,7 @@ EOF
     # Node-2 cycle-1 apex run
     cat <<EOF > apex-cycle1-node2.sh
 #!/bin/bash
-apex \
+APEX_LOGLEVEL=debug apex \
 --public-key=${node2_pubkey} \
 --private-key-file=/etc/wireguard/private.key \
 --controller=${controller} \
@@ -307,7 +307,7 @@ EOF
     # Node-1 cycle-2 apex run
     cat <<EOF > apex-cycle2-node1.sh
 #!/bin/bash
-apex \
+APEX_LOGLEVEL=debug apex \
 --public-key=${node1_pubkey} \
 --private-key-file=/etc/wireguard/private.key \
 --controller=${controller} \
@@ -320,7 +320,7 @@ EOF
     # Node-2 cycle-2 apex run
     cat <<EOF > apex-cycle2-node2.sh
 #!/bin/bash
-apex \
+APEX_LOGLEVEL=debug apex \
 --public-key=${node2_pubkey} \
 --private-key-file=/etc/wireguard/private.key \
 --controller=${controller} \
@@ -352,8 +352,8 @@ EOF
     $DOCKER exec node1 /bin/apex-cycle1-node1.sh &
     $DOCKER exec node2 /bin/apex-cycle1-node2.sh &
 
-    # Allow two seconds for the wg0 interface to readdress
-    sleep 2
+    # Allow five seconds for the wg0 interface to readdress
+    sleep 5
 
     # Check connectivity between the request ip from node1 > node2
     if $DOCKER exec node1 ping -c 2 -w 2 ${node2_requested_ip_cycle1}; then
@@ -455,7 +455,8 @@ setup_child_prefix_connectivity() {
     # Node-1 apex run
     cat <<EOF > apex-run-node1.sh
 #!/bin/bash
-    apex --public-key=${node1_pubkey} \
+APEX_LOGLEVEL=debug apex \
+    --public-key=${node1_pubkey} \
     --private-key-file=/etc/wireguard/private.key  \
     --controller=${controller} \
     --controller-password=${controller_passwd} \
@@ -467,7 +468,8 @@ EOF
     # Node-2 apex run
     cat <<EOF > apex-run-node2.sh
 #!/bin/bash
-    apex --public-key=${node2_pubkey} \
+APEX_LOGLEVEL=debug apex \
+    --public-key=${node2_pubkey} \
     --private-key-file=/etc/wireguard/private.key  \
     --controller=${controller} \
     --controller-password=${controller_passwd} \
@@ -596,7 +598,8 @@ setup_hub_spoke_connectivity() {
     # Node-1 apex run
     cat <<EOF > apex-run-node1.sh
 #!/bin/bash
-    apex --public-key=${node1_pubkey} \
+APEX_LOGLEVEL=debug apex \
+    --public-key=${node1_pubkey} \
     --private-key-file=/etc/wireguard/private.key \
     --controller=${controller} \
     --controller-password=${controller_passwd} \
@@ -607,7 +610,8 @@ EOF
     # Node-2 apex run
     cat <<EOF > apex-run-node2.sh
 #!/bin/bash
-    apex --public-key=${node2_pubkey} \
+APEX_LOGLEVEL=debug apex \
+    --public-key=${node2_pubkey} \
     --private-key-file=/etc/wireguard/private.key \
     --controller=${controller} \
     --controller-password=${controller_passwd} \
@@ -617,7 +621,8 @@ EOF
     # Node-3 apex run
     cat <<EOF > apex-run-node3.sh
 #!/bin/bash
-    apex --public-key=${node3_pubkey} \
+APEX_LOGLEVEL=debug apex \
+    --public-key=${node3_pubkey} \
     --private-key-file=/etc/wireguard/private.key \
     --controller=${controller} \
     --controller-password=${controller_passwd} \
@@ -647,12 +652,12 @@ EOF
 
     # Start the agents on all 3 nodes nodes (currently the hub-router needs to be spun up first)
     sudo $DOCKER exec node1 /bin/apex-run-node1.sh &
-    sleep 3
+    sleep 5
     sudo $DOCKER exec node2 /bin/apex-run-node2.sh &
     sudo $DOCKER exec node3 /bin/apex-run-node3.sh &
 
     # Allow four seconds for the wg0 interface to readdress
-    sleep 4
+    sleep 6
     verify_three_node_connectivity
 
     $DOCKER exec node1 killall apex
@@ -754,7 +759,8 @@ cycle_mesh_configurations(){
     do
         cat <<EOF > apex-run-node1-cycle${i}.sh
 #!/bin/bash
-    apex --public-key=${node1_pubkey} \
+APEX_LOGLEVEL=debug apex \
+    --public-key=${node1_pubkey} \
     --private-key-file=/etc/wireguard/private.key \
     --controller=${controller} \
     --controller-password=${controller_passwd} \
@@ -765,7 +771,8 @@ EOF
 
         cat <<EOF > apex-run-node2-cycle${i}.sh
 #!/bin/bash
-    apex --public-key=${node2_pubkey} \
+APEX_LOGLEVEL=debug apex \
+    --public-key=${node2_pubkey} \
     --private-key-file=/etc/wireguard/private.key \
     --controller=${controller} \
     --controller-password=${controller_passwd} \
@@ -776,7 +783,8 @@ EOF
 
         cat <<EOF > apex-run-node3-cycle${i}.sh
 #!/bin/bash
-    apex --public-key=${node3_pubkey} \
+APEX_LOGLEVEL=debug apex \
+    --public-key=${node3_pubkey} \
     --private-key-file=/etc/wireguard/private.key \
     --controller=${controller} \
     --controller-password=${controller_passwd} \
@@ -803,7 +811,8 @@ EOF
     # Node-1 apex run
     cat <<EOF > apex-pubip-node1.sh
 #!/bin/bash
-    apex --public-key=${node1_pubkey} \
+APEX_LOGLEVEL=debug apex \
+    --public-key=${node1_pubkey} \
     --private-key-file=/etc/wireguard/private.key \
     --controller=${controller} \
     --public-network \
@@ -814,7 +823,8 @@ EOF
     # Node-2 apex run
     cat <<EOF > apex-pubip-node2.sh
 #!/bin/bash
-    apex --public-key=${node2_pubkey} \
+APEX_LOGLEVEL=debug apex \
+    --public-key=${node2_pubkey} \
     --private-key-file=/etc/wireguard/private.key \
     --controller=${controller} \
     --public-network \
@@ -825,7 +835,8 @@ EOF
     # Node-3 apex run
     cat <<EOF > apex-pubip-node3.sh
 #!/bin/bash
-    apex --public-key=${node3_pubkey} \
+APEX_LOGLEVEL=debug apex \
+    --public-key=${node3_pubkey} \
     --private-key-file=/etc/wireguard/private.key \
     --controller=${controller} \
     --public-network \


### PR DESCRIPTION
- Hub zone peer requests will check basic endpoint connectivity to the peer listing endpoints. If they can reach the endpoint IP, they will add a p2p peer entry, if they can not no entry is added and connectivity will be bounced through the hub-router.

Signed-off-by: Brent Salisbury <bsalisbu@redhat.com>