### PR TITLE
nexd: Stop including stack traces in logs

### DIFF
--- a/cmd/nexd/main.go
+++ b/cmd/nexd/main.go
@@ -30,7 +30,9 @@ func main() {
 		logger, err = zap.NewDevelopment()
 		logger.Info("Debug logging enabled")
 	} else {
-		logger, err = zap.NewProduction()
+		logCfg := zap.NewProductionConfig()
+		logCfg.DisableStacktrace = true
+		logger, err = logCfg.Build()
 	}
 	if err != nil {
 		logger.Fatal(err.Error())


### PR DESCRIPTION
In general, stack traces are not useful to users running nexd. Disable them in production mode. They will still be there when being run in debug mode.