### PR TITLE
gen-docs: Add job pre-reqs and pretty Makefile output

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,7 +82,7 @@ jobs:
           fi
 
   go-unit:
-    needs: go-lint
+    needs: [ go-lint, gen-docs ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -169,7 +169,7 @@ jobs:
           kubeconform -summary -output json -schema-location default -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json' -schema-location 'deploy/.crdSchemas/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json' kubeconfigs/
 
   build-images:
-    needs: go-lint
+    needs: [ go-lint, gen-docs ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -234,7 +234,7 @@ jobs:
           path: /tmp/test-ubuntu.tar
 
   build-binaries:
-    needs: go-lint
+    needs: [ go-lint, gen-docs ]
     strategy:
       fail-fast: false
       matrix:
@@ -304,7 +304,7 @@ jobs:
             ${{ steps.build-nexctl.outputs.artifact-name }}
 
   e2e:
-    needs: [go-lint, go-unit, k8s-lint, build-images]
+    needs: [go-lint, gen-docs, go-unit, k8s-lint, build-images]
     name: e2e-integration
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -442,7 +442,7 @@ jobs:
           aws s3 sync . s3://nexodus-io/
 
   build-rpm:
-    needs: ["go-lint"]
+    needs: [ go-lint, gen-docs ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/Makefile
+++ b/Makefile
@@ -9,9 +9,11 @@ help:
 ifeq ($(NOISY_BUILD),)
     ECHO_PREFIX=@
     CMD_PREFIX=@
+	SWAG_ARGS?=--quiet
 else
     ECHO_PREFIX=@\#
     CMD_PREFIX=
+	SWAG_ARGS?=
 endif
 
 NEXODUS_VERSION?=$(shell date +%Y.%m.%d)
@@ -108,7 +110,8 @@ ui-lint: ## Lint the UI source
 
 .PHONY: gen-docs
 gen-docs: ## Generate API docs
-	$(CMD_PREFIX) go run github.com/swaggo/swag/cmd/swag@v1.8.10 init -g ./cmd/apiserver/main.go -o ./internal/docs
+	$(ECHO_PREFIX) printf "  %-12s ./cmd/apiserver/main.go\n" "[API DOCS]"
+	$(CMD_PREFIX) go run github.com/swaggo/swag/cmd/swag@v1.8.10 init $(SWAG_ARGS) -g ./cmd/apiserver/main.go -o ./internal/docs
 
 .PHONY: e2e
 e2e: e2eprereqs test-images ## Run e2e tests


### PR DESCRIPTION
Add pretty output for running `make gen-docs`. Full output from the tool can be seen when you run with `NOISY_BUILD=y` like this:

    $ NOISY_BUILD=y make gen-docs

Also make some other jobs depend on the gen-docs job. It runs in 20% of the time of go-lint, so make jobs that depend on go-lint depend on this one too. If the docs are broken, don't waste time running all the more consuming jobs.