### PR TITLE
docs: Complete removal of apex from docs

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,17 +1,17 @@
 # Deployment
 
-In order to follow our "Service First" guiding principle, we deploy Apex continuously as a service on [OperateFirst](https://operate-first.cloud) using GitOps.
+In order to follow our "Service First" guiding principle, we deploy Nexodus continuously as a service using GitOps.
 
 ## Kubernetes Manifests
 
 Our project is deployed to Kubernetes using [kustomize](https://kustomize.io/).
-This enables Apex to be easily adapted for different deployment scenarios.
+This enables Nexodus to be easily adapted for different deployment scenarios.
 
-The base apex manifests live in `./deploy/apex/base`, and we offer a number of overlays:
+The base nexodus manifests live in `./deploy/nexodus/base`, and we offer a number of overlays:
 
-- Local Development - `./deploy/apex/overlays/dev`
-- Operate First (QA) - `./deploy/apex/overlays/qa`
-- Operate First (Production) - `./deploy/apex/overlays/prod`
+- Local Development - `./deploy/nexodus/overlays/dev`
+- Operate First (QA) - `./deploy/nexodus/overlays/qa`
+- Operate First (Production) - `./deploy/nexodus/overlays/prod`
 
 ## Build Pipeline
 
@@ -22,14 +22,13 @@ On each merge to the `main` branch, the `deploy` workflow is triggered.
 This workflow:
 
 1. Builds container images and pushes them to quay.io
-1. Updates the image tags in `./deploy/apex/overlays/qa` and commits this change back to the repository
+1. Updates the image tags in `./deploy/nexodus/overlays/qa` and commits this change back to the repository
 
 This ensures that the desired state of our deployments is checked into git.
 
 ## Deployment Pipeline
 
-Deployment of Apex on OperateFirst is managed by [ArgoCD](https://argocd.operate-first.cloud/).
-The ArgoCD project configuration lives [here](https://github.com/operate-first/apps/blob/master/argocd/overlays/moc-infra/projects/apex.yaml), and our ArgoCD Application configuration lives [here](https://github.com/operate-first/apps/blob/master/argocd/overlays/moc-infra/applications/envs/moc/smaug/) in folders `apex` and `apex-*`.
+Deployment of Nexodus on OperateFirst is managed by ArgoCD.
 
 ArgoCD will watch this repository for changes and ensure that our deployment is up-to-date.
 It will prevent our application deviating from the desired state.

--- a/docs/design/database.md
+++ b/docs/design/database.md
@@ -118,7 +118,7 @@ Since a `User` is also an `Organization`, once someone has registered to Nexodus
 
 The device-onboarding flow is as follows:
 
-1. A User registers for Nexodus using a sign-up form on <https://apex-hosted.cloud>, with the option to use SSO from Google, Github, Facebook etc..
+1. A User registers for Nexodus using a sign-up form on <https://try.nexodus.io/>, with the option to use SSO from Google, Github, Facebook etc..
 1. User downloads and runs the Nexodus agent
 1. Nexodus agent does a `POST /device` to register the unique device with Nexodus for the user - it's onboarded into their personal organization.
 1. `GET /organization/$id/devices` is polled to retrieve the peer listing for a zone.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -18,10 +18,10 @@ kubectl create -k ./deploy/observability-operators/base
 kubectl wait --for=condition=Ready pods --all -n observability --timeout=300s
 ```
 
-Uncomment the commented lines in `./deploy/apex/overlays/dev/kustomization.yaml` then run:
+Uncomment the commented lines in `./deploy/nexodus/overlays/dev/kustomization.yaml` then run:
 
 ```console
-kubectl apply -k ./deploy/apex/overlays/dev
+kubectl apply -k ./deploy/nexodus/overlays/dev
 ```
 
 The dashboards for the services are available at:

--- a/docs/scenarios/kubernetes-edge.md
+++ b/docs/scenarios/kubernetes-edge.md
@@ -22,7 +22,7 @@ controller on the machine that is reachable from your Kubernetes and MicroShift 
 Once your Nexodus controller is set up, please get the CA certification from Nexodus's secret and keep it handy. You will need this CA cert for deploying the Nexodus agent and to access the Nexodus Controller UI.
 
 ```sh
-kubectl get secret -n apex apex-ca-key-pair -o json | jq -r '.data."ca.crt"'
+kubectl get secret -n nexodus nexodus-ca-key-pair -o json | jq -r '.data."ca.crt"'
 ```
 
 ## Deploying the Nexodus Relay Node
@@ -33,16 +33,16 @@ Please follow the instructions provided in the [README Nexodus Relay Section](..
 
 Please follow the [README Section](../README.md#deploying-on-kubernetes-managed-node) to deploy the Nexodus agent. It mainly requires two steps
 
-1. Set config data in `./deploy/apex-client/overlays/dev/kustomization.yaml` and deploy the Nexodus agent's manifest files
+1. Set config data in `./deploy/nexodus-client/overlays/dev/kustomization.yaml` and deploy the Nexodus agent's manifest files
 
    ```sh
-        kubectl apply -k ./deploy/apex-client/overlays/dev
+        kubectl apply -k ./deploy/nexodus-client/overlays/dev
     ```
 
 2. Tag the worker nodes that you want to join the Nexodus network.
 
     ```sh
-        kubectl label nodes <NODE_NAME> app.kubernetes.io/apex=
+        kubectl label nodes <NODE_NAME> app.kubernetes.io/nexodus=
     ```
 
     This will deploy the Nexodus agent pod on that node and onboard the node to the Nexodus network.
@@ -120,10 +120,10 @@ Request ID: 5648b07d658223aa8f488d9833cac06d
 ## Troubleshooting
 
 * Nexodus agent pod is not deployed even after tagging the MicroShift node.
-  * MicroShift security context doesn't allow deployment of privileged containers. You need to add security context policy to the `apex` service account to allow the deployment.
+  * MicroShift security context doesn't allow deployment of privileged containers. You need to add security context policy to the `nexodus` service account to allow the deployment.
   
   ```sh
-    sudo oc --kubeconfig /var/lib/microshift/resources/kubeadmin/kubeconfig adm policy add-scc-to-user -z apex -n apex privileged
+    sudo oc --kubeconfig /var/lib/microshift/resources/kubeadmin/kubeconfig adm policy add-scc-to-user -z nexodus -n nexodus privileged
   ```
 
 * You don't see wireguard interface `wg0` after Nexodus agent deployment in MicroShift node.


### PR DESCRIPTION
Update to reflect the changes inside of deploy/. In passing, also drop some references to running on operate-first, as we are no longer using that infrastructure.