### PR TITLE
Stash usernames in our DB and show them in the UI

### DIFF
--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -11,6 +11,7 @@ type User struct {
 	Devices    []*Device   `json:"-"`
 	DeviceList []uuid.UUID `gorm:"-" json:"devices" example:"4902c991-3dd1-49a6-9f26-d82496c80aff"`
 	ZoneID     uuid.UUID   `json:"zone_id" example:"94deb404-c4eb-4097-b59d-76b024ff7867"`
+	UserName   string      `json:"username" example:"admin"`
 }
 
 func (u *User) BeforeCreate(tx *gorm.DB) error {

--- a/internal/routers/middleware.go
+++ b/internal/routers/middleware.go
@@ -12,6 +12,9 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+// key for username in gin.Context
+const AuthUserName string = "_apex.UserName"
+
 type KeyCloakAuth struct {
 	jwks *keyfunc.JWKS
 }
@@ -74,6 +77,7 @@ func (a *KeyCloakAuth) AuthFunc() gin.HandlerFunc {
 
 		if claims, ok := token.Claims.(*Claims); ok {
 			c.Set(gin.AuthUserKey, claims.Subject)
+			c.Set(AuthUserName, claims.UserName)
 			// c.Set(AuthUserScope, claims.Scope)
 		} else {
 			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "unable to extract user info from claims"})

--- a/ui/src/pages/Users.tsx
+++ b/ui/src/pages/Users.tsx
@@ -13,7 +13,7 @@ import {
 export const UserList = () => (
     <List>
         <Datagrid rowClick="show" bulkActionButtons={false}>
-            <TextField label = "ID" source="id" />
+            <TextField label = "Username" source="username" />
             <TextField label = "Zone ID" source="zone_id" />
             <ReferenceArrayField label="Devices" source="devices" reference="devices">
                 <SingleFieldList linkType="show">
@@ -28,6 +28,7 @@ export const UserShow = () => (
     <Show>
         <SimpleShowLayout>
             <TextField label = "ID" source="id" />
+            <TextField label = "Username" source="username" />
             <TextField label = "Zone ID" source="zone_id" />
             <ReferenceArrayField label="Devices" source="devices" reference="devices">
                 <Datagrid rowClick="show" bulkActionButtons={false}>


### PR DESCRIPTION
This patch stashes the UserName in the request context in the auth middleware, and then users it when creating a user in our database. The UI is also updated to show the username in the User list instead of IDs. The ID is still visible in the user detail view.

Signed-off-by: Russell Bryant <rbryant@redhat.com>

![Screenshot from 2022-11-17 17-49-41](https://user-images.githubusercontent.com/309258/202577324-7108a482-ecea-4e4c-bfb4-71bad51111c3.png)
![Screenshot from 2022-11-17 17-49-58](https://user-images.githubusercontent.com/309258/202577335-01619fc7-c0a6-424b-b21b-d9e3e99b87a8.png)
