### PR TITLE
Promote job will run once deploy job triggers

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -16,7 +16,6 @@ env:
 jobs:
   update-prod:
     name: Update Production Deployment
-    needs: ["build-images"]
     runs-on: ubuntu-20.04
 
     steps:


### PR DESCRIPTION
the QA deployment and it is deployed successfully. Promote job will use the same image tags that is deployed by deploy job in QA deployment, so dependency on
build-images is not required