### PR TITLE
apex: Fix check for controller arg

### DIFF
--- a/internal/apex/apex.go
+++ b/internal/apex/apex.go
@@ -67,8 +67,7 @@ type wgLocalConfig struct {
 }
 
 func NewApex(ctx context.Context, cCtx *cli.Context) (*Apex, error) {
-	controllerURL := cCtx.Args().First()
-	if controllerURL == "" {
+	if cCtx.String("controller") == "" {
 		log.Fatal("[controller-url] required")
 	}
 
@@ -88,7 +87,7 @@ func NewApex(ctx context.Context, cCtx *cli.Context) (*Apex, error) {
 		publicNetwork:          cCtx.Bool("public-network"),
 		hubRouter:              cCtx.Bool("hub-router"),
 		accessToken:            cCtx.String("with-token"),
-		controllerURL:          controllerURL,
+		controllerURL:          cCtx.String("controller"),
 		os:                     GetOS(),
 	}
 


### PR DESCRIPTION
With the current code, when I run:

    $ sudo dist/apex --controller=<...> --controller-password=<...>

I get the following error:

    FATA[0000] [controller-url] required

The method used to check the controller URL doesn't seem to be appropriate here.

Signed-off-by: Russell Bryant <rbryant@redhat.com>