### PR TITLE
Support User/Org Invitations

### DIFF
--- a/cmd/nexctl/invitation.go
+++ b/cmd/nexctl/invitation.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/google/uuid"
+	"github.com/nexodus-io/nexodus/internal/client"
+)
+
+func acceptInvitation(c *client.Client, id string) error {
+	invID, err := uuid.Parse(id)
+	if err != nil {
+		log.Fatalf("failed to parse a valid UUID from %s %v", id, err)
+	}
+	if err := c.AcceptInvitation(invID); err != nil {
+		log.Fatal(err)
+	}
+	return nil
+}
+
+func deleteInvitation(c *client.Client, id string) error {
+	invID, err := uuid.Parse(id)
+	if err != nil {
+		log.Fatalf("failed to parse a valid UUID from %s %v", id, err)
+	}
+	if err := c.DeleteInvitation(invID); err != nil {
+		log.Fatal(err)
+	}
+	return nil
+}
+
+func createInvitation(c *client.Client, encodeOut, userID string, orgID string) error {
+	orgUUID, err := uuid.Parse(orgID)
+	if err != nil {
+		log.Fatalf("failed to parse a valid UUID from %s %v", orgID, err)
+	}
+
+	res, err := c.CreateInvitation(userID, orgUUID)
+	if err != nil {
+		log.Fatalf("create invitation failed: %v\n", err)
+	}
+
+	if encodeOut == encodeColumn || encodeOut == encodeNoHeader {
+		fmt.Printf("successfully created invitation %s\n", res.ID.String())
+		return nil
+	}
+
+	err = FormatOutput(encodeOut, res)
+	if err != nil {
+		log.Fatalf("failed to print output: %v", err)
+	}
+
+	return nil
+}

--- a/cmd/nexctl/main.go
+++ b/cmd/nexctl/main.go
@@ -310,6 +310,90 @@ func main() {
 					},
 				},
 			},
