### PR TITLE
Add nexd logging to e2e

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@
 /*.key
 !Containerfile.test
 *.test
+integration-tests/tmp/
 
 # config
 .env.*

--- a/integration-tests/integration_test.go
+++ b/integration-tests/integration_test.go
@@ -42,6 +42,7 @@ func init() {
 		ipamDriver = "default"
 		hostDNSName = dockerKindGatewayIP()
 	}
+	_ = nexodus.CreateDirectory("tmp")
 }
 
 func dockerKindGatewayIP() string {

--- a/internal/nexodus/keys.go
+++ b/internal/nexodus/keys.go
@@ -97,8 +97,8 @@ func (ax *Nexodus) generateKeyPair(publicKeyFile, privateKeyFile string) error {
 	// TODO remove this debug statement at some point
 	ax.logger.Debugf("Public Key [ %s ] Private Key [ %s ]", ax.wireguardPubKey, ax.wireguardPvtKey)
 	// write the new keys to disk
-	writeToFile(ax.logger, ax.wireguardPubKey, publicKeyFile, publicKeyPermissions)
-	writeToFile(ax.logger, ax.wireguardPvtKey, privateKeyFile, privateKeyPermissions)
+	WriteToFile(ax.logger, ax.wireguardPubKey, publicKeyFile, publicKeyPermissions)
+	WriteToFile(ax.logger, ax.wireguardPvtKey, privateKeyFile, privateKeyPermissions)
 
 	return nil
 }

--- a/internal/nexodus/utils.go
+++ b/internal/nexodus/utils.go
@@ -158,28 +158,28 @@ func parseNetworkStr(cidr string) (string, error) {
 	return nw.String(), nil
 }
 
-// writeToFile overwrite the contents of a file
-func writeToFile(logger *zap.SugaredLogger, s, file string, filePermissions int) {
+// WriteToFile overwrite the contents of a file
+func WriteToFile(logger *zap.SugaredLogger, s, file string, filePermissions int) {
 	// overwrite the existing file contents
 	f, err := os.OpenFile(file, os.O_RDWR|os.O_CREATE|os.O_TRUNC, os.FileMode(filePermissions))
 	if err != nil {
-		logger.Warnf("Unable to open a key file to write to: %v", err)
+		logger.Warnf("Unable to open the file %s to write to: %v", file, err)
 	}
 
 	defer func(f *os.File) {
 		err = f.Close()
 		if err != nil {
-			logger.Warnf("Unable to write key to file [ %s ] %v", file, err)
+			logger.Warnf("Unable to write to file [ %s ] %v", file, err)
 		}
 	}(f)
 
 	wr := bufio.NewWriter(f)
 	_, err = wr.WriteString(s)
 	if err != nil {
-		logger.Warnf("Unable to write key to file [ %s ] %v", file, err)
+		logger.Warnf("Unable to write to file [ %s ] %v", file, err)
 	}
 	if err = wr.Flush(); err != nil {
-		logger.Warnf("Unable to write key to file [ %s ] %v", file, err)
+		logger.Warnf("Unable to write to file [ %s ] %v", file, err)
 	}
 }
 


### PR DESCRIPTION
- Commit creates a file with the nexd run options for each node, copies them to the node for execution and pipes logs to a file. The file is then picked up in gather for a dump in the case of a test failure for easier debugging.