### PR TITLE
feat: add --insecure-skip-tls-verify flag to the nexd cli tool

### DIFF
--- a/cmd/apiserver/main.go
+++ b/cmd/apiserver/main.go
@@ -53,6 +53,7 @@ func init() {
 
 // @BasePath  		/api
 func main() {
+	// Override to capitalize "Show"
 	cli.HelpFlag.(*cli.BoolFlag).Usage = "Show help"
 	app := &cli.App{
 		Name: "nexodus-controller",

--- a/cmd/apiserver/main.go
+++ b/cmd/apiserver/main.go
@@ -53,31 +53,32 @@ func init() {
 
 // @BasePath  		/api
 func main() {
+	cli.HelpFlag.(*cli.BoolFlag).Usage = "Show help"
 	app := &cli.App{
 		Name: "nexodus-controller",
 		Flags: []cli.Flag{
 			&cli.BoolFlag{
 				Name:    "debug",
 				Value:   false,
-				Usage:   "enable debug logging",
+				Usage:   "Enable debug logging",
 				EnvVars: []string{"NEXAPI_DEBUG"},
 			},
 			&cli.StringFlag{
 				Name:    "oidc-url",
 				Value:   "https://auth.try.nexodus.local",
-				Usage:   "address of oidc provider",
+				Usage:   "Address of oidc provider",
 				EnvVars: []string{"NEXAPI_OIDC_URL"},
 			},
 			&cli.StringFlag{
 				Name:    "oidc-backchannel-url",
 				Value:   "",
-				Usage:   "backend address of oidc provider",
+				Usage:   "Backend address of oidc provider",
 				EnvVars: []string{"NEXAPI_OIDC_BACKCHANNEL"},
 			},
 			&cli.BoolFlag{
 				Name:    "insecure-tls",
 				Value:   false,
-				Usage:   "trust any TLS certificate",
+				Usage:   "Trust any TLS certificate",
 				EnvVars: []string{"NEXAPI_INSECURE_TLS"},
 			},
 			&cli.StringFlag{
@@ -95,43 +96,43 @@ func main() {
 			&cli.StringFlag{
 				Name:    "db-host",
 				Value:   "apiserver-db",
-				Usage:   "db host",
+				Usage:   "Database host name",
 				EnvVars: []string{"NEXAPI_DB_HOST"},
 			},
 			&cli.StringFlag{
 				Name:    "db-port",
 				Value:   "5432",
-				Usage:   "db port",
+				Usage:   "Database port",
 				EnvVars: []string{"NEXAPI_DB_PORT"},
 			},
 			&cli.StringFlag{
 				Name:    "db-user",
 				Value:   "apiserver",
-				Usage:   "db user",
+				Usage:   "Database user",
 				EnvVars: []string{"NEXAPI_DB_USER"},
 			},
 			&cli.StringFlag{
 				Name:    "db-password",
 				Value:   "secret",
-				Usage:   "db password",
+				Usage:   "Database password",
 				EnvVars: []string{"NEXAPI_DB_PASSWORD"},
 			},
 			&cli.StringFlag{
 				Name:    "db-name",
 				Value:   "apiserver",
-				Usage:   "db name",
+				Usage:   "Database name",
 				EnvVars: []string{"NEXAPI_DB_NAME"},
 			},
 			&cli.StringFlag{
 				Name:    "db-sslmode",
 				Value:   "disable",
-				Usage:   "db ssl mode",
+				Usage:   "Database ssl mode",
 				EnvVars: []string{"NEXAPI_DB_SSLMODE"},
 			},
 			&cli.StringFlag{
 				Name:    "ipam-address",
 				Value:   "ipam:9090",
-				Usage:   "address of ipam grpc service",
+				Usage:   "Address of ipam grpc service",
 				EnvVars: []string{"NEXAPI_IPAM_URL"},
 			},
 			&cli.BoolFlag{
@@ -204,7 +205,7 @@ func main() {
 	}
 	app.Commands = append(app.Commands, &cli.Command{
 		Name:  "rollback",
-		Usage: "rollback the last database migration",
+		Usage: "Rollback the last database migration",
 		Action: func(cCtx *cli.Context) error {
 			ctx := cCtx.Context
 			withLoggerAndDB(ctx, cCtx, func(logger *zap.Logger, db *gorm.DB) {

--- a/cmd/nexctl/main.go
+++ b/cmd/nexctl/main.go
@@ -23,6 +23,7 @@ const (
 var Version = "dev"
 
 func main() {
+	// Override usage to capitalize "Show"
 	cli.HelpFlag.(*cli.BoolFlag).Usage = "Show help"
 	app := &cli.App{
 		Name: "nexctl",

--- a/cmd/nexctl/main.go
+++ b/cmd/nexctl/main.go
@@ -23,33 +23,34 @@ const (
 var Version = "dev"
 
 func main() {
+	cli.HelpFlag.(*cli.BoolFlag).Usage = "Show help"
 	app := &cli.App{
 		Name: "nexctl",
 		Flags: []cli.Flag{
 			&cli.BoolFlag{
 				Name:    "debug",
 				Value:   false,
-				Usage:   "enable debug logging",
+				Usage:   "Enable debug logging",
 				EnvVars: []string{"NEXCTL_DEBUG"},
 			},
 			&cli.StringFlag{
 				Name:  "host",
 				Value: "https://api.try.nexodus.local",
-				Usage: "api server",
+				Usage: "Api server URL",
 			},
 			&cli.StringFlag{
 				Name:  "username",
-				Usage: "username",
+				Usage: "Username",
 			},
 			&cli.StringFlag{
 				Name:  "password",
-				Usage: "password",
+				Usage: "Password",
 			},
 			&cli.StringFlag{
 				Name:     "output",
 				Value:    encodeColumn,
 				Required: false,
-				Usage:    "output format: json, json-raw, no-header, column (default columns)",
+				Usage:    "Output format: json, json-raw, no-header, column (default columns)",
 			},
 		},
 		Commands: []*cli.Command{
@@ -63,27 +64,27 @@ func main() {
 			},
 			{
 				Name:  "nexd",
-				Usage: "commands for interacting with the local instance of nexd",
+				Usage: "Commands for interacting with the local instance of nexd",
 				Subcommands: []*cli.Command{
 					{
 						Name:   "version",
-						Usage:  "nexd version",
+						Usage:  "Display the nexd version",
 						Action: cmdLocalVersion,
 					},
 					{
 						Name:   "status",
-						Usage:  "nexd status",
+						Usage:  "Display the nexd status",
 						Action: cmdLocalStatus,
 					},
 				},
 			},
 			{
 				Name:  "organization",
-				Usage: "commands relating to organizations",
+				Usage: "Commands relating to organizations",
 				Subcommands: []*cli.Command{
 					{
 						Name:  "list",
-						Usage: "list organizations",
+						Usage: "List organizations",
 						Action: func(cCtx *cli.Context) error {
 							c, err := client.NewClient(cCtx.Context,
 								cCtx.String("host"), nil,
@@ -101,7 +102,7 @@ func main() {
 					},
 					{
 						Name:  "create",
-						Usage: "create a organizations",
+						Usage: "Create a organizations",
 						Flags: []cli.Flag{
 							&cli.StringFlag{
 								Name:     "name",
@@ -141,7 +142,7 @@ func main() {
 					},
 					{
 						Name:  "delete",
-						Usage: "delete a organization",
+						Usage: "Delete a organization",
 						Flags: []cli.Flag{
 							&cli.StringFlag{
 								Name:     "organization-id",
@@ -168,11 +169,11 @@ func main() {
 			},
 			{
 				Name:  "device",
-				Usage: "commands relating to devices",
+				Usage: "Commands relating to devices",
 				Subcommands: []*cli.Command{
 					{
 						Name:  "list",
-						Usage: "list all devices",
+						Usage: "List all devices",
 						Flags: []cli.Flag{
 							&cli.StringFlag{
 								Name:     "organization-id",
@@ -206,7 +207,7 @@ func main() {
 					},
 					{
 						Name:  "delete",
-						Usage: "delete a device",
+						Usage: "Delete a device",
 						Flags: []cli.Flag{
 							&cli.StringFlag{
 								Name:     "device-id",
@@ -233,11 +234,11 @@ func main() {
 			},
 			{
 				Name:  "user",
-				Usage: "commands relating to users",
+				Usage: "Commands relating to users",
 				Subcommands: []*cli.Command{
 					{
 						Name:  "list",
-						Usage: "list all users",
+						Usage: "List all users",
 						Action: func(cCtx *cli.Context) error {
 							c, err := client.NewClient(cCtx.Context,
 								cCtx.String("host"), nil,
@@ -255,7 +256,7 @@ func main() {
 					},
 					{
 						Name:  "get-current",
-						Usage: "get current user",
+						Usage: "Get current user",
 						Action: func(cCtx *cli.Context) error {
 							c, err := client.NewClient(cCtx.Context,
 								cCtx.String("host"), nil,
@@ -273,7 +274,7 @@ func main() {
 					},
 					{
 						Name:  "delete",
-						Usage: "delete a user",
+						Usage: "Delete a user",
 						Flags: []cli.Flag{
 							&cli.StringFlag{
 								Name:     "user-id",

--- a/cmd/nexd/main.go
+++ b/cmd/nexd/main.go
@@ -38,6 +38,7 @@ func main() {
 		logger.Fatal(err.Error())
 	}
 
+	cli.HelpFlag.(*cli.BoolFlag).Usage = "Show help"
 	// flags are stored in the global flags variable
 	app := &cli.App{
 		Name:  "nexd",
@@ -46,58 +47,61 @@ func main() {
 			&cli.StringFlag{
 				Name:     "public-key",
 				Value:    "",
-				Usage:    "public key for the local host - agent generates keys by default",
+				Usage:    "Public key for the local host - agent generates keys by default",
 				EnvVars:  []string{"NEXD_PUB_KEY"},
 				Required: false,
 			},
 			&cli.StringFlag{
 				Name:     "private-key",
 				Value:    "",
-				Usage:    "private key for the local host (dev purposes only - soon to be removed)",
+				Usage:    "Private key for the local host (dev purposes only - soon to be removed)",
 				EnvVars:  []string{"NEXD_PRIVATE_KEY"},
 				Required: false,
 			},
 			&cli.IntFlag{
 				Name:     "listen-port",
 				Value:    0,
-				Usage:    "port wireguard is to listen for incoming peers on",
+				Usage:    "Port wireguard is to listen for incoming peers on",
 				EnvVars:  []string{"NEXD_LISTEN_PORT"},
 				Required: false,
 			},
 			&cli.StringFlag{
 				Name:     "request-ip",
 				Value:    "",
-				Usage:    "request a specific IP address from Ipam if available (optional)",
+				Usage:    "Request a specific IP address from Ipam if available (optional)",
 				EnvVars:  []string{"NEXD_REQUESTED_IP"},
 				Required: false,
 			},
 			&cli.StringFlag{
 				Name:     "local-endpoint-ip",
 				Value:    "",
-				Usage:    "specify the endpoint address of this node instead of being discovered (optional)",
+				Usage:    "Specify the endpoint address of this node instead of being discovered (optional)",
 				EnvVars:  []string{"NEXD_LOCAL_ENDPOINT_IP"},
 				Required: false,
 			},
 			&cli.StringSliceFlag{
 				Name:     "child-prefix",
-				Usage:    "request a CIDR range of addresses that will be advertised from this node (optional)",
+				Usage:    "Request a CIDR range of addresses that will be advertised from this node (optional)",
 				EnvVars:  []string{"NEXD_REQUESTED_CHILD_PREFIX"},
 				Required: false,
 			},
-			&cli.BoolFlag{Name: "stun",
-				Usage:    "discover the public address for this host using STUN",
+			&cli.BoolFlag{
+				Name:     "stun",
+				Usage:    "Discover the public address for this host using STUN",
 				Value:    false,
 				EnvVars:  []string{"NEXD_STUN"},
 				Required: false,
 			},
-			&cli.BoolFlag{Name: "hub-router",
-				Usage:    "set if this node is to be the hub in a hub and spoke deployment",
+			&cli.BoolFlag{
+				Name:     "hub-router",
+				Usage:    "Set if this node is to be the hub in a hub and spoke deployment",
 				Value:    false,
 				EnvVars:  []string{"NEXD_HUB_ROUTER"},
 				Required: false,
 			},
-			&cli.BoolFlag{Name: "relay-only",
-				Usage:    "set if this node is unable to NAT hole punch in a hub zone (Nexodus will set this automatically if symmetric NAT is detected)",
+			&cli.BoolFlag{
+				Name:     "relay-only",
+				Usage:    "Set if this node is unable to NAT hole punch in a hub zone (Nexodus will set this automatically if symmetric NAT is detected)",
 				Value:    false,
 				EnvVars:  []string{"NEXD_RELAY_ONLY"},
 				Required: false,
@@ -105,15 +109,22 @@ func main() {
 			&cli.StringFlag{
 				Name:     "username",
 				Value:    "",
-				Usage:    "username for accessing the nexodus service",
+				Usage:    "Username for accessing the nexodus service",
 				EnvVars:  []string{"NEXD_USERNAME"},
 				Required: false,
 			},
 			&cli.StringFlag{
 				Name:     "password",
 				Value:    "",
-				Usage:    "password for accessing the nexodus service",
+				Usage:    "Password for accessing the nexodus service",
 				EnvVars:  []string{"NEXD_PASSWORD"},
+				Required: false,
+			},
+			&cli.BoolFlag{
+				Name:     "insecure-skip-tls-verify",
+				Value:    false,
+				Usage:    "If true, server certificates will not be checked for validity. This will make your HTTPS connections insecure",
+				EnvVars:  []string{"APEX_INSECURE_SKIP_TLS_VERIFY"},
 				Required: false,
 			},
 		},
@@ -149,6 +160,7 @@ func main() {
 				cCtx.Bool("stun"),
 				cCtx.Bool("hub-router"),
 				cCtx.Bool("relay-only"),
+				cCtx.Bool("insecure-skip-tls-verify"),
 				Version,
 			)
 			if err != nil {

--- a/cmd/nexd/main.go
+++ b/cmd/nexd/main.go
@@ -38,6 +38,7 @@ func main() {
 		logger.Fatal(err.Error())
 	}
 
+	// Overwrite usage to capitalize "Show"
 	cli.HelpFlag.(*cli.BoolFlag).Usage = "Show help"
 	// flags are stored in the global flags variable
 	app := &cli.App{

--- a/internal/client/auth.go
+++ b/internal/client/auth.go
@@ -58,10 +58,10 @@ func newDeviceFlowToken(ctx context.Context, deviceEndpoint, tokenEndpoint, clie
 	return token, idToken, nil
 }
 
-func startLogin(hostname url.URL) (*agent.DeviceStartReponse, error) {
+func startLogin(client *http.Client, hostname url.URL) (*agent.DeviceStartReponse, error) {
 	dest := hostname
 	dest.Path = "/login/start"
-	res, err := http.Post(dest.String(), "application/json", nil)
+	res, err := client.Post(dest.String(), "application/json", nil)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -44,7 +44,13 @@ func NewClient(ctx context.Context, addr string, authcb func(string), options ..
 		c.logger = l.Sugar()
 	}
 
-	resp, err := startLogin(*baseURL)
+	httpClient := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: opts.tlsConfig,
+		},
+	}
+
+	resp, err := startLogin(httpClient, *baseURL)
 	if err != nil {
 		return nil, err
 	}
@@ -91,6 +97,7 @@ func NewClient(ctx context.Context, addr string, authcb func(string), options ..
 		return nil, err
 	}
 
+	ctx = context.WithValue(ctx, oauth2.HTTPClient, httpClient)
 	c.client = config.Client(ctx, token)
 
 	return &c, nil

--- a/internal/client/options.go
+++ b/internal/client/options.go
@@ -1,6 +1,9 @@
 package client
 
-import "go.uber.org/zap"
+import (
+	"crypto/tls"
+	"go.uber.org/zap"
+)
 
 type options struct {
 	deviceFlow   bool
@@ -8,6 +11,7 @@ type options struct {
 	username     string
 	password     string
 	logger       *zap.SugaredLogger
+	tlsConfig    *tls.Config
 }
 
 func newOptions(opts ...Option) (*options, error) {
@@ -30,6 +34,15 @@ func WithPasswordGrant(
 		o.deviceFlow = false
 		o.username = username
 		o.password = password
+		return nil
+	}
+}
+
+func WithTLSConfig(
+	config *tls.Config,
+) Option {
+	return func(o *options) error {
+		o.tlsConfig = config
 		return nil
 	}
 }


### PR DESCRIPTION
add --insecure-skip-tls-verify flag to the nexd cli tool.  This can be handy if your testing against a nexodus server that is using self signed certs and your device has not installed those certs into the system certs.

chore: Uppercase first letter of all flag Usage to be consistent with how other tools like git and kubectl show help.