### PR TITLE
[dont merge] Migrate to the agent managing routes

### DIFF
--- a/tests/e2e-scripts/init-containers.sh
+++ b/tests/e2e-scripts/init-containers.sh
@@ -1060,7 +1060,7 @@ if [ -z "$DOCKER" ]; then
     DOCKER=docker
 fi
 if [ -z "$DOCKER_COMPOSE" ]; then
-    DOCKER_COMPOSE=docker-compose
+    DOCKER_COMPOSE="docker compose"
 fi
 
 echo -e "Job running with OS Image: ${os}"


### PR DESCRIPTION
- This removes almost all of wg-quick except for wg-quick strip for parsing new peers.
- By adding `wg setconf` it allows for adding peers without having to down the wg iface.
- Adds OSX interface and route creation and deletion.
- Most of the Linux ip commands need replacing with netlink calls.

Signed-off-by: Brent Salisbury <bsalisbu@redhat.com>