+			{
+				Name:  "invitation",
+				Usage: "commands relating to invitations",
+				Subcommands: []*cli.Command{
+					{
+						Name:  "create",
+						Usage: "create an invitation",
+						Flags: []cli.Flag{
+							&cli.StringFlag{
+								Name:     "user-id",
+								Required: true,
+							},
+							&cli.StringFlag{
+								Name:     "org-id",
+								Required: true,
+							},
+						},
+						Action: func(cCtx *cli.Context) error {
+							c, err := client.NewClient(cCtx.Context,
+								cCtx.String("host"), nil,
+								client.WithPasswordGrant(
+									cCtx.String("username"),
+									cCtx.String("password"),
+								),
+							)
+							if err != nil {
+								log.Fatal(err)
+							}
+							encodeOut := cCtx.String("output")
+							userID := cCtx.String("user-id")
+							orgID := cCtx.String("org-id")
+							return createInvitation(c, encodeOut, userID, orgID)
+						},
+					},
+					{
+						Name:  "delete",
+						Usage: "delete an invitation",
+						Flags: []cli.Flag{
+							&cli.StringFlag{
+								Name:     "inv-id",
+								Required: true,
+							},
+						},
+						Action: func(cCtx *cli.Context) error {
+							c, err := client.NewClient(cCtx.Context,
+								cCtx.String("host"), nil,
+								client.WithPasswordGrant(
+									cCtx.String("username"),
+									cCtx.String("password"),
+								),
+							)
+							if err != nil {
+								log.Fatal(err)
+							}
+							userID := cCtx.String("inv-id")
+							return deleteInvitation(c, userID)
+						},
+					},
+					{
+						Name:  "accept",
+						Usage: "accept an invitation",
+						Flags: []cli.Flag{
+							&cli.StringFlag{
+								Name:     "inv-id",
+								Required: true,
+							},
+						},
+						Action: func(cCtx *cli.Context) error {
+							c, err := client.NewClient(cCtx.Context,
+								cCtx.String("host"), nil,
+								client.WithPasswordGrant(
+									cCtx.String("username"),
+									cCtx.String("password"),
+								),
+							)
+							if err != nil {
+								log.Fatal(err)
+							}
+							userID := cCtx.String("inv-id")
+							return acceptInvitation(c, userID)
+						},
+					},
+				},
+			},
 		},
 	}
 	if err := app.Run(os.Args); err != nil {

--- a/docs/development/design/database.md
+++ b/docs/development/design/database.md
@@ -79,6 +79,8 @@ erDiagram
     USER ||--o{ DEVICE : has
     USER ||--|{ ORGANIZATION : belongs_to
     ORGANIZATION ||--o{ DEVICE: contains
+    INVITE ||--|| USER : has
+    INVITE ||--|| ORGANIZATION: has
     USER{
         string id
         string username
@@ -106,6 +108,12 @@ erDiagram
         string cidr
         string hub_zone
     }
+    INVITATION{
+        string id
+        string user_id
+        string organization_id
+        string expiry
+    }
 ```
 
 In this simplified model we only have 3 concepts:
@@ -115,6 +123,8 @@ In this simplified model we only have 3 concepts:
 - Organization: A collection of users who have permissions to onboard one or more devices into this organization
 
 Since a `User` is also an `Organization`, once someone has registered to Nexodus we onboard devices into their personal organization.
+
+The addition of users to an `Organization` happens via invitation. An organization owner creates an which is valid for a period of time. During that validity period, a user may accept this invitaion which will add them to the organization. An organization may also revoke and invitation after offer, but before it was accepted.
 
 The device-onboarding flow is as follows:
 

--- a/integration-tests/device-api.feature
+++ b/integration-tests/device-api.feature
@@ -16,6 +16,7 @@ Feature: Device API
       {
         "devices": [],
         "id": "${user_id}",
+        "invitations": [],
         "organizations": [
           "${organization_id}"
         ],

--- a/integration-tests/util_test.go
+++ b/integration-tests/util_test.go
@@ -276,15 +276,16 @@ func (suite *NexodusIntegrationSuite) runNexd(ctx context.Context, node testcont
 	nexodus.WriteToFile(suite.logger, strings.Join(cmd, " "), runScriptLocal, 0755)
 	// copy the nexd run script to the test container
 	err := node.CopyFileToContainer(ctx, runScriptLocal, fmt.Sprintf("/bin/%s", runScript), 0755)
-	if suite.T().Failed() {
-		suite.logger.Errorf("execution of copy command on %s failed: %v", nodeName, err)
-	}
+	suite.Require().NoError(err, fmt.Errorf("execution of copy command on %s failed: %v", nodeName, err))
+
 	// execute the nexd run script on the test container
 	out, err := suite.containerExec(ctx, node, []string{"/bin/bash", "-c", runScript})
 	if suite.T().Failed() {
 		suite.logger.Errorf("execution of command on %s failed: %s", nodeName, strings.Join(cmd, " "))
 		suite.logger.Errorf("output:\n%s", out)
 		suite.logger.Errorf("%+v", err)
+	} else {
+		suite.Require().NoError(err)
 	}
 }
 
@@ -394,7 +395,7 @@ func (suite *NexodusIntegrationSuite) NewTLSConfig() *tls.Config {
 
 // nexdStatus checks for a Running status of the nexd process via nexctl
 func (suite *NexodusIntegrationSuite) nexdStatus(ctx context.Context, ctr testcontainers.Container) error {
-	timeoutCtx, cancel := context.WithTimeout(ctx, time.Second*10)
+	timeoutCtx, cancel := context.WithTimeout(ctx, time.Second*1000)
 	defer cancel()
 	running, _ := util.CheckPeriodically(timeoutCtx, time.Second, func() (bool, error) {
 		statOut, _ := suite.containerExec(ctx, ctr, []string{"/bin/nexctl", "nexd", "status"})

--- a/internal/client/invitation.go
+++ b/internal/client/invitation.go
@@ -1,0 +1,97 @@
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/google/uuid"
+	"github.com/nexodus-io/nexodus/internal/models"
+)
+
+const (
+	INVITATIONS       = "/api/invitations"
+	INVITATION        = "/api/invitations/%s"
+	INVITATION_ACCEPT = "/api/invitations/%s/accept"
+)
+
+// CreateInvitation creates an invitation
+func (c *Client) CreateInvitation(userID string, orgID uuid.UUID) (models.Invitation, error) {
+	dest := c.baseURL.JoinPath(INVITATIONS).String()
+	organization := models.AddInvitation{
+		UserID:         userID,
+		OrganizationID: orgID,
+	}
+	inviteJSON, _ := json.Marshal(organization)
+
+	req, err := http.NewRequest(http.MethodPost, dest, bytes.NewReader(inviteJSON))
+	if err != nil {
+		return models.Invitation{}, err
+	}
+
+	res, err := c.client.Do(req)
+	if err != nil {
+		return models.Invitation{}, err
+	}
+	defer res.Body.Close()
+
+	resBody, err := io.ReadAll(res.Body)
+	if err != nil {
+		return models.Invitation{}, err
+	}
+
+	if res.StatusCode != http.StatusCreated {
+		return models.Invitation{}, fmt.Errorf("failed to create the invitation. %s", string(resBody))
+	}
+
+	var data models.Invitation
+	if err := json.Unmarshal(resBody, &data); err != nil {
+		return models.Invitation{}, err
+	}
+
+	return data, nil
+}
+
+// AcceptInvitation accepts and invitation
+func (c *Client) AcceptInvitation(id uuid.UUID) error {
+	dest := c.baseURL.JoinPath(fmt.Sprintf(INVITATION_ACCEPT, id.String())).String()
+
+	req, err := http.NewRequest(http.MethodPost, dest, nil)
+	if err != nil {
+		return err
+	}
+
+	res, err := c.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusNoContent {
+		return fmt.Errorf("failed to accept invitation %d", res.StatusCode)
+	}
+	return nil
+}
+
+// DeleteInvitation deletes an invitation
+func (c *Client) DeleteInvitation(id uuid.UUID) error {
+	dest := c.baseURL.JoinPath(fmt.Sprintf(INVITATION_ACCEPT, id.String())).String()
+
+	req, err := http.NewRequest(http.MethodDelete, dest, nil)
+	if err != nil {
+		return err
+	}
+
+	res, err := c.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusNoContent {
+		return fmt.Errorf("failed to accept invitation %d", res.StatusCode)
+	}
+	return nil
+}

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -10,6 +10,7 @@ import (
 	"github.com/nexodus-io/nexodus/internal/database/migration_20230126_0000"
 	"github.com/nexodus-io/nexodus/internal/database/migration_20230314_0000"
 	"github.com/nexodus-io/nexodus/internal/database/migration_20230321_0000"
+	"github.com/nexodus-io/nexodus/internal/database/migration_20230327_0000"
 	"github.com/nexodus-io/nexodus/internal/database/migrations"
 	"github.com/uptrace/opentelemetry-go-extra/otelgorm"
 	"go.opentelemetry.io/otel"
@@ -63,7 +64,15 @@ func NewDatabase(
 }
 
 func NewTestDatabase() (*gorm.DB, error) {
-	db, err := gorm.Open(sqlite.Open("file::memory:?cache=shared"), &gorm.Config{})
+	logger, err := zap.NewDevelopment()
+	if err != nil {
+		return nil, err
+	}
+	gormLogger := NewLogger(logger.Sugar())
+	config := &gorm.Config{
+		Logger: gormLogger,
+	}
+	db, err := gorm.Open(sqlite.Open("file::memory:?cache=shared"), config)
 	if err != nil {
 		return nil, err
 	}
@@ -88,6 +97,7 @@ func Migrations() *migrations.Migrations {
 			migration_20230126_0000.Migrate(),
 			migration_20230314_0000.Migrate(),
 			migration_20230321_0000.Migrate(),
+			migration_20230327_0000.Migrate(),
 		},
 	}
 }

--- a/internal/database/migration_20230327_0000/20230217-0000.go
+++ b/internal/database/migration_20230327_0000/20230217-0000.go
@@ -1,0 +1,37 @@
+package migration_20230327_0000
+
+import (
+	"time"
+
+	"github.com/go-gormigrate/gormigrate/v2"
+	"github.com/google/uuid"
+	"github.com/nexodus-io/nexodus/internal/database/migrations"
+)
+
+// Base contains common columns for all tables.
+type Base struct {
+	ID        uuid.UUID  `gorm:"type:uuid;primary_key;" json:"id" example:"aa22666c-0f57-45cb-a449-16efecc04f2e"`
+	CreatedAt time.Time  `json:"-"`
+	UpdatedAt time.Time  `json:"-"`
+	DeletedAt *time.Time `sql:"index" json:"-"`
+}
+
+// Invitation is a request for a user to join an organization
+type Invitation struct {
+	Base
+	UserID         string    `json:"user_id"`
+	OrganizationID uuid.UUID `json:"organization_id"`
+	Expiry         time.Time `json:"expiry"`
+}
+
+type Organization struct {
+	OwnerID string `gorm:"owner_id;"`
+}
+
+func Migrate() *gormigrate.Migration {
+	migrationId := "20230327-0000"
+	return migrations.CreateMigrationFromActions(migrationId,
+		migrations.CreateTableAction(&Invitation{}),
+		migrations.AddTableColumnsAction(&Organization{}),
+	)
+}

--- a/internal/docs/docs.go
+++ b/internal/docs/docs.go
@@ -963,6 +963,24 @@ const docTemplate = `{
                 }
             }
         },
+        "models.Invitation": {
+            "type": "object",
+            "properties": {
+                "expiry": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string",
+                    "example": "aa22666c-0f57-45cb-a449-16efecc04f2e"
+                },
+                "organization_id": {
+                    "type": "string"
+                },
+                "user_id": {
+                    "type": "string"
+                }
+            }
+        },
         "models.Organization": {
             "type": "object",
             "properties": {
@@ -982,10 +1000,19 @@ const docTemplate = `{
                     "type": "string",
                     "example": "aa22666c-0f57-45cb-a449-16efecc04f2e"
                 },
+                "invitations": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.Invitation"
+                    }
+                },
                 "ipCidr": {
                     "type": "string"
                 },
                 "name": {
+                    "type": "string"
+                },
+                "ownerID": {
                     "type": "string"
                 },
                 "users": {
@@ -1048,6 +1075,12 @@ const docTemplate = `{
                     "description": "Since the ID comes from the IDP, we have no control over the format...",
                     "type": "string",
                     "example": "aa22666c-0f57-45cb-a449-16efecc04f2e"
+                },
+                "invitations": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.Invitation"
+                    }
                 },
                 "organizations": {
                     "type": "array",

--- a/internal/docs/swagger.json
+++ b/internal/docs/swagger.json
@@ -956,6 +956,24 @@
                 }
             }
         },
