### PR TITLE
STUN processing for overlapping endpoint cidr

### DIFF
--- a/internal/apex/configure-hub.go
+++ b/internal/apex/configure-hub.go
@@ -123,7 +123,9 @@ func (ax *Apex) parseHubWireguardConfig(listenPort int) {
 		if err != nil {
 			log.Errorf("failed to split host:port endpoint pair: %v", err)
 		}
-		if isReachable(reachablePeers, peerIP) {
+		// if the endpoint is both reachable and share the same STUN address, assume they are mesh candidates
+		if isReachable(reachablePeers, peerIP) && ax.nodeReflexiveAddress == value.ReflexiveIPv4 {
+			log.Debugf("ICE candidate match for direct peering is [ %s ] with a STUN Address of [ %s ]", value.NodeAddress, value.ReflexiveIPv4)
 			peer := wgPeerConfig{
 				pubkey,
 				value.EndpointIP,

--- a/internal/apex/configure-pull.go
+++ b/internal/apex/configure-pull.go
@@ -187,10 +187,10 @@ func (ax *Apex) DeployWireguardConfig() {
 		// this is probably unnecessary but leaving it until we reconcile the routing tables.
 		// old routes dont currently get purged until we handle deletes. This adds very little
 		// observable latency so far as the next function adds them back TODO: reconcile route tabless
-		_, err := RunCommand("ip", "route", "flush", "dev", "wg0")
-		if err != nil {
-			log.Debugf("Failed to flush the wg0 routes: %v\n", err)
-		}
+		//_, err := RunCommand("ip", "route", "flush", "dev", "wg0")
+		//if err != nil {
+		//	log.Debugf("Failed to flush the wg0 routes: %v\n", err)
+		//}
 		// add routes for each peer candidate
 		for _, peer := range latestCfg.Peer {
 			ax.handlePeerRoute(peer)
@@ -267,7 +267,6 @@ func appendChildPrefix(nodeAddress, childPrefix string) string {
 // TODO: routes need to be looked up if the exists, netlink etc.
 // TODO: AllowedIPs should be a slice, currently child-prefix is two routes seperated by a comma
 func (ax *Apex) handlePeerRoute(wgPeerConfig wgPeerConfig) {
-	//var prefix string
 	switch ax.os {
 	case Darwin.String():
 		// Darwin maps to a tunX address which needs to be discovered

--- a/internal/apex/utils.go
+++ b/internal/apex/utils.go
@@ -121,10 +121,11 @@ func discoverGenericIPv4(controller string, port string) (string, error) {
 	return "", fmt.Errorf("failed to obtain the local IP")
 }
 
-// GetPubIP retrieves current global IP address using STUN
-func GetPubIP() (string, error) {
+
+// GetPubIPv4 retrieves current global IP address using STUN
+func GetPubIPv4() (string, error) {
 	// Creating a "connection" to STUN server.
-	c, err := stun.Dial("udp", "stun.l.google.com:19302")
+	c, err := stun.Dial("udp4", "stun.l.google.com:19302")
 	if err != nil {
 		log.Error(err)
 		return "", err
@@ -176,7 +177,7 @@ func IsNAT(nodeOS, controller string, port string) (bool, error) {
 		}
 		hostIP = linuxIP.String()
 	}
-	pubIP, err := GetPubIP()
+	pubIP, err := GetPubIPv4()
 	if err != nil {
 		return false, err
 	}

--- a/internal/handlers/peer.go
+++ b/internal/handlers/peer.go
@@ -148,6 +148,7 @@ func (api *API) CreatePeerInZone(c *gin.Context) {
 		}
 	}
 	if found {
+		peer.ReflexiveIPv4 = request.ReflexiveIPv4
 		peer.EndpointIP = request.EndpointIP
 
 		if request.NodeAddress != peer.NodeAddress {
@@ -223,6 +224,7 @@ func (api *API) CreatePeerInZone(c *gin.Context) {
 			ZonePrefix:  ipamPrefix,
 			HubZone:     hubZone,
 			HubRouter:   hubRouter,
+			ReflexiveIPv4: request.ReflexiveIPv4,
 		}
 		tx.Create(peer)
 		zone.Peers = append(zone.Peers, peer)

--- a/internal/models/peer.go
+++ b/internal/models/peer.go
@@ -14,6 +14,7 @@ type Peer struct {
 	HubRouter   bool      `json:"hub_router"`
 	HubZone     bool      `json:"hub_zone"`
 	ZonePrefix  string    `json:"zone_prefix" example:"10.1.1.0/24"`
+	ReflexiveIPv4 string `json:"reflexive-ip4"`
 }
 
 // AddPeer are the fields required to add a new Peer
@@ -26,4 +27,5 @@ type AddPeer struct {
 	HubRouter   bool      `json:"hub_router"`
 	HubZone     bool      `json:"hub_zone"`
 	ZonePrefix  string    `json:"zone_prefix" example:"10.1.1.0/24"`
+	ReflexiveIPv4 string    `json:"reflexive-ip4"`
 }


### PR DESCRIPTION
- Adds some ICE candidacy steps by leveraging STUN processing to rule out overlapping endpoint addresses on remote edge sites.
- The drawback is it sacrifices some meshing in VPC scenarios where the host has a 1:1 NAT mapping. All resolvable.

Signed-off-by: Brent Salisbury <bsalisbu@redhat.com>