### PR TITLE
controller: Use ubi as the base image

### DIFF
--- a/Containerfile.controller
+++ b/Containerfile.controller
@@ -10,7 +10,7 @@ RUN CGO_ENABLED=0 go build \
     -ldflags="-extldflags=-static" \
     -o controller ./cmd/apexcontroller
 
-FROM scratch
+FROM registry.access.redhat.com/ubi8/ubi
 
 COPY --from=build /src/controller /controller
 EXPOSE 8080


### PR DESCRIPTION
I needed to debug something from inside the controller container, but wasn't able to since it was built as a scratch image. This switches to use redhat's UBI as a base image which has some helpful basics, including curl.

Signed-off-by: Russell Bryant <rbryant@redhat.com>