### PR TITLE
Resolves a local meshing bug

### DIFF
--- a/internal/apex/apex.go
+++ b/internal/apex/apex.go
@@ -188,6 +188,7 @@ func (ax *Apex) Run() {
 		ax.hubRouter,
 		false,
 		"",
+		ax.nodeReflexiveAddress,
 	)
 	if err != nil {
 		log.Fatalf("error creating peer: %+v", err)

--- a/internal/client/peers.go
+++ b/internal/client/peers.go
@@ -15,15 +15,16 @@ const (
 	ZONE_PEERS = "/api/zones/%s/peers"
 )
 
-func (c *Client) CreatePeerInZone(zoneID uuid.UUID, deviceID uuid.UUID, endpointIP string, requestedIP string, childPrefix string, hubRouter bool, hubZone bool, zonePrefix string) (models.Peer, error) {
+func (c *Client) CreatePeerInZone(zoneID uuid.UUID, deviceID uuid.UUID, endpointIP string, requestedIP string, childPrefix string, hubRouter bool, hubZone bool, zonePrefix string, reflexiveIP string) (models.Peer, error) {
 	registerRequest := models.AddPeer{
-		DeviceID:    deviceID,
-		EndpointIP:  endpointIP,
-		NodeAddress: requestedIP,
-		ChildPrefix: childPrefix,
-		HubRouter:   hubRouter,
-		HubZone:     hubZone,
-		ZonePrefix:  zonePrefix,
+		DeviceID:      deviceID,
+		EndpointIP:    endpointIP,
+		NodeAddress:   requestedIP,
+		ChildPrefix:   childPrefix,
+		HubRouter:     hubRouter,
+		HubZone:       hubZone,
+		ZonePrefix:    zonePrefix,
+		ReflexiveIPv4: reflexiveIP,
 	}
 	body, err := json.Marshal(registerRequest)
 	if err != nil {


### PR DESCRIPTION
- The reflexive address wasn't getting passed to the controller at registration so the ICE candidacy was failing for two reachable nodes under the same NAT cone.

Signed-off-by: Brent Salisbury <bsalisbu@redhat.com>