### PR TITLE
nexd: Don't dump a stacktrace if no url is provided

### DIFF
--- a/cmd/nexd/main.go
+++ b/cmd/nexd/main.go
@@ -126,7 +126,8 @@ func main() {
 
 			controller := cCtx.Args().First()
 			if controller == "" {
-				logger.Fatal("<controller-url> required")
+				logger.Info("<controller-url> required")
+				return nil
 			}
 
 			ctx, _ := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGQUIT, syscall.SIGINT)


### PR DESCRIPTION
Lack of the URL is not an error serious enough to dump a stack trace in the logs. Just dump an info message before exiting cleanly.