### PR TITLE
compose: Restart Controller if it fails

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,9 @@ services:
     build:
       context: .
       dockerfile: ./Containerfile.controller
+    deploy:
+      restart_policy:
+        condition: on-failure
     command:
       - "--keycloak-address=keycloak"
       - "--db-address=${CONTROLLER_DB_HOST}"


### PR DESCRIPTION
This will happen if the IPAM service isn't available as it MUST be availbe to allocate the default zone prefix on first boot.

Signed-off-by: Dave Tucker <dave@dtucker.co.uk>