### PR TITLE
installer: Improve an error message

### DIFF
--- a/hack/apex-installer.sh
+++ b/hack/apex-installer.sh
@@ -100,7 +100,7 @@ EOF
             elif [ "$linuxDistro" == "CentOS Stream" ] || [ "$linuxDistro" == "Fedora Linux" ]; then
                 sudo dnf -q install wireguard-tools -y
             else
-                error_message "Currenly only support Ubuntu, Fedora and Centos Stream."
+                error_message "This script only support installing wireguard-tools on Ubuntu, Fedora and Centos Stream. Please install wireguard-tools and try again."
                 exit 1
             fi
 


### PR DESCRIPTION
I forgot to include this in my previous installer patch. This improves the error message for when wireguard isn't installed on a platform we can't detect. If it's some other Linux distro, they can install wireguard-tools and run it again and the script should work.

Signed-off-by: Russell Bryant <rbryant@redhat.com>