### PR TITLE
apex-installer: Fix Fedora check

### DIFF
--- a/hack/apex-installer.sh
+++ b/hack/apex-installer.sh
@@ -97,10 +97,11 @@ EOF
             info_message "Wireguard is not installed. Installing WireGuard..."
             if [ "$linuxDistro" == "Ubuntu" ]; then
                 sudo DEBIAN_FRONTEND=noninteractive apt-get -qq --no-install-recommends install wireguard wireguard-tools -y
-            elif [ "$linuxDistro" == "CentOS Stream" ] || [ "$linuxDistro" == "Fedora" ]; then
+            elif [ "$linuxDistro" == "CentOS Stream" ] || [ "$linuxDistro" == "Fedora Linux" ]; then
                 sudo dnf -q install wireguard-tools -y
             else
                 error_message "Currenly only support Ubuntu, Fedora and Centos Stream."
+                exit 1
             fi
 
             if [ "$?" == "0" ]; then 


### PR DESCRIPTION
At least on Fedora 36, $NAME is "Fedora Linux", not "Fedora".

Also fix the error path to exit. Previously it would emit the error but continue trying to run the rest of the script. We know the install won't be complete without wireguard present, so just abort.

Signed-off-by: Russell Bryant <rbryant@redhat.com>