+        "models.Invitation": {
+            "type": "object",
+            "properties": {
+                "expiry": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string",
+                    "example": "aa22666c-0f57-45cb-a449-16efecc04f2e"
+                },
+                "organization_id": {
+                    "type": "string"
+                },
+                "user_id": {
+                    "type": "string"
+                }
+            }
+        },
         "models.Organization": {
             "type": "object",
             "properties": {
@@ -975,10 +993,19 @@
                     "type": "string",
                     "example": "aa22666c-0f57-45cb-a449-16efecc04f2e"
                 },
+                "invitations": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.Invitation"
+                    }
+                },
                 "ipCidr": {
                     "type": "string"
                 },
                 "name": {
+                    "type": "string"
+                },
+                "ownerID": {
                     "type": "string"
                 },
                 "users": {
@@ -1041,6 +1068,12 @@
                     "description": "Since the ID comes from the IDP, we have no control over the format...",
                     "type": "string",
                     "example": "aa22666c-0f57-45cb-a449-16efecc04f2e"
+                },
+                "invitations": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.Invitation"
+                    }
                 },
                 "organizations": {
                     "type": "array",

--- a/internal/docs/swagger.yaml
+++ b/internal/docs/swagger.yaml
@@ -60,6 +60,18 @@ definitions:
       user_id:
         type: string
     type: object
+  models.Invitation:
+    properties:
+      expiry:
+        type: string
+      id:
+        example: aa22666c-0f57-45cb-a449-16efecc04f2e
+        type: string
+      organization_id:
+        type: string
+      user_id:
+        type: string
+    type: object
   models.Organization:
     properties:
       description:
@@ -73,9 +85,15 @@ definitions:
       id:
         example: aa22666c-0f57-45cb-a449-16efecc04f2e
         type: string
+      invitations:
+        items:
+          $ref: '#/definitions/models.Invitation'
+        type: array
       ipCidr:
         type: string
       name:
+        type: string
+      ownerID:
         type: string
       users:
         items:
@@ -120,6 +138,10 @@ definitions:
           format...
         example: aa22666c-0f57-45cb-a449-16efecc04f2e
         type: string
+      invitations:
+        items:
+          $ref: '#/definitions/models.Invitation'
+        type: array
       organizations:
         items:
           $ref: '#/definitions/models.Organization'

--- a/internal/handlers/device.go
+++ b/internal/handlers/device.go
@@ -16,10 +16,11 @@ import (
 )
 
 var (
-	errUserOrOrgNotFound = errors.New("user or organization not found")
-	errUserNotFound      = errors.New("user not found")
-	errDeviceNotFound    = errors.New("device not found")
-	errOrgNotFound       = errors.New("organization not found")
+	errUserOrOrgNotFound  = errors.New("user or organization not found")
+	errOrgNotFound        = errors.New("organization not found")
+	errUserNotFound       = errors.New("user not found")
+	errDeviceNotFound     = errors.New("device not found")
+	errInvitationNotFound = errors.New("invitation not found")
 )
 
 type errDuplicateDevice struct {

--- a/internal/handlers/handlers_test.go
+++ b/internal/handlers/handlers_test.go
@@ -24,7 +24,8 @@ import (
 )
 
 const (
-	TestUserID = "f606de8d-092d-4606-b981-80ce9f5a3b2a"
+	TestUserID  = "f606de8d-092d-4606-b981-80ce9f5a3b2a"
+	TestUser2ID = "3381dcaf-f61e-4671-8787-3e53490894ae"
 )
 
 type HandlerTestSuite struct {
@@ -34,6 +35,7 @@ type HandlerTestSuite struct {
 	wg                 *sync.WaitGroup
 	api                *API
 	testOrganizationID uuid.UUID
+	testUser2OrgID     uuid.UUID
 }
 
 func (suite *HandlerTestSuite) SetupSuite() {
@@ -73,6 +75,8 @@ func (suite *HandlerTestSuite) BeforeTest(_, _ string) {
 	suite.api.db.Exec("DELETE FROM devices")
 	var err error
 	suite.testOrganizationID, err = suite.api.createUserIfNotExists(context.Background(), TestUserID, "testuser")
+	suite.Require().NoError(err)
+	suite.testUser2OrgID, err = suite.api.createUserIfNotExists(context.Background(), TestUser2ID, "testuser2")
 	suite.Require().NoError(err)
 }
 

--- a/internal/handlers/invitations.go
+++ b/internal/handlers/invitations.go
@@ -1,0 +1,139 @@
+package handlers
+
+import (
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/nexodus-io/nexodus/internal/models"
+	"gorm.io/gorm"
+)
+
+func (api *API) CreateInvitation(c *gin.Context) {
+	ctx, span := tracer.Start(c.Request.Context(), "InviteUserToOrganization")
+	defer span.End()
+	multiOrganizationEnabled, err := api.fflags.GetFlag("multi-organization")
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, models.NewApiInternalError(err))
+		return
+	}
+	allowForTests := c.GetString("_apex.testCreateOrganization")
+	if !multiOrganizationEnabled && allowForTests != "true" {
+		c.JSON(http.StatusMethodNotAllowed, models.NewNotAllowedError("multi-organization support is disabled"))
+		return
+	}
+	var request models.AddInvitation
+	if err := c.BindJSON(&request); err != nil {
+		c.JSON(http.StatusBadRequest, models.NewBadPayloadError())
+		return
+	}
+	var user models.User
+	if res := api.db.WithContext(ctx).Preload("Organizations").Preload("Invitations").First(&user, "id = ?", request.UserID); res.Error != nil {
+		c.JSON(http.StatusNotFound, models.NewNotFoundError("user"))
+		return
+	}
+	for _, org := range user.Organizations {
+		if org.ID == request.OrganizationID {
+			c.JSON(http.StatusBadRequest, models.NewFieldValidationError("organization", "user is already in requested org"))
+			return
+		}
+	}
+	for _, inv := range user.Invitations {
+		if inv.OrganizationID == request.OrganizationID && inv.Expiry.After(time.Now()) {
+			c.JSON(http.StatusConflict, models.NewConflictsError(inv.ID.String()))
+			return
+		}
+	}
+	invite := models.NewInvitation(user.ID, request.OrganizationID)
+	if res := api.db.WithContext(ctx).Create(&invite); res.Error != nil {
+		c.JSON(http.StatusInternalServerError, models.NewApiInternalError(err))
+		return
+	}
+	c.JSON(http.StatusCreated, invite)
+}
+
+func (api *API) AcceptInvitation(c *gin.Context) {
+	ctx, span := tracer.Start(c.Request.Context(), "InviteUserToOrganization")
+	defer span.End()
+	multiOrganizationEnabled, err := api.fflags.GetFlag("multi-organization")
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, models.NewApiInternalError(err))
+		return
+	}
+	allowForTests := c.GetString("_apex.testCreateOrganization")
+	if !multiOrganizationEnabled && allowForTests != "true" {
+		c.JSON(http.StatusMethodNotAllowed, models.NewNotAllowedError("multi-organization support is disabled"))
+		return
+	}
+	k, err := uuid.Parse(c.Param("invitation"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, models.NewBadPathParameterError("invitation"))
+		return
+	}
+
+	var invitation models.Invitation
+	err = api.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+		if res := tx.First(&invitation, "id = ?", k); res.Error != nil {
+			return errInvitationNotFound
+		}
+		var user models.User
+		if res := tx.Preload("Organizations").First(&user, "id = ?", invitation.UserID); res.Error != nil {
+			return errUserNotFound
+		}
+
+		var org models.Organization
+		if res := tx.First(&org, "id = ?", invitation.OrganizationID); res.Error != nil {
+			return errOrgNotFound
+		}
+		user.Organizations = append(user.Organizations, &org)
+		if res := tx.Save(&user); res.Error != nil {
+			return res.Error
+		}
+		if res := tx.Delete(&invitation); res.Error != nil {
+			return res.Error
+		}
+		return nil
+	})
+
+	if err != nil {
+		if errors.Is(err, errInvitationNotFound) {
+			c.JSON(http.StatusNotFound, models.NewNotFoundError("invitation"))
+		} else if errors.Is(err, errUserNotFound) {
+			c.JSON(http.StatusNotFound, models.NewNotFoundError("user"))
+		} else if errors.Is(err, errOrgNotFound) {
+			c.JSON(http.StatusNotFound, models.NewNotFoundError("organization"))
+		} else {
+			c.JSON(http.StatusInternalServerError, models.NewApiInternalError(err))
+		}
+		return
+	}
+
+	c.Status(http.StatusNoContent)
+}
+
+func (api *API) DeleteInvitation(c *gin.Context) {
+	ctx, span := tracer.Start(c.Request.Context(), "DeleteInvitation")
+	defer span.End()
+	multiOrganizationEnabled, err := api.fflags.GetFlag("multi-organization")
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, models.NewApiInternalError(err))
+		return
+	}
+	allowForTests := c.GetString("_apex.testCreateOrganization")
+	if !multiOrganizationEnabled && allowForTests != "true" {
+		c.JSON(http.StatusMethodNotAllowed, models.NewNotAllowedError("multi-organization support is disabled"))
+		return
+	}
+	k, err := uuid.Parse(c.Param("invitation"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, models.NewBadPathParameterError("invitation"))
+		return
+	}
+	if res := api.db.WithContext(ctx).Delete(&models.Invitation{}, k); res.Error != nil {
+		c.JSON(http.StatusInternalServerError, models.NewApiInternalError(res.Error))
+		return
+	}
+	c.Status(http.StatusNoContent)
+}

