### PR TITLE
Adds ec2 e2e for relay nodes

### DIFF
--- a/ops/ansible/aws/deploy-ec2.yml
+++ b/ops/ansible/aws/deploy-ec2.yml
@@ -22,6 +22,13 @@
   roles:
     - role: deploy-mesh
 
+# Deploy and start the relay only agents
+- hosts: nexodusRelayNodes
+  vars_files:
+    - vars.yml
+  roles:
+    - role: deploy-mesh
+
 # Validate nodes by running a connectivity test from the spoke node for QA e2e deployment
 - hosts:  "{{ groups['nexodusNodes'][0] }}"
   vars_files:

--- a/ops/ansible/aws/deploy-mesh/tasks/main.yml
+++ b/ops/ansible/aws/deploy-mesh/tasks/main.yml
@@ -85,3 +85,14 @@
     --username '{{ nexodus_auth_uid }}' \
     --password '{{ nexodus_auth_password }}' \
     {{ nexodus_url }} > nexodus-logs.txt 2>&1 &
+  when: "'nexodusNodes' in group_names"
+
+- name: Attach the Relay Only Client to the Controller
+  become: yes
+  shell: |
+    nexd \
+    --username '{{ nexodus_auth_uid }}' \
+    --password '{{ nexodus_auth_password }}' \
+    --relay-only \
+    {{ nexodus_url }} > nexodus-logs.txt 2>&1 &
+  when: "'nexodusRelayNodes' in group_names"

--- a/ops/ansible/aws/inventory.txt
+++ b/ops/ansible/aws/inventory.txt
@@ -1,3 +1,5 @@
 [relayNode]
 
 [nexodusNodes]
+
+[nexodusRelayNodes]

--- a/ops/ansible/aws/setup-ec2/tasks/main.yml
+++ b/ops/ansible/aws/setup-ec2/tasks/main.yml
@@ -94,7 +94,7 @@
         cidr_ip: 0.0.0.0/0
       - proto: tcp
         ports:
-        - 22
+          - 22
         cidr_ip: 0.0.0.0/0
 
 - name: Launching EC2 Instances in VPC Green
@@ -175,6 +175,37 @@
     regexp: "nexodusNodes"
     line: "[nexodusNodes]\n{{ nodeIP['results'][item]['instances'][0]['public_ip_address']}} ansible_user={{ ansible_user }} ansible_connection=ssh node_name=nexodus-demo-red-node-{{ item+1 }}"
   loop: "{{ range(0, node_count_red | int) }}"
+
+- name: Launching Relay Only EC2 Instances in VPC Red
+  amazon.aws.ec2_instance:
+    name: "nexodus-demo-red-relay-node-{{ item+1 }}"
+    aws_region: "{{ aws_region }}"
+    key_name: "{{ aws_key_name }}"
+    instance_type: "{{ aws_instance_type }}"
+    image_id: "{{ aws_image_id }}"
+    security_group: "{{ secgroup_id_red }}"
+    volumes:
+      - device_name: /dev/sda1
+        ebs:
+          volume_size: 25
+          delete_on_termination: true
+          volume_type: standard
+    network:
+      assign_public_ip: true
+    subnet_id: "{{ aws_subnet_red }}"
+    tags:
+      NodeType: "{{ aws_nodetype_tag }}"
+    state: running
+    wait: true
+  register: nodeIP
+  loop: "{{ range(0, relay_node_count_red | int) }}"
+
+- name: Updating the node's public ip in inventory
+  lineinfile:
+    path: "{{ inventory_location }}"
+    regexp: "nexodusRelayNodes"
+    line: "[nexodusRelayNodes]\n{{ nodeIP['results'][item]['instances'][0]['public_ip_address']}} ansible_user={{ ansible_user }} ansible_connection=ssh node_name=nexodus-demo-red-relay-node-{{ item+1 }}"
+  loop: "{{ range(0, relay_node_count_red | int) }}"
 
 - name: Refresh inventory to ensure new instances exist in inventory
   meta: refresh_inventory

--- a/ops/ansible/aws/validate-connectivity/tasks/main.yml
+++ b/ops/ansible/aws/validate-connectivity/tasks/main.yml
@@ -6,7 +6,7 @@
 
 - name: Summarize spoke nodes + relay node for a connectivity range
   set_fact:
-    spoke_range_end: "{{ node_count_blue + node_count_red + node_count_green + 1 }}"
+    spoke_range_end: "{{ node_count_blue + node_count_red + node_count_green + relay_node_count_red + 1 }}"
 
 - name: Get the first 3 octets of the zone prefix
   shell: echo {{ nexodus_zone_prefix }} | head -c -6

--- a/ops/ansible/aws/vars.yml
+++ b/ops/ansible/aws/vars.yml
@@ -28,6 +28,9 @@ node_count_green: 2                         # the number of cluster nodes you wa
 vpc_id_green: vpc-0566e09aa71f553c1         # VPC id from your aws account
 aws_subnet_green: subnet-0f8a1403fde2af94e  # VPC subnet id from your aws account
 
+### Relay Client Node Details ###
+relay_node_count_red: 1                   # Number of relay client nodes
+
 ### Controller Section (values are there for example, replace with your environment) ###
 controller_address: <CONTROLLER_ADDRESS>
 nexodus_binary: https://nexodus-io.s3.amazonaws.com/nexodus-amd64-linux


### PR DESCRIPTION
- This adds relay testing for qa dispatch. It is a much more in depth infra and validation than what can be mocked up in CI for relay testing.
- This is dispatched from GH actions. Previous tests prior to this can be viewed in actions history, this adds additional nodes joined as --relay-only.