### PR TITLE
Reset the nexodus stack after ec2 qa runs

### DIFF
--- a/.github/workflows/qa-ec2.yml
+++ b/.github/workflows/qa-ec2.yml
@@ -63,6 +63,11 @@ jobs:
       - name: Mesh Connectivity Results
         run: cat ./ops/ansible/aws/connectivity-results.txt
 
+      - name: Reset the Nexodus Stack
+        if: always()
+        run: |
+          ansible-playbook -vv ./ops/ansible/aws/recreate-api-db.yml -u ubuntu
+
       - name: Terminate EC2 Instances
         if: always()
         run: |

--- a/ops/ansible/aws/deploy-ec2.yml
+++ b/ops/ansible/aws/deploy-ec2.yml
@@ -8,13 +8,6 @@
   roles:
     - role: setup-ec2
 
-# Create a Zone
-#- hosts: relayNode
-#  vars_files:
-#    - vars.yml
-#  roles:
-#    - role: create-zone
-
 # Deploy and start the hub router
 - hosts: relayNode
   vars_files:

--- a/ops/ansible/aws/recreate-api-db.yml
+++ b/ops/ansible/aws/recreate-api-db.yml
@@ -1,0 +1,20 @@
+# Recreate the api-server db used in ec2-e2e
+- name: Define the api-server as read from Ansible vars
+  hosts: localhost
+  vars_files:
+    - vars.yml
+  tasks:
+    - name: add new host
+      add_host:
+        hostname: '{{ controller_address }}'
+        groups: controllerGroup
+
+- name: API server operations
+  hosts: all:controllerGroup
+  tasks:
+    - name: Reset the Nexodus Stack
+      shell: |
+        cd nexodus
+        kubectl delete -n nexodus deploy/apiserver postgrescluster/database deploy/ipam
+        kubectl apply -k deploy/nexodus/overlays/dev
+      ignore_errors: yes


### PR DESCRIPTION
- This allows for dispatching of ec2-qa without any manual interaction with the api-server. After the job completes the stack is reset for the next dispatch.