### PR TITLE
New onboarding flow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -20,7 +20,6 @@ apex-amd64-linux
 # Ops files
 ops/
 tests/
-hack/
 docs/
 **/peer-inventory/*
 **/endpoints.toml

--- a/.github/workflows/ci-e2e.yml
+++ b/.github/workflows/ci-e2e.yml
@@ -27,4 +27,6 @@ jobs:
         go-version: 1.18
 
     - name: Run e2e
-      run: make OS_IMAGE=quay.io/networkstatic/${{ matrix.DEPLOYMENT }} run-ci-e2e
+      run: |
+        make OS_IMAGE=quay.io/networkstatic/${{ matrix.DEPLOYMENT }} e2e
+        [ "$?" = 0 ] || cat docker-compose.log

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@
 ./tests/*.key
 /*.key
 /apex-*.sh
+docker-compose.log

--- a/Containerfile.nginx
+++ b/Containerfile.nginx
@@ -1,0 +1,4 @@
+FROM docker.io/library/nginx:stable-alpine
+COPY ./hack/nginx.conf /etc/nginx/conf.d/default.conf
+EXPOSE 8080
+CMD ["nginx", "-g", "daemon off;"]

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ test-images:
 OS_IMAGE?="quay.io/apex/test:fedora"
 
 # Runs the CI e2e tests used in github actions
-.PHONY: run-ci-e2e
-run-ci-e2e: dist/apex
+.PHONY: e2e
+e2e: dist/apex
 	docker compose build
 	./tests/e2e-scripts/init-containers.sh -o $(OS_IMAGE)

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ In the following curl command, replace localhost with the IP address of the node
 
 Create zone blue:
 ```shell
-curl -L -X POST 'http://localhost:8080/zone' \
+curl -L -X POST 'http://localhost:8080/api/zone' \
 -H 'Content-Type: application/json' \
 --data-raw '{
     "Name": "zone-blue",
@@ -160,7 +160,7 @@ curl -L -X POST 'http://localhost:8080/zone' \
 
 Create zone red:
 ```shell
-curl -L -X POST 'http://localhost:8080/zone' \
+curl -L -X POST 'http://localhost:8080/api/zone' \
 -H 'Content-Type: application/json' \
 --data-raw '{
     "Name": "zone-red",
@@ -172,7 +172,7 @@ curl -L -X POST 'http://localhost:8080/zone' \
 #### **Verify the created zones**
 
 ```shell
-curl -L -X GET 'http://localhost:8080/zones'
+curl -L -X GET 'http://localhost:8080/api/zones'
 ```
 
 #### **Join the nodes to the zones**
@@ -205,7 +205,7 @@ ifconfig
 You can also view the lease state of the IPAM objects with:
 
 ```shell
-curl http://localhost:8080/ipam/leases/zone-blue
+curl http://localhost:8080/api/ipam/leases/zone-blue
 ```
 Curl should respond with output similar to the following
 
@@ -354,7 +354,7 @@ There are currently some supported REST calls:
 **Get all peers:**
 
 ```shell
-curl -s --location --request GET 'http://localhost:8080/peers' | python -m json.tool
+curl -s --location --request GET 'http://localhost:8080/api/peers' | python -m json.tool
 ```
 
 *Output:*
@@ -401,7 +401,7 @@ curl -s --location --request GET 'http://localhost:8080/peers' | python -m json.
 **Get a peer by key:**
 
 ```shell
-curl -s --location --request GET 'http://localhost:8080/peers/M+BTP8LbMikKLufoTTI7tPL5Jf3SHhNki6SXEXa5Uic=' | python -m json.tool
+curl -s --location --request GET 'http://localhost:8080/api/peers/M+BTP8LbMikKLufoTTI7tPL5Jf3SHhNki6SXEXa5Uic=' | python -m json.tool
 ```
 
 *Output:*
@@ -418,7 +418,7 @@ curl -s --location --request GET 'http://localhost:8080/peers/M+BTP8LbMikKLufoTT
 **Get zone details:**
 
 ```shell
-curl --location --request GET 'http://localhost:8080/zones'
+curl --location --request GET 'http://localhost:8080/api/zones'
 ```
 
 *Output:* **(notice the overlapping CIDR address support)**
@@ -441,8 +441,8 @@ curl --location --request GET 'http://localhost:8080/zones'
 **Get the leases of nodes in a particular zone:**
 
 ```shell
-curl --location --request GET 'http://localhost:8080/ipam/leases/zone-blue'
-curl --location --request GET 'http://localhost:8080/ipam/leases/zone-red'
+curl --location --request GET 'http://localhost:8080/api/ipam/leases/zone-blue'
+curl --location --request GET 'http://localhost:8080/api/ipam/leases/zone-red'
 ```
 
 *Output:*

--- a/cmd/apex/main.go
+++ b/cmd/apex/main.go
@@ -62,13 +62,6 @@ func main() {
 				Required: true,
 			},
 			&cli.StringFlag{
-				Name:     "zone",
-				Value:    "00000000-0000-0000-0000-000000000000",
-				Usage:    "the tenancy zone the peer is to join - zone needs to be created before joining (optional)",
-				EnvVars:  []string{"APEX_ZONE"},
-				Required: false,
-			},
-			&cli.StringFlag{
 				Name:     "request-ip",
 				Value:    "",
 				Usage:    "request a specific IP address from Ipam if available (optional)",
@@ -99,6 +92,13 @@ func main() {
 				Usage:    "set if this node is to be the hub in a hub and spoke deployment",
 				Value:    false,
 				EnvVars:  []string{"APEX_HUB_ROUTER"},
+				Required: false,
+			},
+			&cli.StringFlag{
+				Name:     "with-token",
+				Value:    "",
+				Usage:    "access token for apex controller (optional)",
+				EnvVars:  []string{"APEX_ACCESS_TOKEN"},
 				Required: false,
 			},
 		},

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,8 +45,6 @@ services:
     build:
       context: .
       dockerfile: ./Containerfile.controller
-    ports:
-      - 8080:8080
     command:
       - "--streamer-address=${STREAMER_IP:-redis}"
       - "--streamer-password=${STREAMER_PASSWORD:-floofykittens}"
@@ -64,8 +62,6 @@ services:
     build:
       context: .
       dockerfile: ./Containerfile.ui
-    ports:
-      - 3000:3000
 
   keycloak-db:
     image: docker.io/library/postgres
@@ -80,8 +76,6 @@ services:
     deploy:
       restart_policy:
         condition: on-failure
-    ports:
-      - 8888:8080
     environment:
       - KEYCLOAK_ADMIN=${KEYCLOAK_ADMIN_USER-admin}
       - KEYCLOAK_ADMIN_PASSWORD=${KEYCLOAK_ADMIN_PASSWORD-floofykittens}
@@ -93,5 +87,20 @@ services:
       - ./hack/controller-realm.json:/opt/keycloak/data/import/controller-realm.json
     command:
         - start-dev
+        - --proxy=passthrough
         - --import-realm
         - --features=token-exchange
+        - --hostname-url=http://localhost:8080/auth
+        - --hostname-strict=true
+        - --hostname-strict-backchannel=true
+
+  proxy:
+    depends_on:
+     - controller
+     - keycloak
+     - ui
+    ports:
+      - 8080:8080
+    build:
+      context: .
+      dockerfile: ./Containerfile.nginx

--- a/hack/controller-realm.json
+++ b/hack/controller-realm.json
@@ -260,9 +260,11 @@
         "containerId" : "27c6800f-b067-498d-82d6-f117c06e152c",
         "attributes" : { }
       } ],
+      "apex-cli" : [ ],
       "security-admin-console" : [ ],
       "admin-cli" : [ ],
       "account-console" : [ ],
+      "front-controller" : [ ],
       "broker" : [ {
         "id" : "4301ff51-2161-489c-8b4a-51d5f273f8e0",
         "name" : "read-token",
@@ -272,7 +274,6 @@
         "containerId" : "3e366f7d-0a35-486a-b437-8f8a68a7f769",
         "attributes" : { }
       } ],
-      "front-controller" : [ ],
       "account" : [ {
         "id" : "e6fa97be-45bf-429f-b02b-5cc053766b3e",
         "name" : "manage-account-links",
@@ -420,7 +421,7 @@
       "credentialData" : "{\"hashIterations\":27500,\"algorithm\":\"pbkdf2-sha256\",\"additionalParameters\":{}}"
     } ],
     "disableableCredentialTypes" : [ ],
-    "requiredActions" : [ "UPDATE_PASSWORD" ],
+    "requiredActions" : [ ],
     "realmRoles" : [ "user", "default-roles-controller" ],
     "notBefore" : 0,
     "groups" : [ ]
@@ -442,7 +443,7 @@
       "credentialData" : "{\"hashIterations\":27500,\"algorithm\":\"pbkdf2-sha256\",\"additionalParameters\":{}}"
     } ],
     "disableableCredentialTypes" : [ ],
-    "requiredActions" : [ "UPDATE_PASSWORD" ],
+    "requiredActions" : [ ],
     "realmRoles" : [ "default-roles-controller" ],
     "notBefore" : 0,
     "groups" : [ ]
@@ -464,7 +465,51 @@
       "credentialData" : "{\"hashIterations\":27500,\"algorithm\":\"pbkdf2-sha256\",\"additionalParameters\":{}}"
     } ],
     "disableableCredentialTypes" : [ ],
-    "requiredActions" : [ "UPDATE_PASSWORD" ],
+    "requiredActions" : [ ],
+    "realmRoles" : [ "default-roles-controller" ],
+    "notBefore" : 0,
+    "groups" : [ ]
+  }, {
+    "id" : "0ecc031c-d233-4b60-b835-d70ac155040d",
+    "createdTimestamp" : 1666213569990,
+    "username" : "kitteh4",
+    "enabled" : true,
+    "totp" : false,
+    "emailVerified" : false,
+    "firstName" : "Kitteh",
+    "lastName" : "Four",
+    "credentials" : [ {
+      "id" : "d76ba23d-77db-473e-9e95-94cb3e32de81",
+      "type" : "password",
+      "userLabel" : "My password",
+      "createdDate" : 1666213650698,
+      "secretData" : "{\"value\":\"zUR73ewKSFUBuq4poOhLz5nwhbY6tIoBk3qfNUm0SdoxtKipwKPcTy/NN1T3XHbds8+oyfBUYgrHcVzCM8xDTw==\",\"salt\":\"B9OECsD3kW0a3COCBlkuaA==\",\"additionalParameters\":{}}",
+      "credentialData" : "{\"hashIterations\":27500,\"algorithm\":\"pbkdf2-sha256\",\"additionalParameters\":{}}"
+    } ],
+    "disableableCredentialTypes" : [ ],
+    "requiredActions" : [ ],
+    "realmRoles" : [ "default-roles-controller" ],
+    "notBefore" : 0,
+    "groups" : [ ]
+  }, {
+    "id" : "2a2ad08c-542f-44e1-992a-e760f61e1998",
+    "createdTimestamp" : 1666213569990,
+    "username" : "kitteh5",
+    "enabled" : true,
+    "totp" : false,
+    "emailVerified" : false,
+    "firstName" : "Kitteh",
+    "lastName" : "Five",
+    "credentials" : [ {
+      "id" : "6bc7ac8a-027a-43a6-90f2-79b56de917cf",
+      "type" : "password",
+      "userLabel" : "My password",
+      "createdDate" : 1666213650698,
+      "secretData" : "{\"value\":\"zUR73ewKSFUBuq4poOhLz5nwhbY6tIoBk3qfNUm0SdoxtKipwKPcTy/NN1T3XHbds8+oyfBUYgrHcVzCM8xDTw==\",\"salt\":\"B9OECsD3kW0a3COCBlkuaA==\",\"additionalParameters\":{}}",
+      "credentialData" : "{\"hashIterations\":27500,\"algorithm\":\"pbkdf2-sha256\",\"additionalParameters\":{}}"
+    } ],
+    "disableableCredentialTypes" : [ ],
+    "requiredActions" : [ ],
     "realmRoles" : [ "default-roles-controller" ],
     "notBefore" : 0,
     "groups" : [ ]
@@ -577,6 +622,44 @@
     "defaultClientScopes" : [ "web-origins", "acr", "roles", "profile", "email" ],
     "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
   }, {
+    "id" : "260ed06b-bbfa-4cdd-b04a-2f4838965cb9",
+    "clientId" : "apex-cli",
+    "name" : "",
+    "description" : "",
+    "rootUrl" : "",
+    "adminUrl" : "",
+    "baseUrl" : "",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "alwaysDisplayInConsole" : false,
+    "clientAuthenticatorType" : "client-secret",
+    "secret" : "QkskUDQenfXRxWx9UA0TeuwmOnHilHtQ",
+    "redirectUris" : [ ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : false,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : false,
+    "frontchannelLogout" : true,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "oidc.ciba.grant.enabled" : "false",
+      "client.secret.creation.time" : "1667177954",
+      "backchannel.logout.session.required" : "true",
+      "display.on.consent.screen" : "false",
+      "oauth2.device.authorization.grant.enabled" : "true",
+      "backchannel.logout.revoke.offline.tokens" : "false"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : true,
+    "nodeReRegistrationTimeout" : -1,
+    "defaultClientScopes" : [ "web-origins", "acr", "roles", "profile", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+  }, {
     "id" : "134bafc1-3355-4ddb-9029-6b48e0afad66",
     "clientId" : "api-clients",
     "name" : "",
@@ -605,6 +688,7 @@
       "oidc.ciba.grant.enabled" : "false",
       "client.secret.creation.time" : "1666223033",
       "backchannel.logout.session.required" : "true",
+      "post.logout.redirect.uris" : "+",
       "display.on.consent.screen" : "false",
       "oauth2.device.authorization.grant.enabled" : "false",
       "backchannel.logout.revoke.offline.tokens" : "false"
@@ -647,14 +731,14 @@
     "clientId" : "front-controller",
     "name" : "",
     "description" : "",
-    "rootUrl" : "http://localhost:3000",
+    "rootUrl" : "http://localhost:8080",
     "adminUrl" : "",
-    "baseUrl" : "http://localhost:3000",
+    "baseUrl" : "http://localhost:8080",
     "surrogateAuthRequired" : false,
     "enabled" : true,
     "alwaysDisplayInConsole" : false,
     "clientAuthenticatorType" : "client-secret",
-    "redirectUris" : [ "http://localhost:3000/*" ],
+    "redirectUris" : [ "http://localhost:8080/*" ],
     "webOrigins" : [ "*" ],
     "notBefore" : 0,
     "bearerOnly" : false,
@@ -669,7 +753,7 @@
     "attributes" : {
       "oidc.ciba.grant.enabled" : "false",
       "backchannel.logout.session.required" : "true",
-      "post.logout.redirect.uris" : "http://localhost:3000/*",
+      "post.logout.redirect.uris" : "http://localhost:8080/*",
       "display.on.consent.screen" : "false",
       "oauth2.device.authorization.grant.enabled" : "false",
       "backchannel.logout.revoke.offline.tokens" : "false"
@@ -1244,7 +1328,7 @@
       "subType" : "authenticated",
       "subComponents" : { },
       "config" : {
-        "allowed-protocol-mapper-types" : [ "saml-user-property-mapper", "oidc-address-mapper", "oidc-sha256-pairwise-sub-mapper", "saml-role-list-mapper", "oidc-full-name-mapper", "oidc-usermodel-attribute-mapper", "saml-user-attribute-mapper", "oidc-usermodel-property-mapper" ]
+        "allowed-protocol-mapper-types" : [ "oidc-sha256-pairwise-sub-mapper", "oidc-full-name-mapper", "oidc-usermodel-property-mapper", "oidc-address-mapper", "saml-user-property-mapper", "saml-role-list-mapper", "saml-user-attribute-mapper", "oidc-usermodel-attribute-mapper" ]
       }
     }, {
       "id" : "6394b4cb-6417-4e16-9614-f18a5f81dc64",
@@ -1304,7 +1388,7 @@
       "subType" : "anonymous",
       "subComponents" : { },
       "config" : {
-        "allowed-protocol-mapper-types" : [ "oidc-address-mapper", "oidc-usermodel-property-mapper", "saml-role-list-mapper", "oidc-usermodel-attribute-mapper", "oidc-sha256-pairwise-sub-mapper", "saml-user-property-mapper", "oidc-full-name-mapper", "saml-user-attribute-mapper" ]
+        "allowed-protocol-mapper-types" : [ "oidc-address-mapper", "oidc-usermodel-attribute-mapper", "oidc-sha256-pairwise-sub-mapper", "oidc-full-name-mapper", "oidc-usermodel-property-mapper", "saml-user-attribute-mapper", "saml-user-property-mapper", "saml-role-list-mapper" ]
       }
     } ],
     "org.keycloak.keys.KeyProvider" : [ {
@@ -1356,7 +1440,7 @@
   "internationalizationEnabled" : false,
   "supportedLocales" : [ ],
   "authenticationFlows" : [ {
-    "id" : "25545030-aecd-4446-b299-71fde3ae6227",
+    "id" : "bad509f4-57e6-40fd-948d-d7ed1e17bfc1",
     "alias" : "Account verification options",
     "description" : "Method with which to verity the existing account",
     "providerId" : "basic-flow",
@@ -1378,7 +1462,7 @@
       "userSetupAllowed" : false
     } ]
   }, {
-    "id" : "8b8cd9bd-d5b9-4a00-b46a-35cd5b2d3e4a",
+    "id" : "9e556d68-2a5b-420d-a818-ceb258016c2f",
     "alias" : "Authentication Options",
     "description" : "Authentication options.",
     "providerId" : "basic-flow",
@@ -1407,7 +1491,7 @@
       "userSetupAllowed" : false
     } ]
   }, {
-    "id" : "7025e5a2-4821-42a2-9032-daf682931dc1",
+    "id" : "065001ce-ac78-484e-ae92-522711e6c8a0",
     "alias" : "Browser - Conditional OTP",
     "description" : "Flow to determine if the OTP is required for the authentication",
     "providerId" : "basic-flow",
@@ -1429,7 +1513,7 @@
       "userSetupAllowed" : false
     } ]
   }, {
-    "id" : "3124458a-f880-4276-a2ef-9391c64ec984",
+    "id" : "8122ec98-24a2-4356-85f9-03bbb6bfe7db",
     "alias" : "Direct Grant - Conditional OTP",
     "description" : "Flow to determine if the OTP is required for the authentication",
     "providerId" : "basic-flow",
@@ -1451,7 +1535,7 @@
       "userSetupAllowed" : false
     } ]
   }, {
-    "id" : "ad63aaf1-cad0-492a-b797-d84913a5db0e",
+    "id" : "2db78c78-5fac-4a88-b92c-aaac8340a5b4",
     "alias" : "First broker login - Conditional OTP",
     "description" : "Flow to determine if the OTP is required for the authentication",
     "providerId" : "basic-flow",
@@ -1473,7 +1557,7 @@
       "userSetupAllowed" : false
     } ]
   }, {
-    "id" : "160be23d-94e0-4749-8779-32d61556b9b3",
+    "id" : "6ec5e984-3513-4082-a3d2-d4ea347fde43",
     "alias" : "Handle Existing Account",
     "description" : "Handle what to do if there is existing account with same email/username like authenticated identity provider",
     "providerId" : "basic-flow",
@@ -1495,7 +1579,7 @@
       "userSetupAllowed" : false
     } ]
   }, {
-    "id" : "9ae34f78-8bbe-484b-8924-2ffe2073a7db",
+    "id" : "7f6d8627-c384-4be2-a2d9-c2c90ac4519c",
     "alias" : "Reset - Conditional OTP",
     "description" : "Flow to determine if the OTP should be reset or not. Set to REQUIRED to force.",
     "providerId" : "basic-flow",
@@ -1517,7 +1601,7 @@
       "userSetupAllowed" : false
     } ]
   }, {
-    "id" : "d3ba4f29-7efe-4ba3-bf16-9fc7ce0c2007",
+    "id" : "bd15a5c3-3e39-4f87-b7d3-2202e6d2e26a",
     "alias" : "User creation or linking",
     "description" : "Flow for the existing/non-existing user alternatives",
     "providerId" : "basic-flow",
@@ -1540,7 +1624,7 @@
       "userSetupAllowed" : false
     } ]
   }, {
-    "id" : "162615d7-4067-469b-ab8e-90d42c44e438",
+    "id" : "eb585f40-ab60-4104-8061-97bed5dc24d6",
     "alias" : "Verify Existing Account by Re-authentication",
     "description" : "Reauthentication of existing account",
     "providerId" : "basic-flow",
@@ -1562,7 +1646,7 @@
       "userSetupAllowed" : false
     } ]
   }, {
-    "id" : "3278862a-4d0d-4924-b630-cdb22afe1f42",
+    "id" : "004e3f2b-11e6-4084-b3e3-e28a2a8a1603",
     "alias" : "browser",
     "description" : "browser based authentication",
     "providerId" : "basic-flow",
@@ -1598,7 +1682,7 @@
       "userSetupAllowed" : false
     } ]
   }, {
-    "id" : "c5d7b0a8-ef3b-4d34-af98-f822a115f58f",
+    "id" : "210754f9-744c-4b19-b229-2ef24a3401be",
     "alias" : "clients",
     "description" : "Base authentication for clients",
     "providerId" : "client-flow",
@@ -1634,7 +1718,7 @@
       "userSetupAllowed" : false
     } ]
   }, {
-    "id" : "39dd26f1-189c-4695-b1ce-92703d6b766a",
+    "id" : "3d1481f8-3f01-4871-95b8-56570a43f80b",
     "alias" : "direct grant",
     "description" : "OpenID Connect Resource Owner Grant",
     "providerId" : "basic-flow",
@@ -1663,7 +1747,7 @@
       "userSetupAllowed" : false
     } ]
   }, {
-    "id" : "405a909b-562a-448e-9d1e-6bbb440187c8",
+    "id" : "442c5a83-e977-457d-a9ef-5528164a9235",
     "alias" : "docker auth",
     "description" : "Used by Docker clients to authenticate against the IDP",
     "providerId" : "basic-flow",
@@ -1678,7 +1762,7 @@
       "userSetupAllowed" : false
     } ]
   }, {
-    "id" : "74ac786c-af41-4d69-b3b9-5328a0518434",
+    "id" : "03aa0df0-8b46-4d5a-a532-33cde94d3823",
     "alias" : "first broker login",
     "description" : "Actions taken after first broker login with identity provider account, which is not yet linked to any Keycloak account",
     "providerId" : "basic-flow",
@@ -1701,7 +1785,7 @@
       "userSetupAllowed" : false
     } ]
   }, {
-    "id" : "f4701633-ea06-4103-8cd6-394dd0dd88b4",
+    "id" : "b7c6703c-0f80-4437-9a60-3740f8bfe720",
     "alias" : "forms",
     "description" : "Username, password, otp and other auth forms.",
     "providerId" : "basic-flow",
@@ -1723,7 +1807,7 @@
       "userSetupAllowed" : false
     } ]
   }, {
-    "id" : "7ffb5e95-9758-46d7-8b56-5157463867e0",
+    "id" : "cb3e1b9a-92f9-4369-a9af-f82277f2ca41",
     "alias" : "http challenge",
     "description" : "An authentication flow based on challenge-response HTTP Authentication Schemes",
     "providerId" : "basic-flow",
@@ -1745,7 +1829,7 @@
       "userSetupAllowed" : false
     } ]
   }, {
-    "id" : "a6e37627-1042-4133-8b71-672c51809a53",
+    "id" : "98253b07-2319-4a93-983d-cbcf8cb60e0a",
     "alias" : "registration",
     "description" : "registration flow",
     "providerId" : "basic-flow",
@@ -1761,7 +1845,7 @@
       "userSetupAllowed" : false
     } ]
   }, {
-    "id" : "cf69cef5-be0d-40ea-a864-3259c90486c2",
+    "id" : "5680fed0-2bdd-4959-a25e-26266167753e",
     "alias" : "registration form",
     "description" : "registration form",
     "providerId" : "form-flow",
@@ -1797,7 +1881,7 @@
       "userSetupAllowed" : false
     } ]
   }, {
-    "id" : "9fd470ab-2508-4969-a517-cc87c8e05e5e",
+    "id" : "dac33b5b-24e6-4fba-8a4b-e4768fe238f3",
     "alias" : "reset credentials",
     "description" : "Reset credentials for a user if they forgot their password or something",
     "providerId" : "basic-flow",
@@ -1833,7 +1917,7 @@
       "userSetupAllowed" : false
     } ]
   }, {
-    "id" : "37580000-e45e-42dc-8b32-79d0fb85e0fb",
+    "id" : "a7832d9a-a2e0-48f3-a41a-160ea4d91b95",
     "alias" : "saml ecp",
     "description" : "SAML ECP Profile Authentication Flow",
     "providerId" : "basic-flow",
@@ -1849,13 +1933,13 @@
     } ]
   } ],
   "authenticatorConfig" : [ {
-    "id" : "f0ccc271-7f3c-4f47-9082-d35f6119efa4",
+    "id" : "8bb822c5-d8fe-49f0-a283-6b23e4add11f",
     "alias" : "create unique user config",
     "config" : {
       "require.password.update.after.registration" : "false"
     }
   }, {
-    "id" : "e798af2b-71f8-4c2f-8103-484423ad22b1",
+    "id" : "4f8a9a54-b62d-4d01-b315-7c24b78e7abf",
     "alias" : "review profile config",
     "config" : {
       "update.profile.on.first.login" : "missing"

--- a/hack/keycloak-grant.sh
+++ b/hack/keycloak-grant.sh
@@ -1,17 +1,19 @@
 #!/bin/sh
 
-HOST="localhost:8888"
+HOST="localhost:8080/auth"
 REALM="controller"
 USERNAME="$1"
 PASSWORD="$2"
 CLIENTID='api-clients'
 CLIENTSECRET='cvXhCRXI2Vld244jjDcnABCMrTEq2rwE'
 
-curl -s -X POST \
+token=$(curl -sf -X POST \
     http://$HOST/realms/$REALM/protocol/openid-connect/token \
     -H 'Content-Type: application/x-www-form-urlencoded' \
     -d "username=$USERNAME" \
     -d "password=$PASSWORD" \
     -d "grant_type=password" \
     -d "client_id=$CLIENTID" \
-    -d "client_secret=$CLIENTSECRET" | jq -r ".access_token"
+    -d "client_secret=$CLIENTSECRET" | jq -r ".access_token")
+
+echo $token

--- a/hack/nginx.conf
+++ b/hack/nginx.conf
@@ -1,0 +1,23 @@
+server {
+  listen 8080;
+
+  location / {
+    proxy_pass http://ui:3000;
+  }
+
+  location /api {
+      return 302 /api/;
+  }
+
+  location /api/ {
+      proxy_pass http://controller:8080/; 
+  }
+
+  location /auth {
+      return 302 /auth/;
+  }
+
+  location /auth/ {
+      proxy_pass http://keycloak:8080/;
+  }
+}

--- a/internal/apex/auth.go
+++ b/internal/apex/auth.go
@@ -1,0 +1,203 @@
+package apex
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// TODO: These consts witll differ from installation to installation.
+// Need to find a way to provide these dynamically (config file) etc...
+const (
+	APEX_CLIENT_ID     = "apex-cli"
+	APEX_CLIENT_SECRET = "QkskUDQenfXRxWx9UA0TeuwmOnHilHtQ"
+	LOGIN_URL          = "http://%s/auth/realms/controller/protocol/openid-connect/auth/device"
+	VERIFICATION_URI   = "http://%s/auth/realms/controller/device"
+	VERIFY_URL         = "http://%s/auth/realms/controller/protocol/openid-connect/token"
+	GRANT_TYPE         = "urn:ietf:params:oauth:grant-type:device_code"
+	REGISTER_DEVICE    = "http://%s/api/devices"
+	USER_URL           = "http://%s/api/users/me"
+)
+
+type TokenResponse struct {
+	DeviceCode              string `json:"device_code"`
+	UserCode                string `json:"user_code"`
+	VerificationURI         string `json:"verification_uri"`
+	VerificationURIComplete string `json:"verification_uri_complete"`
+	ExpiresIn               int    `json:"expires_in"`
+	Interval                int    `json:"interval"`
+}
+
+type Authenticator struct {
+	hostname     string
+	accessToken  string
+	refreshToken string
+}
+
+func NewAuthenticator(hostname string) Authenticator {
+	return Authenticator{
+		hostname:     hostname,
+		accessToken:  "",
+		refreshToken: "",
+	}
+}
+
+func (a *Authenticator) Token() (string, error) {
+	// TODO: We should handle using the refreshToken if the
+	// current access token has expired.
+	if a.accessToken != "" {
+		return a.accessToken, nil
+	}
+	return "", fmt.Errorf("not authenticated")
+}
+
+func (a *Authenticator) Authenticate(ctx context.Context) error {
+	token, err := getToken(a.hostname)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("Your device must be registered with Apex Controller.")
+	fmt.Printf("Your one-time code is: %s\n", token.UserCode)
+	fmt.Println("Please open the following URL in your browser and enter your one-time code:")
+	fmt.Printf("%s\n", fmt.Sprintf(VERIFICATION_URI, a.hostname))
+
+	c := make(chan error, 1)
+	ctx, cancel := context.WithTimeout(ctx, time.Duration(token.ExpiresIn)*time.Second)
+	defer cancel()
+	go func() {
+		c <- a.pollForResponse(ctx, token)
+	}()
+
+	err = <-c
+	if err != nil {
+		return err
+	}
+	fmt.Println("Authentication succeeded.")
+	return nil
+}
+
+func getToken(hostname string) (*TokenResponse, error) {
+	v := url.Values{}
+	v.Set("client_id", APEX_CLIENT_ID)
+	v.Set("client_secret", APEX_CLIENT_SECRET)
+	res, err := http.PostForm(fmt.Sprintf(LOGIN_URL, hostname), v)
+	if err != nil {
+		return nil, err
+	}
+
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var t TokenResponse
+	if err := json.Unmarshal(body, &t); err != nil {
+		return nil, err
+	}
+
+	return &t, nil
+}
+
+func (a *Authenticator) pollForResponse(ctx context.Context, t *TokenResponse) error {
+	v := url.Values{}
+	v.Set("device_code", t.DeviceCode)
+	v.Set("client_id", APEX_CLIENT_ID)
+	v.Set("client_secret", APEX_CLIENT_SECRET)
+	v.Set("grant_type", GRANT_TYPE)
+
+	type response struct {
+		AccessToken  string `json:"access_token"`
+		RefreshToken string `json:"refresh_token"`
+	}
+
+	ticker := time.NewTicker(time.Duration(t.Interval) * time.Second)
+
+	var r response
+LOOP:
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			res, err := http.PostForm(fmt.Sprintf(VERIFY_URL, a.hostname), v)
+			if err != nil {
+				continue
+			}
+			body, err := io.ReadAll(res.Body)
+			if err != nil {
+				continue
+			}
+
+			if err := json.Unmarshal(body, &r); err != nil {
+				continue
+			}
+
+			if r.AccessToken != "" {
+				break LOOP
+			}
+		}
+	}
+	a.accessToken = r.AccessToken
+	a.refreshToken = r.RefreshToken
+	return nil
+}
+
+func RegisterDevice(hostname string, publicKey string, accessToken string) error {
+	body, err := json.Marshal(map[string]string{
+		"public-key": publicKey,
+	})
+	if err != nil {
+		return err
+	}
+
+	r, err := http.NewRequest("POST", fmt.Sprintf(REGISTER_DEVICE, hostname), bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	r.Header.Set("authorization", fmt.Sprintf("bearer %s", accessToken))
+
+	if _, err := http.DefaultClient.Do(r); err != nil {
+		return err
+	}
+	return nil
+}
+
+func GetZone(hostname string, accessToken string) (string, error) {
+	r, err := http.NewRequest("GET", fmt.Sprintf(USER_URL, hostname), nil)
+	if err != nil {
+		return "", err
+	}
+	r.Header.Set("authorization", fmt.Sprintf("bearer %s", accessToken))
+
+	res, err := http.DefaultClient.Do(r)
+	if err != nil {
+		return "", err
+	}
+
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return "", err
+	}
+
+	log.Debugf("%+v", string(body))
+	type UserJSON struct {
+		ID      string   `json:"id"`
+		Devices []string `json:"devices"`
+		ZoneID  string   `json:"zone-id"`
+	}
+
+	var u UserJSON
+	if err := json.Unmarshal(body, &u); err != nil {
+		return "", err
+	}
+
+	return u.ZoneID, nil
+}

--- a/internal/apexcontroller/controller.go
+++ b/internal/apexcontroller/controller.go
@@ -77,6 +77,9 @@ func NewController(ctx context.Context, streamerIp string, streamerPort int, str
 	}
 
 	// Migrate the schema
+	if err := db.AutoMigrate(&User{}); err != nil {
+		return nil, err
+	}
 	if err := db.AutoMigrate(&Zone{}); err != nil {
 		return nil, err
 	}
@@ -130,21 +133,23 @@ func NewController(ctx context.Context, streamerIp string, streamerPort int, str
 	ct.Router.Use(cors.New(corsConfig))
 	ct.Router.Use()
 
-	public := ct.Router.Group("/health")
-	public.GET("/", func(c *gin.Context) {
+	ct.Router.GET("/health", func(c *gin.Context) {
 		c.JSON(http.StatusOK, gin.H{"message": "ok"})
 	})
 
 	private := ct.Router.Group("/")
 	private.Use(auth.AuthFunc())
-	private.GET("/peers", ct.handleListPeers)    // http://localhost:8080/peers
-	private.GET("/peers/:id", ct.handleGetPeers) // http://localhost:8080/peers/:id
-	private.GET("/zones", ct.handleListZones)    // http://localhost:8080/zones
-	private.GET("/zones/:id", ct.handleGetZones) // http://localhost:8080/zones/:id
+	private.Use(ct.UserMiddleware)
+	private.GET("/peers", ct.handleListPeers)    // http://localhost/api/peers
+	private.GET("/peers/:id", ct.handleGetPeers) // http://localhost/api/peers/:id
+	private.GET("/zones", ct.handleListZones)    // http://localhost/api/zones
+	private.GET("/zones/:id", ct.handleGetZones) // http://localhost/api/zones/:id
 	private.POST("/zones", ct.handlePostZones)
-	private.GET("/devices", ct.handleListDevices)    // http://localhost:8080/devices
-	private.GET("/devices/:id", ct.handleGetDevices) // http://localhost:8080/devices/:id
+	private.GET("/devices", ct.handleListDevices)    // http://localhost/api/devices
+	private.GET("/devices/:id", ct.handleGetDevices) // http://localhost/api/devices/:id
 	private.POST("/devices", ct.handlePostDevices)
+	private.GET("/users/:id", ct.handleGetUser)
+	private.PATCH("/users/:id", ct.handlePatchUser)
 
 	createDefaultZone := func() error {
 		if err := ct.CreateDefaultZone(); err != nil {
@@ -196,23 +201,14 @@ func (ct *Controller) Run() {
 				log.Debugf("Register node msg received on channel [ %s ]\n", messages.ZoneChannelDefault)
 				log.Debugf("Received registration request: %+v\n", msgEvent.Peer)
 				if msgEvent.Peer.PublicKey != "" {
-					zone, err := ct.zoneExists(ctx, msgEvent.Peer.ZoneID)
-					if err != nil {
-						log.Error(err)
-						if err = publishErrorMessage(pubDefault,
-							msgEvent.Peer.ZoneID, messages.Error, messages.ChannelNotRegistered, err.Error()); err != nil {
-							log.Errorf("unable to publish error message %s", err)
+					peers, err := ct.AddPeer(ctx, msgEvent)
+					if err == nil {
+						// publishPeers the latest peer list
+						if err := publishPeers(pubDefault, messages.ZoneChannelDefault, peers); err != nil {
+							log.Errorf("unable to publish peer list: %s", err)
 						}
 					} else {
-						peers, err := ct.AddPeer(ctx, msgEvent, zone)
-						if err == nil {
-							// publishPeers the latest peer list
-							if err := publishPeers(pubDefault, messages.ZoneChannelDefault, peers); err != nil {
-								log.Errorf("unable to publish peer list: %s", err)
-							}
-						} else {
-							log.Errorf("peer was not added: %v", err)
-						}
+						log.Errorf("peer was not added: %v", err)
 					}
 				}
 			}
@@ -278,18 +274,27 @@ type MsgTypes struct {
 	Peer  Peer
 }
 
-func (ct *Controller) zoneExists(ctx context.Context, zoneId string) (*Zone, error) {
-	var zone Zone
-	res := ct.db.Preload("Peers").First(&zone, "id = ?", zoneId)
-	// todo, the needs to go over an err channel to the agent
-	if res.Error != nil && errors.Is(res.Error, gorm.ErrRecordNotFound) {
-		return &zone, fmt.Errorf("requested zone [ %s ] was not found.", zoneId)
-	}
-	return &zone, nil
-
-}
-func (ct *Controller) AddPeer(ctx context.Context, msgEvent messages.Message, zone *Zone) ([]messages.Peer, error) {
+func (ct *Controller) AddPeer(ctx context.Context, msgEvent messages.Message) ([]messages.Peer, error) {
 	tx := ct.db.Begin()
+
+	// TODO: This could be written as a single query
+	var device Device
+	if res := tx.Where("public_key = ?", msgEvent.Peer.PublicKey).First(&device); res.Error != nil {
+		tx.Rollback()
+		return nil, fmt.Errorf("device with key %s not found: %v", msgEvent.Peer.PublicKey, res.Error)
+	}
+
+	var user User
+	if res := tx.First(&user, "id = ?", device.UserID); res.Error != nil {
+		tx.Rollback()
+		return nil, fmt.Errorf("user with id %s not found: %v", device.UserID, res.Error)
+	}
+
+	var zone Zone
+	if res := tx.Preload("Peers").First(&zone, "id = ?", user.ZoneID); res.Error != nil {
+		tx.Rollback()
+		return nil, fmt.Errorf("zone with id %s not found: %v", user.ZoneID, res.Error)
+	}
 
 	ipamPrefix := zone.IpCidr
 	var hubZone bool
@@ -301,34 +306,22 @@ func (ct *Controller) AddPeer(ctx context.Context, msgEvent messages.Message, zo
 		var hubRouterAlreadyExists string
 		for _, p := range zone.Peers {
 			// If the node joining is a re-join from the zone-router allow it
-			if p.HubRouter && p.DeviceID != msgEvent.Peer.PublicKey {
+			if p.HubRouter && p.DeviceID != device.ID {
 				hubRouterAlreadyExists = p.EndpointIP
+				tx.Rollback()
 				return nil, fmt.Errorf("hub router already exists on the endpoint %s", hubRouterAlreadyExists)
 			}
 		}
 	}
+
 	if zone.HubZone {
 		hubZone = true
 	}
 
-	var key Device
-	res := ct.db.First(&key, "public_key = ?", msgEvent.Peer.PublicKey)
-	if res.Error != nil {
-		if errors.Is(res.Error, gorm.ErrRecordNotFound) {
-			log.Debug("Public key not found. Adding a new one")
-			key = Device{
-				ID:        uuid.New().String(),
-				PublicKey: msgEvent.Peer.PublicKey,
-			}
-			tx.Create(&key)
-		} else {
-			return nil, res.Error
-		}
-	}
 	var found bool
 	var peer *Peer
 	for _, p := range zone.Peers {
-		if p.DeviceID == msgEvent.Peer.PublicKey {
+		if p.DeviceID == device.ID {
 			found = true
 			peer = p
 			break
@@ -343,10 +336,12 @@ func (ct *Controller) AddPeer(ctx context.Context, msgEvent messages.Message, zo
 				var err error
 				ip, err = ct.assignSpecificNodeAddress(ctx, ipamPrefix, msgEvent.Peer.NodeAddress)
 				if err != nil {
+					tx.Rollback()
 					return nil, err
 				}
 			} else {
 				if peer.NodeAddress == "" {
+					tx.Rollback()
 					return nil, fmt.Errorf("peer does not have a node address assigned in the peer table and did not request a specifc address")
 				}
 				ip = peer.NodeAddress
@@ -357,6 +352,7 @@ func (ct *Controller) AddPeer(ctx context.Context, msgEvent messages.Message, zo
 
 		if msgEvent.Peer.ChildPrefix != peer.ChildPrefix {
 			if err := ct.assignChildPrefix(ctx, msgEvent.Peer.ChildPrefix); err != nil {
+				tx.Rollback()
 				return nil, err
 			}
 		}
@@ -369,24 +365,27 @@ func (ct *Controller) AddPeer(ctx context.Context, msgEvent messages.Message, zo
 			var err error
 			ip, err = ct.assignSpecificNodeAddress(ctx, ipamPrefix, msgEvent.Peer.NodeAddress)
 			if err != nil {
+				tx.Rollback()
 				return nil, err
 			}
 		} else {
 			var err error
 			ip, err = ct.assignFromPool(ctx, ipamPrefix)
 			if err != nil {
+				tx.Rollback()
 				return nil, err
 			}
 		}
 		// allocate a child prefix if requested
 		if msgEvent.Peer.ChildPrefix != "" {
 			if err := ct.assignChildPrefix(ctx, msgEvent.Peer.ChildPrefix); err != nil {
+				tx.Rollback()
 				return nil, err
 			}
 		}
 		peer = &Peer{
 			ID:          uuid.New().String(),
-			DeviceID:    key.ID,
+			DeviceID:    device.ID,
 			ZoneID:      zone.ID,
 			EndpointIP:  msgEvent.Peer.EndpointIP,
 			AllowedIPs:  ip,
@@ -403,8 +402,8 @@ func (ct *Controller) AddPeer(ctx context.Context, msgEvent messages.Message, zo
 	for _, p := range zone.Peers {
 		var d Device
 		if res := tx.First(&d, "id = ?", p.DeviceID); res.Error != nil {
-			log.Warnf("Device %s was not found in database", p.DeviceID)
-			continue
+			tx.Rollback()
+			return nil, fmt.Errorf("Device %s was not found in database", p.DeviceID)
 		}
 		peerList = append(peerList, messages.Peer{
 			PublicKey:   d.PublicKey,
@@ -448,26 +447,15 @@ func (ct *Controller) MessageHandling(ctx context.Context) {
 				log.Debugf("Register node msg received on channel [ %s ]\n", messages.ZoneChannelController)
 				log.Debugf("Received registration request: %+v\n", msgEvent.Peer)
 				if msgEvent.Peer.PublicKey != "" {
-					zone, err := ct.zoneExists(ctx, msgEvent.Peer.ZoneID)
-					if err != nil {
-						log.Error(err)
-						if err = publishErrorMessage(
-							pub, msgEvent.Peer.ZoneID, messages.Error, messages.ChannelNotRegistered, err.Error()); err != nil {
-							log.Errorf("failed to publish error message %s", err)
+					peers, err := ct.AddPeer(ctx, msgEvent)
+					if err == nil {
+						// publishPeers the latest peer list
+						if err := publishPeers(pub, msgEvent.Peer.ZoneID, peers); err != nil {
+							log.Errorf("failed to publish peer updates: %s", err)
 						}
 					} else {
-						peers, err := ct.AddPeer(ctx, msgEvent, zone)
-						if err == nil {
-							// publishPeers the latest peer list
-							if err := publishPeers(pub, msgEvent.Peer.ZoneID, peers); err != nil {
-								log.Errorf("failed to publish peer updates: %s", err)
-							}
-						} else {
-
-							log.Errorf("peer was not added: %v", err)
-						}
+						log.Errorf("peer was not added: %v", err)
 					}
-
 				}
 			}
 		}

--- a/internal/apexcontroller/handlers.go
+++ b/internal/apexcontroller/handlers.go
@@ -132,8 +132,9 @@ func (ct *Controller) handleGetPeers(c *gin.Context) {
 }
 
 type DeviceJSON struct {
-	ID    string   `json:"id"`
-	Peers []string `json:"peer-ids"`
+	ID        string `json:"id"`
+	PublicKey string `json:"public-key"`
+	UserID    string `json:"user-id"`
 }
 
 func (ct *Controller) handleListDevices(c *gin.Context) {
@@ -144,11 +145,10 @@ func (ct *Controller) handleListDevices(c *gin.Context) {
 	}
 	results := make([]DeviceJSON, 0)
 	for _, d := range devices {
-		var peers []string
-		ct.db.Model(&Peer{}).Where("device_id = ?", d.ID).Pluck("id", &peers)
 		results = append(results, DeviceJSON{
-			ID:    d.ID,
-			Peers: peers,
+			ID:        d.ID,
+			PublicKey: d.PublicKey,
+			UserID:    d.UserID,
 		})
 	}
 	// For pagination
@@ -169,24 +169,23 @@ func (ct *Controller) handleGetDevices(c *gin.Context) {
 		c.Status(http.StatusNotFound)
 		return
 	}
-	var peers []string
-	ct.db.Model(&Peer{}).Where("device_id = ?", device.ID).Pluck("id", &peers)
 	results := DeviceJSON{
-		ID:    device.ID,
-		Peers: peers,
+		ID:        device.ID,
+		PublicKey: device.PublicKey,
+		UserID:    device.UserID,
 	}
 	c.JSON(http.StatusOK, results)
 }
 
 type DeviceRequest struct {
-	PublicKey string `json:"name"`
+	PublicKey string `json:"public-key"`
 }
 
 func (ct *Controller) handlePostDevices(c *gin.Context) {
 	var request DeviceRequest
 	// Call BindJSON to bind the received JSON
 	if err := c.BindJSON(&request); err != nil {
-		c.Status(http.StatusBadRequest)
+		c.IndentedJSON(http.StatusBadRequest, gin.H{"error": err})
 		return
 	}
 	if request.PublicKey == "" {
@@ -194,14 +193,147 @@ func (ct *Controller) handlePostDevices(c *gin.Context) {
 		return
 	}
 
+	userRaw, ok := c.Get(UserRecord)
+	if !ok {
+		c.IndentedJSON(http.StatusInternalServerError, gin.H{"error": "no user record in context"})
+		return
+	}
+
+	user, ok := userRaw.(User)
+	if !ok {
+		c.IndentedJSON(http.StatusInternalServerError, gin.H{"error": "user in context is not correct type"})
+		return
+	}
+
+	var d Device
+	res := ct.db.Where("public_key == ?", request.PublicKey).First(d)
+	if res.Error == nil {
+		// implicit ok for already exists condition
+		c.Status(http.StatusOK)
+		return
+	}
+	if res.Error != nil && !errors.Is(res.Error, gorm.ErrRecordNotFound) {
+		c.IndentedJSON(http.StatusInternalServerError, gin.H{"error": "database error"})
+	}
+
 	device := &Device{
 		ID:        uuid.New().String(),
 		PublicKey: request.PublicKey,
+		UserID:    user.ID,
 	}
-	err := ct.db.Create(device)
-	if err != nil {
-		c.IndentedJSON(http.StatusInternalServerError, gin.H{"error": err})
+
+	if res := ct.db.Create(device); res.Error != nil {
+		c.IndentedJSON(http.StatusInternalServerError, gin.H{"error": res.Error})
 		return
 	}
-	c.IndentedJSON(http.StatusCreated, device)
+
+	user.Devices = append(user.Devices, device)
+	ct.db.Save(&user)
+
+	result := DeviceJSON{
+		ID:        device.ID,
+		UserID:    device.UserID,
+		PublicKey: device.PublicKey,
+	}
+
+	c.IndentedJSON(http.StatusCreated, result)
+}
+
+type UserRequest struct {
+	ZoneID string `json:"zone-id"`
+}
+
+func (ct *Controller) handlePatchUser(c *gin.Context) {
+	userId := c.Param("id")
+	if userId == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "user id is not valid"})
+		return
+	}
+	var request UserRequest
+	// Call BindJSON to bind the received JSON
+	if err := c.BindJSON(&request); err != nil {
+		c.IndentedJSON(http.StatusBadRequest, gin.H{"error": err})
+		return
+	}
+
+	if request.ZoneID == "" {
+		c.IndentedJSON(http.StatusBadRequest, gin.H{"message": "the request did not contain valid data"})
+		return
+	}
+
+	var user User
+	if userId == "me" {
+		userRaw, ok := c.Get(UserRecord)
+		if !ok {
+			c.IndentedJSON(http.StatusInternalServerError, gin.H{"error": "no user record in context"})
+			return
+		}
+
+		user, ok = userRaw.(User)
+		if !ok {
+			c.IndentedJSON(http.StatusInternalServerError, gin.H{"error": "user in context is not correct type"})
+		}
+	} else {
+		if res := ct.db.First(&user, "id = ?", userId); res.Error != nil {
+			c.IndentedJSON(http.StatusInternalServerError, gin.H{"error": res.Error})
+			return
+		}
+	}
+
+	var zone Zone
+	if res := ct.db.First(&zone, "id = ?", request.ZoneID); res.Error != nil {
+		c.IndentedJSON(http.StatusBadRequest, gin.H{"error": "zone id is not valid"})
+		return
+	}
+
+	user.ZoneID = request.ZoneID
+
+	ct.db.Save(&user)
+
+	c.Status(http.StatusOK)
+}
+
+type UserJSON struct {
+	ID      string   `json:"id"`
+	Devices []string `json:"devices"`
+	ZoneID  string   `json:"zone-id"`
+}
+
+func (ct *Controller) handleGetUser(c *gin.Context) {
+	userId := c.Param("id")
+	if userId == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "user id is not valid"})
+		return
+	}
+
+	var user User
+	if userId == "me" {
+		userRaw, ok := c.Get(UserRecord)
+		if !ok {
+			c.IndentedJSON(http.StatusInternalServerError, gin.H{"error": "no user record in context"})
+			return
+		}
+
+		user, ok = userRaw.(User)
+		if !ok {
+			c.IndentedJSON(http.StatusInternalServerError, gin.H{"error": "user in context is not correct type"})
+		}
+	} else {
+		if res := ct.db.Preload("Devices").First(&user, "id = ?", userId); res.Error != nil {
+			c.IndentedJSON(http.StatusInternalServerError, gin.H{"error": res.Error})
+			return
+		}
+	}
+
+	var devices []string
+	for _, d := range user.Devices {
+		devices = append(devices, d.ID)
+	}
+	result := UserJSON{
+		ID:      user.ID,
+		Devices: devices,
+		ZoneID:  user.ZoneID,
+	}
+
+	c.JSON(http.StatusOK, result)
 }

--- a/internal/apexcontroller/models.go
+++ b/internal/apexcontroller/models.go
@@ -7,11 +7,18 @@ import (
 	apiv1 "github.com/metal-stack/go-ipam/api/v1"
 )
 
-// Device is a unique end-user device.
+// User is the owner of a device, and a member of one Zone
+type User struct {
+	ID      string `gorm:"primaryKey"`
+	Devices []*Device
+	ZoneID  string
+}
+
+// Device is a unique, end-user device.
 type Device struct {
-	ID        string
+	ID        string `gorm:"primaryKey"`
+	UserID    string
 	PublicKey string `gorm:"uniqueIndex"`
-	Peers     []Peer
 }
 
 // Peer is an association between a Device and a Zone.
@@ -30,7 +37,7 @@ type Peer struct {
 
 // Zone is a collection of devices that are connected together.
 type Zone struct {
-	ID          string
+	ID          string `gorm:"primaryKey"`
 	Peers       []*Peer
 	Name        string
 	Description string

--- a/internal/apexcontroller/streamer-util.go
+++ b/internal/apexcontroller/streamer-util.go
@@ -45,18 +45,3 @@ func createAllPeerMessage(postData []messages.Peer) (string, string) {
 	msg, _ := json.Marshal(postData)
 	return id, string(msg)
 }
-
-func publishErrorMessage(stm *streamer.Streamer, channel string, event messages.EventType, code messages.ErrorCode, msg string) error {
-	jsonMsg := createErrorMessage(event, code, msg)
-	log.Printf("Published new error message to channel %s : %s\n", channel, jsonMsg)
-	return stm.PublishMessage(channel, jsonMsg)
-}
-
-func createErrorMessage(event messages.EventType, code messages.ErrorCode, msg string) string {
-	errMsg := messages.ErrorMessage{}
-	errMsg.Event = event
-	errMsg.Code = code
-	errMsg.Msg = msg
-	jMsg, _ := json.Marshal(&errMsg)
-	return string(jMsg)
-}

--- a/tests/Containerfile.alpine
+++ b/tests/Containerfile.alpine
@@ -1,2 +1,2 @@
 FROM alpine:3.16
-RUN apk add --no-cache iputils wireguard-tools
+RUN apk add --no-cache iputils wireguard-tools iptables psmisc

--- a/tests/Containerfile.fedora
+++ b/tests/Containerfile.fedora
@@ -3,7 +3,10 @@ RUN dnf update -qy && \
     dnf install --setopt=install_weak_deps=False -qy \
     iputils \
     iproute \
+    psmisc \
     procps-ng \
     wireguard-tools \
+    iptables \
+    hostname \
     && \
     dnf clean all

--- a/tests/Containerfile.ubuntu
+++ b/tests/Containerfile.ubuntu
@@ -5,5 +5,7 @@ RUN apt-get update -qy && \
     iputils-ping \
     iproute2 \
     wireguard-tools \
+    iptables \
+    psmisc \
     && \
     apt-get clean

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -24,7 +24,7 @@ import { DeviceList, DeviceShow } from "./pages/devices";
 import { MyLayout } from "./components/layout";
 
 const config : KeycloakConfig = {
-  url: 'http://localhost:8888',
+  url: 'http://localhost:8080/auth',
   realm: 'controller',
   clientId: 'front-controller',
 };
@@ -53,7 +53,7 @@ const App = () => {
             authProvider.current = keycloakAuthProvider(keycloakClient, {
                 onPermissions: getPermissions,
             });
-            dataProvider.current = simpleRestProvider('http://localhost:8080', httpClient(keycloakClient), 'X-Total-Count');
+            dataProvider.current = simpleRestProvider('http://localhost:8080/api', httpClient(keycloakClient), 'X-Total-Count');
             setKeycloak(keycloakClient);
         };
         if (!keycloak) {


### PR DESCRIPTION
1. Adds `User` to the controller DB. User ID's are populated when a user calls POST /devices
2. Adds POST /devices API to associate a device to a user
3. Adds a PATCH /users/:id to move a user to a different Zone (required for e2e tests to work)
4. Improves the Makefile! `make e2e` runs the e2e tests. It will also build the `apex` binary (if required) and fetches said binary from `/dist/apex`.
5. Adds Dockerfiles for the test images and pushed them to quay.io (including a small alpine image)
6. Save docker-compose log output to docker-compose.log. This makes it easier to find failures in test output


NOTE: Until the work is done on `apex` to support the OATH Device flow ALL KEYS MUST BE PRE-PROVISIONED and registered using the API.
