### PR TITLE
docs: Add concepts, agent usage sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![build](https://github.com/redhat-et/apex/actions/workflows/build.yml/badge.svg)](https://github.com/redhat-et/apex/actions/workflows/build.yml)
 
-*Roads? Where we're going, we don't need roads - Dr. Emmett Brown*
+> *Roads? Where we're going, we don't need roads - Dr. Emmett Brown*
 
 This project demonstrates an approach for building an IP connectivity-as-a-service solution that provides isolated zone-based connectivity using Wireguard for tunneling.
 
@@ -11,6 +11,7 @@ This project demonstrates an approach for building an IP connectivity-as-a-servi
 This project aims to provide connectivity between nodes deployed across heterogeneous environments (Edge, Public, Private, and Hybrid Cloud) with different visibilities (nodes in a Cloud VPC, nodes behind NAT, etc.). This solution is not specific to any infrastructure or application platform but focuses on providing IP connectivity between nodes and the container or VM workloads running on those nodes. This service is complementary to platforms-specific networking, as it can be used to expand connectivity to places that the platform could not reach otherwise.
 
 Some of the features and use cases that this project aims to support are:
+
 - **IoT networking** - connectivity to any node, anywhere
 - **Hybrid data center connectivity** - circumvents NAT challenges
 - **IP mobility** - /32 host routing allows addresses to be advertised anywhere with convergence times only limited by a round-trip time to a controller.


### PR DESCRIPTION
Add a section at the top of the docs that introduces Apex concepts. These are terms that will be used repeatedly throughout the rest of the documentation, so they must be defined upfront. (Controller, Agent, Zone).

A new section has been added on Agent usage, as well. It covers installation, basic invocation, and the steps taken to enroll the first couple of nodes and verify their connectivity.

I've also introduced a table of contents to this file. It is automatically generated and updated by the "Markdown All in One" extension to vscode that I'm using at the moment.

In passing, I put the quote in the main README as a blockquote, which I think looks a little nicer.

Signed-off-by: Russell Bryant <rbryant@redhat.com>