### PR TITLE
Add env variable to docker-componse.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,10 +31,10 @@ services:
     ports:
       - 8080:8080
     command:
-      - "--streamer-address=redis"
-      - "--streamer-password=floofykittens"
-      - "--db-address=postgres"
-      - "--db-password=floofykittens"
+      - "--streamer-address=${STREAMER_IP:-redis}"
+      - "--streamer-password=${STREAMER_PASSWORD:-floofykittens}"
+      - "--db-address=${DB_IP:-postgres}"
+      - "--db-password=${DB_PASSWORD:-floofykittens}"
     environment:
       APEX_CONTROLLER_LOGLEVEL: debug
 
@@ -58,10 +58,10 @@ services:
     environment:
       - KEYCLOAK_ADMIN=admin
       - KEYCLOAK_ADMIN_PASSWORD=floofykittens
-      - KC_DB=postgres
-      - KC_DB_URL=jdbc:postgresql://postgres/keycloak
-      - KC_DB_USERNAME=controller
-      - KC_DB_PASSWORD=floofykittens
+      - KC_DB=${DB_IP:-postgres}
+      - KC_DB_URL=jdbc:postgresql://${DB_IP:-postgres}/keycloak
+      - KC_DB_USERNAME=${DB_USER:-controller}
+      - KC_DB_PASSWORD=${DB_PASSWORD:-floofykittens}
     volumes:
       - ./hack/controller-realm.json:/opt/keycloak/data/import/controller-realm.json
     command:

--- a/hack/README.md
+++ b/hack/README.md
@@ -1,7 +1,90 @@
 
 # Developer Quickstart
 
-## Build the binaries
+## Dev Environment setup using docker-compose
+
+### On local machine
+Clone the apex repo:
+
+```shell
+git clone https://github.com/redhat-et/apex.git
+```
+
+```shell
+cd apex
+docker-compose build
+docker-compose up -d
+```
+
+These commands will build all the required binaries/images and start all the component of the controller stack (redis server, postgres db, keycloak instance, UI and controller).
+
+If you already have a running redis server instance and wants to use that, you can specify following environment variable to point the stack to that remote redis server
+
+```shell
+STREAMER_IP=<redis-ip-address> STREAMER_PASSWORD=<redis-password> docker-compose up -d
+```
+
+Similarly if want to connect to any existing postgres instance
+```shell
+DB_IP=<db-ip> DB_USER=<db-user-name> DB_PASSWORD=<db-password> docker-compose up -d
+```
+
+### On Remote Machine hosted somewhere in your intranet)
+Make sure the remote machine have key based authentication enabled for ssh (won't work with password prompts), and also running docker and docker-compose.
+
+```shell
+docker context create remote --docker "host=ssh://<REMOTE_USER>@<REMOTE_MACHINE_IP_OR_DNS"
+
+docker-compose --context remote build
+docker-compose --context remote up -d
+```
+
+### On Remote Machine hosted on Cloud (E.g Aws)
+
+Add the access ID of the Cloud VM to your local machine `~/.ssh/config`.
+```
+Host <dns-name-of-cloud-vm>
+  User <USER>
+  IdentityFile <Location of the access key>
+
+e.g 
+Host ec2-xxx-yyy-zzz-www.us-west-1.compute.amazonaws.com
+  User ubuntu
+  IdentityFile ~/Downloads/aws/aws-access-key.pem
+```
+
+That should allow you to access your Cloud VM without explicitly specifying the access key using `-i` option.
+Once you setup key base authentication for your Cloud VM, you can create a docker context and use that for docker-compose.
+
+```shell
+docker context create cloudvm --docker "host=ssh://<USER>@<CLOUD_VM_IP_OR_DNS"
+
+docker-compose --context cloudvm build
+docker-compose --context cloudvm up -d
+```
+
+### On Kubernetes deployment 
+You will need the Kubernetes config file available somewhere locally to deploy the stack on the kubernetes cluster using docker-compose.
+
+Create a new context 
+
+```shell
+docker context create k8s \
+    --default-stack-orchestrator=kubernetes \
+    --kubernetes config-file=<path-to-kube-config> \
+    --docker host=unix:///var/run/docker.sock
+```
+
+and use the context with docker-compose to deploy controller stack
+
+```shell
+docker-compose --k8s cloudvm build
+docker-compose --k8s cloudvm up -d
+```
+
+## Dev environment setup using individual components
+
+### Build the binaries
 Following command will build the binaries for your default host OS, and place it in `dist` directory.
 
 ```shell
@@ -23,7 +106,7 @@ make build-apex-darwin
 make build-controller-darwin
 ```
 
-## Setup the dev environment:
+### Setup the dev environment:
 Start redis instance in Cloud or on any local node. This nodes must be reachable from all the nodes that you will be using for your dev environment to test the connectivity and the machine where Apex Controller will be running (e.g your laptop). Below is an example for podman or docker for ease of use, no other configuration is required.
 
 ```shell
@@ -66,9 +149,16 @@ sudo APEX_LOG_LEVEL=debug ./apex --public-key=<NODE_WIREGUARD_PUBLIC_KEY>  \
 ```
 
 ##  Cleanup the dev environment
+
+### Controller cleanup
+If you are using docker-compose, run `docker compose down` and it will remove all the containers running the controller stack.
+
+If you have setup individual components, kill those processes.
+
+### Node cleanup
 If you want to remove the node from the network, and want to cleanup all the configuration done on the node. Fire away following commands:
 
-Ctrl + c (cmd+c) the agent process. and remove the wireguard interface and relevant configuration files.
+Ctrl + c (cmd+c) the Apex process, and remove the wireguard interface and relevant configuration files.
 *Linux:*
 ```shell
 sudo rm /etc/wireguard/wg0-latest-rev.conf
@@ -79,5 +169,3 @@ sudo ip link del wg0
 ```shell
 sudo wg-quick down wg0
 ```
-
-Kill your Controller and build & restart if you want to deploy new changes.


### PR DESCRIPTION
This PR adds
*.* Add env variable to docker-componse.yml
In case user want to point the controlelr stack
to already running redis or postgres instance,
it can use these environment variable to point
controller, keycloak to remove redis/postgres

*.* Instruction to deploy the controller stack on
remove VM, remote VM somewhere on Cloud, and Kubernetes (local or remote)

Signed-off-by: Anil Kumar Vishnoi <avishnoi@redhat.com>