### PR TITLE
Fix tags for apex images

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -11,6 +11,7 @@ env:
   CONTROLLER_UI_IMAGE_NAME: controller-ui
   APEX_IMAGE_NAME: apex
   KEYCLOAK_IMAGE_NAME: keycloak
+  IMAGE_TAG: latest
 
 jobs:
   build:
@@ -32,6 +33,8 @@ jobs:
       uses: docker/metadata-action@v3.6.2
       with:
         images: ${{ env.REGISTRY }}/${{ env.REPOSITORY }}/${{ env.CONTROLLER_IMAGE_NAME }}
+        tag: |
+          type=raw,value=${{ env.IMAGE_TAG }}
 
     - name: Build controller image
       id: build-controller
@@ -55,6 +58,8 @@ jobs:
       uses: docker/metadata-action@v3.6.2
       with:
         images: ${{ env.REGISTRY }}/${{ env.REPOSITORY }}/${{ env.CONTROLLER_UI_IMAGE_NAME }}
+        tag: |
+          type=raw,value=${{ env.IMAGE_TAG }}
 
     - name: Build controller-ui image
       id: build-controller-ui
@@ -78,6 +83,8 @@ jobs:
       uses: docker/metadata-action@v3.6.2
       with:
         images: ${{ env.REGISTRY }}/${{ env.REPOSITORY }}/${{ env.APEX_IMAGE_NAME }}
+        tag: |
+          type=raw,value=${{ env.IMAGE_TAG }}
 
     - name: Build apex image
       id: build-apex
@@ -101,6 +108,8 @@ jobs:
       uses: docker/metadata-action@v3.6.2
       with:
         images: ${{ env.REGISTRY }}/${{ env.REPOSITORY }}/${{ env.KEYCLOAK_IMAGE_NAME }}
+        tag: |
+          type=raw,value=${{ env.IMAGE_TAG }}
 
     - name: Build keycloak image
       id: build-keycloak

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
     - --password=${IPAM_DB_PASSWORD}
   
   controller:
-    image: quay.io/apex/controller
+    image: quay.io/apex/controller:latest
     depends_on:
       - controller-db
       - ipam
@@ -45,7 +45,7 @@ services:
       APEX_CONTROLLER_LOGLEVEL: debug
 
   ui:
-    image: quay.io/apex/controller-ui
+    image: quay.io/apex/controller-ui:latest
     depends_on:
      - controller
      - keycloak

--- a/tests/e2e-scripts/init-containers.sh
+++ b/tests/e2e-scripts/init-containers.sh
@@ -17,7 +17,7 @@ start_containers() {
 
     local node_image=${1}
 
-    $DOCKER_COMPOSE up -d
+    $DOCKER_COMPOSE up --build -d
 
     # allow for all services to come up and be ready
     timeout 300s bash -c 'until curl -sfL http://localhost:8080/api/health; do sleep 1; done'


### PR DESCRIPTION
Currently CI image job is pushing the image under main tag.

So everytime you run docker-compose locally it builds the
images because it doesn't find latest tag in quay.io. If
you want to pull the images from quay.io, you need to change
the tag to main.

CI endup building the images (which is required) for the same
reason.

This patch, publishes the images under latest tag, and explictly
asking CI to build the images.

Signed-off-by: Anil Kumar Vishnoi <avishnoi@redhat.com>