--- a/internal/handlers/invitations_test.go
+++ b/internal/handlers/invitations_test.go
@@ -1,0 +1,141 @@
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/nexodus-io/nexodus/internal/models"
+)
+
+func (suite *HandlerTestSuite) TestCreateAcceptRefuseInvitation() {
+	require := suite.Require()
+
+	var inviteID uuid.UUID
+
+	tt := []struct {
+		name   string
+		userID string
+		orgID  uuid.UUID
+		code   int
+		action string
+	}{
+		{
+			name:   "invite to existing org fails",
+			code:   http.StatusBadRequest,
+			userID: TestUserID,
+			orgID:  suite.testOrganizationID,
+			action: "invite",
+		},
+		{
+			name:   "invite to new org succeeds",
+			code:   http.StatusCreated,
+			userID: TestUserID,
+			orgID:  suite.testUser2OrgID,
+			action: "invite",
+		},
+		{
+			name:   "re-invite to same org fails",
+			code:   http.StatusConflict,
+			userID: TestUserID,
+			orgID:  suite.testUser2OrgID,
+			action: "invite",
+		},
+		{
+			name:   "refuse invite succeeds",
+			code:   http.StatusNoContent,
+			userID: TestUserID,
+			orgID:  suite.testUser2OrgID,
+			action: "refuse",
+		},
+		{
+			name:   "re-invite to same org succeeds",
+			code:   http.StatusCreated,
+			userID: TestUserID,
+			orgID:  suite.testUser2OrgID,
+			action: "invite",
+		},
+		{
+			name:   "accept org succeeds",
+			code:   http.StatusNoContent,
+			userID: TestUserID,
+			orgID:  suite.testUser2OrgID,
+			action: "accept",
+		},
+		{
+			name:   "invite to existing org fails",
+			code:   http.StatusBadRequest,
+			userID: TestUserID,
+			orgID:  suite.testOrganizationID,
+			action: "invite",
+		},
+	}
+	for _, c := range tt {
+		suite.T().Log(c.name)
+
+		var res *httptest.ResponseRecorder
+		switch c.action {
+		case "invite":
+			request := models.AddInvitation{
+				UserID:         c.userID,
+				OrganizationID: c.orgID,
+			}
+			reqBody, err := json.Marshal(request)
+			require.NoError(err)
+			_, res, err = suite.ServeRequest(
+				http.MethodPost,
+				"/", "/",
+				func(c *gin.Context) {
+					c.Set("_apex.testCreateOrganization", "true")
+					suite.api.CreateInvitation(c)
+				}, bytes.NewReader(reqBody),
+			)
+			require.NoError(err)
+			body, err := io.ReadAll(res.Body)
+			require.NoError(err)
+			require.Equal(c.code, res.Code, "HTTP error: %s", string(body))
+			if res.Code == http.StatusCreated {
+				var inv models.Invitation
+				err = json.Unmarshal(body, &inv)
+				require.NoError(err)
+				require.NotEqual(uuid.Nil, inv.ID)
+				inviteID = inv.ID
+			}
+		case "accept":
+			var err error
+			require.NotEqual(uuid.Nil, inviteID)
+			_, res, err = suite.ServeRequest(
+				http.MethodPost,
+				"/:invitation", fmt.Sprintf("/%s", inviteID.String()),
+				func(c *gin.Context) {
+					c.Set("_apex.testCreateOrganization", "true")
+					suite.api.AcceptInvitation(c)
+				}, nil,
+			)
+			require.NoError(err)
+			body, err := io.ReadAll(res.Body)
+			require.NoError(err)
+			require.Equal(c.code, res.Code, "HTTP error: %s", string(body))
+		case "refuse":
+			var err error
+			require.NotEqual(uuid.Nil, inviteID)
+			_, res, err = suite.ServeRequest(
+				http.MethodPost,
+				"/:invitation", fmt.Sprintf("/%s", inviteID.String()),
+				func(c *gin.Context) {
+					c.Set("_apex.testCreateOrganization", "true")
+					suite.api.DeleteInvitation(c)
+				}, nil,
+			)
+			require.NoError(err)
+			body, err := io.ReadAll(res.Body)
+			require.NoError(err)
+			require.Equal(c.code, res.Code, "HTTP error: %s", string(body))
+		}
+	}
+}

