### PR TITLE
Makefile: build the apex agent for arm-linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 all: go-lint apex controller
 
 .PHONY: apex
-apex: dist/apex dist/apex-amd64-linux dist/apex-amd64-darwin dist/apex-arm64-darwin dist/apex-amd64-windows
+apex: dist/apex dist/apex-arm-linux dist/apex-amd64-linux dist/apex-amd64-darwin dist/apex-arm64-darwin dist/apex-amd64-windows
 
 COMMON_DEPS=$(wildcard ./internal/messages/*.go) $(wildcard ./internal/streamer/*.go) go.sum go.mod
 
@@ -15,6 +15,9 @@ dist:
 
 dist/apex: $(APEX_DEPS) | dist
 	CGO_ENABLED=0 go build -o $@ ./cmd/apex
+
+dist/apex-arm-linux: $(APEX_DEPS) | dist
+	CGO_ENABLED=0 GOOS=linux GOARCH=arm go build -o $@ ./cmd/apex
 
 dist/apex-amd64-linux: $(APEX_DEPS) | dist
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o $@ ./cmd/apex


### PR DESCRIPTION
Add arm-linux as a build target for apex. I didn't add the same for the controller, as it seemed more likely to only want to run the agent on an arm device right now.

Signed-off-by: Russell Bryant <rbryant@redhat.com>