### PR TITLE
Switch to  mikefarah's github action to pull in

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: chrisdickinson/setup-yq@latest
+      - uses: mikefarah/yq@v4.31.2
 
       - name: Read Image SHAs from QA deployment
         id: gitsha


### PR DESCRIPTION
latest version of jq. Existing github action pulls very old version of jq and it throws following error

`Error: unknown command ".images[0].newTag" for "yq"`