--- a/internal/handlers/organization_test.go
+++ b/internal/handlers/organization_test.go
@@ -86,7 +86,7 @@ func (suite *HandlerTestSuite) TestListOrganizations() {
 		var actual []models.OrganizationJSON
 		err = json.Unmarshal(body, &actual)
 		assert.NoError(err)
-		assert.Len(actual, 4)
+		assert.Len(actual, 5)
 	}
 
 	{
@@ -105,9 +105,10 @@ func (suite *HandlerTestSuite) TestListOrganizations() {
 		err = json.Unmarshal(body, &actual)
 		assert.NoError(err)
 
-		assert.Len(actual, 4)
+		assert.Len(actual, 5)
 		seen := map[string]bool{
 			"testuser":       false,
+			"testuser2":      false,
 			"organization-a": false,
 			"organization-b": false,
 			"organization-c": false,
@@ -156,9 +157,9 @@ func (suite *HandlerTestSuite) TestListOrganizations() {
 		err = json.Unmarshal(body, &actual)
 		assert.NoError(err)
 
-		assert.Len(actual, 1)
-		assert.Equal("4", res.Header().Get(TotalCountHeader))
-		assert.Equal("organization-c", actual[0].Name)
+		assert.Len(actual, 2)
+		assert.Equal("5", res.Header().Get(TotalCountHeader))
+		assert.Equal("organization-b", actual[0].Name)
 	}
 
 	for _, o := range organizationIDs {

--- a/internal/models/device.go
+++ b/internal/models/device.go
@@ -11,7 +11,7 @@ type Device struct {
 	Base
 	UserID                   string         `json:"user_id"`
 	OrganizationID           uuid.UUID      `json:"organization_id"`
-	PublicKey                string         `json:"public_key" gorm:"uniqueIndex"`
+	PublicKey                string         `json:"public_key"`
 	LocalIP                  string         `json:"local_ip"`
 	AllowedIPs               pq.StringArray `json:"allowed_ips" gorm:"type:text[]" swaggertype:"array,string"`
 	TunnelIP                 string         `json:"tunnel_ip"`

--- a/internal/models/error.go
+++ b/internal/models/error.go
@@ -53,6 +53,15 @@ func NewInvalidField(field string) ValidationError {
 	}
 }
 
+func NewFieldValidationError(field string, reason string) ValidationError {
+	return ValidationError{
+		Field: field,
+		BaseError: BaseError{
+			Error: reason,
+		},
+	}
+}
+
 // ConflictsError is returned in the body of an HTTP 409
 type ConflictsError struct {
 	ID string `json:"id" example:"a1fae5de-dd96-4b20-8362-95f6a574c4b1"`

--- a/internal/models/invitation.go
+++ b/internal/models/invitation.go
@@ -1,0 +1,30 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Invitation is a request for a user to join an organization
+type Invitation struct {
+	Base
+	UserID         string    `json:"user_id"`
+	OrganizationID uuid.UUID `json:"organization_id"`
+	Expiry         time.Time `json:"expiry"`
+}
+
+func NewInvitation(userID string, orgID uuid.UUID) Invitation {
+	// invitation expires after 1 week
+	expiry := time.Now().Add(time.Hour * 24 * 7)
+	return Invitation{
+		UserID:         userID,
+		OrganizationID: orgID,
+		Expiry:         expiry,
+	}
+}
+
+type AddInvitation struct {
+	UserID         string    `json:"user_id"`
+	OrganizationID uuid.UUID `json:"organization_id"`
+}

--- a/internal/models/organization.go
+++ b/internal/models/organization.go
@@ -10,17 +10,20 @@ import (
 // Organization contains Users and their Devices
 type Organization struct {
 	Base
+	OwnerID     string  `gorm:"owner_id;"`
 	Users       []*User `gorm:"many2many:user_organizations;"`
 	Devices     []*Device
-	Name        string `gorm:"uniqueIndex"`
+	Name        string `gorm:"uniqueIndex" sql:"index"`
 	Description string
 	IpCidr      string
 	HubZone     bool
+	Invitations []*Invitation
 }
 
 // Organization contains Users and their Devices
 type OrganizationJSON struct {
 	ID          uuid.UUID   `json:"id"`
+	OwnerID     string      `json:"owner_id" example:"aa22666c-0f57-45cb-a449-16efecc04f2e"`
 	Users       []string    `json:"users" example:"94deb404-c4eb-4097-b59d-76b024ff7867"`
 	Devices     []uuid.UUID `json:"devices" example:"4902c991-3dd1-49a6-9f26-d82496c80aff"`
 	Name        string      `json:"name" example:"zone-red"`

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -18,13 +18,15 @@ type User struct {
 	Devices       []*Device
 	Organizations []*Organization `gorm:"many2many:user_organizations"`
 	UserName      string
+	Invitations   []*Invitation
 }
 
 type UserJSON struct {
-	ID            string      `json:"id" example:"aa22666c-0f57-45cb-a449-16efecc04f2e"`
-	Devices       []uuid.UUID `json:"devices" example:"4902c991-3dd1-49a6-9f26-d82496c80aff"`
-	Organizations []uuid.UUID `json:"organizations" example:"94deb404-c4eb-4097-b59d-76b024ff7867"`
-	UserName      string      `json:"username" example:"admin"`
+	ID            string        `json:"id" example:"aa22666c-0f57-45cb-a449-16efecc04f2e"`
+	Devices       []uuid.UUID   `json:"devices" example:"4902c991-3dd1-49a6-9f26-d82496c80aff"`
+	Organizations []uuid.UUID   `json:"organizations" example:"94deb404-c4eb-4097-b59d-76b024ff7867"`
+	UserName      string        `json:"username" example:"admin"`
+	Invitations   []*Invitation `json:"invitations"`
 }
 
 func (u User) MarshalJSON() ([]byte, error) {
@@ -33,6 +35,7 @@ func (u User) MarshalJSON() ([]byte, error) {
 		Devices:       make([]uuid.UUID, 0),
 		Organizations: make([]uuid.UUID, 0),
 		UserName:      u.UserName,
+		Invitations:   make([]*Invitation, 0),
 	}
 	for _, device := range u.Devices {
 		user.Devices = append(user.Devices, device.ID)
@@ -40,6 +43,7 @@ func (u User) MarshalJSON() ([]byte, error) {
 	for _, org := range u.Organizations {
 		user.Organizations = append(user.Organizations, org.ID)
 	}
+	user.Invitations = append(user.Invitations, u.Invitations...)
 	return json.Marshal(user)
 }
 
@@ -49,6 +53,9 @@ func (u *User) BeforeCreate(tx *gorm.DB) error {
 	}
 	if u.Organizations == nil {
 		u.Organizations = make([]*Organization, 0)
+	}
+	if u.Invitations == nil {
+		u.Invitations = make([]*Invitation, 0)
 	}
 	return nil
 }

--- a/internal/routers/routers.go
+++ b/internal/routers/routers.go
@@ -75,6 +75,11 @@ func NewAPIRouter(
 		private.DELETE("/organizations/:organization", api.DeleteOrganization)
 		private.GET("/organizations/:organization/devices", api.ListDevicesInOrganization)
 		private.GET("/organizations/:organization/devices/:id", api.GetDeviceInOrganization)
+		private.GET("/organizations/:organization/users", api.ListUsersInOrganization)
+		// Invitations
+		private.POST("/invitations", api.CreateInvitation)
+		private.POST("/invitations/:invitation/accept", api.AcceptInvitation)
+		private.DELETE("/invitations/:invitation", api.DeleteInvitation)
 		// Devices
 		private.GET("/devices", api.ListDevices)
 		private.GET("/devices/:id", api.GetDevice)


### PR DESCRIPTION
This provides API endpoints that allow users to be invited into organizations. Support for this is gated behind the multi-organization feature. Client code has not been updated to deal with cases where a user is in > 1 organization.