### PR TITLE
Skip adding the relay node as a /32 peer

### DIFF
--- a/internal/nexodus/wg-peers.go
+++ b/internal/nexodus/wg-peers.go
@@ -133,7 +133,7 @@ func (ax *Nexodus) buildPeersConfig() {
 				value.PublicKey,
 				value.TunnelIP,
 				value.OrganizationID)
-		} else if !ax.symmetricNat && !value.SymmetricNat {
+		} else if !ax.symmetricNat && !value.SymmetricNat && !value.Relay {
 			// the bulk of the peers will be added here except for local address peers. Endpoint sockets added here are likely
 			// to be changed from the state discovered by the relay node if peering with nodes with NAT in between.
 			// if the node itself (ax.symmetricNat) or the peer (value.SymmetricNat) is a


### PR DESCRIPTION
- Commit prevents the relay node from adding a /32 entry since the relay node needs the full org prefix in the peer e.g. /16
- It is getting the /16 but throwing an error when it tries to add another further down in the method.