### PR TITLE
[do not merge] STUN processing for overlapping endpoint cidr

### DIFF
--- a/internal/apex/configure-hub.go
+++ b/internal/apex/configure-hub.go
@@ -123,7 +123,9 @@ func (ax *Apex) parseHubWireguardConfig(listenPort int) {
 		if err != nil {
 			log.Errorf("failed to split host:port endpoint pair: %v", err)
 		}
-		if isReachable(reachablePeers, peerIP) {
+		// if the endpoint is both reachable and share the same STUN address, assume they are mesh candidates
+		if isReachable(reachablePeers, peerIP) && ax.nodeReflexiveAddress == value.ReflexiveIPv4 {
+			log.Debugf("ICE candidate match for direct peering is [ %s ] with a STUN Address of [ %s ]", value.NodeAddress, value.ReflexiveIPv4)
 			peer := wgPeerConfig{
 				pubkey,
 				value.EndpointIP,

--- a/internal/apex/configure-pull.go
+++ b/internal/apex/configure-pull.go
@@ -301,7 +301,6 @@ func appendChildPrefix(nodeAddress, childPrefix string) string {
 // TODO: routes need to be looked up if the exists, netlink etc.
 // TODO: AllowedIPs should be a slice, currently child-prefix is two routes seperated by a comma
 func (ax *Apex) handlePeerRoute(wgPeerConfig wgPeerConfig) {
-	//var prefix string
 	switch ax.os {
 	case Darwin.String():
 		// Darwin maps to a tunX address which needs to be discovered

--- a/internal/apex/utils.go
+++ b/internal/apex/utils.go
@@ -120,10 +120,10 @@ func discoverGenericIPv4(controller string, port string) (string, error) {
 	return "", fmt.Errorf("failed to obtain the local IP")
 }
 
-// GetPubIP retrieves current global IP address using STUN
-func GetPubIP() (string, error) {
+// GetPubIPv4 retrieves current global IP address using STUN
+func GetPubIPv4() (string, error) {
 	// Creating a "connection" to STUN server.
-	c, err := stun.Dial("udp", "stun.l.google.com:19302")
+	c, err := stun.Dial("udp4", "stun.l.google.com:19302")
 	if err != nil {
 		log.Error(err)
 		return "", err
@@ -175,7 +175,7 @@ func IsNAT(nodeOS, controller string, port string) (bool, error) {
 		}
 		hostIP = linuxIP.String()
 	}
-	pubIP, err := GetPubIP()
+	pubIP, err := GetPubIPv4()
 	if err != nil {
 		return false, err
 	}

--- a/internal/apexcontroller/handlers.go
+++ b/internal/apexcontroller/handlers.go
@@ -272,6 +272,7 @@ func (ct *Controller) handlePostZonePeers(c *gin.Context) {
 		}
 	}
 	if found {
+		peer.ReflexiveIPv4 = request.ReflexiveIPv4
 		peer.EndpointIP = request.EndpointIP
 
 		if request.NodeAddress != peer.NodeAddress {
@@ -338,15 +339,16 @@ func (ct *Controller) handlePostZonePeers(c *gin.Context) {
 			}
 		}
 		peer = &Peer{
-			DeviceID:    device.ID,
-			ZoneID:      zone.ID,
-			EndpointIP:  request.EndpointIP,
-			AllowedIPs:  ip,
-			NodeAddress: ip,
-			ChildPrefix: request.ChildPrefix,
-			ZonePrefix:  ipamPrefix,
-			HubZone:     hubZone,
-			HubRouter:   hubRouter,
+			DeviceID:      device.ID,
+			ZoneID:        zone.ID,
+			EndpointIP:    request.EndpointIP,
+			AllowedIPs:    ip,
+			NodeAddress:   ip,
+			ChildPrefix:   request.ChildPrefix,
+			ZonePrefix:    ipamPrefix,
+			HubZone:       hubZone,
+			HubRouter:     hubRouter,
+			ReflexiveIPv4: request.ReflexiveIPv4,
 		}
 		tx.Create(peer)
 		zone.Peers = append(zone.Peers, peer)

--- a/internal/apexcontroller/models.go
+++ b/internal/apexcontroller/models.go
@@ -76,27 +76,29 @@ type AddDevice struct {
 // Peer is an association between a Device and a Zone.
 type Peer struct {
 	Base
-	DeviceID    uuid.UUID `json:"device-id" example:"fde38e78-a4af-4f44-8f5a-d84ef1846a85"`
-	ZoneID      uuid.UUID `json:"zone-id" example:"2b655c5b-cfdd-4550-b7f0-a36a590fc97a"`
-	EndpointIP  string    `json:"endpoint-ip" example:"10.1.1.1"`
-	AllowedIPs  string    `json:"allowed-ips" example:"10.1.1.1"`
-	NodeAddress string    `json:"node-address" example:"1.2.3.4"`
-	ChildPrefix string    `json:"child-prefix" example:"172.16.42.0/24"`
-	HubRouter   bool      `json:"hub-router"`
-	HubZone     bool      `json:"hub-zone"`
-	ZonePrefix  string    `json:"zone-prefix" example:"10.1.1.0/24"`
+	DeviceID      uuid.UUID `json:"device-id" example:"fde38e78-a4af-4f44-8f5a-d84ef1846a85"`
+	ZoneID        uuid.UUID `json:"zone-id" example:"2b655c5b-cfdd-4550-b7f0-a36a590fc97a"`
+	EndpointIP    string    `json:"endpoint-ip" example:"10.1.1.1"`
+	AllowedIPs    string    `json:"allowed-ips" example:"10.1.1.1"`
+	NodeAddress   string    `json:"node-address" example:"1.2.3.4"`
+	ChildPrefix   string    `json:"child-prefix" example:"172.16.42.0/24"`
+	HubRouter     bool      `json:"hub-router"`
+	HubZone       bool      `json:"hub-zone"`
+	ZonePrefix    string    `json:"zone-prefix" example:"10.1.1.0/24"`
+	ReflexiveIPv4 string    `json:"reflexive-ip4"`
 }
 
 // AddPeer are the fields required to add a new Peer
 type AddPeer struct {
-	DeviceID    uuid.UUID `json:"device-id" example:"6a6090ad-fa47-4549-a144-02124757ab8f"`
-	EndpointIP  string    `json:"endpoint-ip" example:"10.1.1.1"`
-	AllowedIPs  string    `json:"allowed-ips" example:"10.1.1.1"`
-	NodeAddress string    `json:"node-address" example:"1.2.3.4"`
-	ChildPrefix string    `json:"child-prefix" example:"172.16.42.0/24"`
-	HubRouter   bool      `json:"hub-router"`
-	HubZone     bool      `json:"hub-zone"`
-	ZonePrefix  string    `json:"zone-prefix" example:"10.1.1.0/24"`
+	DeviceID      uuid.UUID `json:"device-id" example:"6a6090ad-fa47-4549-a144-02124757ab8f"`
+	EndpointIP    string    `json:"endpoint-ip" example:"10.1.1.1"`
+	AllowedIPs    string    `json:"allowed-ips" example:"10.1.1.1"`
+	NodeAddress   string    `json:"node-address" example:"1.2.3.4"`
+	ChildPrefix   string    `json:"child-prefix" example:"172.16.42.0/24"`
+	HubRouter     bool      `json:"hub-router"`
+	HubZone       bool      `json:"hub-zone"`
+	ZonePrefix    string    `json:"zone-prefix" example:"10.1.1.0/24"`
+	ReflexiveIPv4 string    `json:"reflexive-ip4"`
 }
 
 // Zone is a collection of devices that are connected together.


### PR DESCRIPTION
- Adds some ICE candidacy steps by leveraging STUN processing to rule out overlapping endpoint addresses on remote edge sites.
- The drawback is it sacrifices some meshing in VPC scenarios where the host has a 1:1 NAT mapping. All resolvable.

Signed-off-by: Brent Salisbury <bsalisbu@redhat.com>