### PR TITLE
Add endpoint delete for user removal from an org #439

### DIFF
--- a/cmd/nexctl/main.go
+++ b/cmd/nexctl/main.go
@@ -298,6 +298,36 @@ func main() {
 							return deleteUser(c, encodeOut, userID)
 						},
 					},
+					{
+						Name:  "remove-user",
+						Usage: "Remove a user from an organization",
+						Flags: []cli.Flag{
+							&cli.StringFlag{
+								Name:     "user-id",
+								Required: true,
+							},
+							&cli.StringFlag{
+								Name:     "organization-id",
+								Required: true,
+							},
+						},
+						Action: func(cCtx *cli.Context) error {
+							c, err := client.NewClient(cCtx.Context,
+								cCtx.String("host"), nil,
+								client.WithPasswordGrant(
+									cCtx.String("username"),
+									cCtx.String("password"),
+								),
+							)
+							if err != nil {
+								log.Fatal(err)
+							}
+							encodeOut := cCtx.String("output")
+							userID := cCtx.String("user-id")
+							orgID := cCtx.String("organization-id")
+							return deleteUserFromOrg(c, encodeOut, userID, orgID)
+						},
+					},
 				},
 			},
 		},

--- a/cmd/nexctl/user.go
+++ b/cmd/nexctl/user.go
@@ -61,6 +61,25 @@ func deleteUser(c *client.Client, encodeOut, userID string) error {
 	return nil
 }
 
+func deleteUserFromOrg(c *client.Client, encodeOut, userID, orgID string) error {
+	res, err := c.DeleteUserFromOrganization(userID, orgID)
+	if err != nil {
+		log.Fatalf("user removal failed: %v\n", err)
+	}
+
+	if encodeOut == encodeColumn || encodeOut == encodeNoHeader {
+		fmt.Printf("successfully removed user %s from organization %s\n", userID, orgID)
+		return nil
+	}
+
+	err = FormatOutput(encodeOut, res)
+	if err != nil {
+		log.Fatalf("failed to print output: %v", err)
+	}
+
+	return nil
+}
+
 func getCurrent(c *client.Client, encodeOut string) error {
 	user, err := c.GetCurrentUser()
 	if err != nil {

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-gormigrate/gormigrate/v2"
 	"github.com/nexodus-io/nexodus/internal/database/migration_20230113_0000"
 	"github.com/nexodus-io/nexodus/internal/database/migration_20230126_0000"
+	"github.com/nexodus-io/nexodus/internal/database/migration_20230314_0000"
 	"github.com/nexodus-io/nexodus/internal/database/migrations"
 	"github.com/uptrace/opentelemetry-go-extra/otelgorm"
 	"go.opentelemetry.io/otel"
@@ -84,6 +85,7 @@ func Migrations() *migrations.Migrations {
 		Migrations: []*gormigrate.Migration{
 			migration_20230113_0000.Migrate(),
 			migration_20230126_0000.Migrate(),
+			migration_20230314_0000.Migrate(),
 		},
 	}
 }

--- a/internal/database/migration_20230314_0000/20230314-0000.go
+++ b/internal/database/migration_20230314_0000/20230314-0000.go
@@ -1,0 +1,68 @@
+package migration_20230314_0000
+
+import (
+	"time"
+
+	"github.com/go-gormigrate/gormigrate/v2"
+	"github.com/google/uuid"
+	"github.com/lib/pq"
+	"github.com/nexodus-io/nexodus/internal/database/migrations"
+)
+
+// Base contains common columns for all tables.
+type Base struct {
+	ID        uuid.UUID  `gorm:"type:uuid;primary_key;" json:"id" example:"aa22666c-0f57-45cb-a449-16efecc04f2e"`
+	CreatedAt time.Time  `json:"-"`
+	UpdatedAt time.Time  `json:"-"`
+	DeletedAt *time.Time `sql:"index" json:"-"`
+}
+
+// Device is a unique, end-user device.
+// Devices belong to one User and may be onboarded into an organization
+type Device struct {
+	Base
+	UserID                   string
+	OrganizationID           uuid.UUID
+	PublicKey                string
+	LocalIP                  string
+	AllowedIPs               pq.StringArray `gorm:"type:text[]"`
+	TunnelIP                 string
+	ChildPrefix              pq.StringArray `gorm:"type:text[]"`
+	Relay                    bool
+	OrganizationPrefix       string
+	ReflexiveIPv4            string
+	EndpointLocalAddressIPv4 string
+	SymmetricNat             bool
+	Hostname                 string
+}
+
+// Organization contains Users and their Devices
+type Organization struct {
+	Base
+	Users       []*User `gorm:"many2many:user_organizations;"`
+	Devices     []*Device
+	Name        string
+	Description string
+	IpCidr      string
+	HubZone     bool
+}
+
+// User is a person who uses Nexodus
+type User struct {
+	// Since the ID comes from the IDP, we have no control over the format...
+	ID            string `gorm:"primary_key;" json:"id" example:"aa22666c-0f57-45cb-a449-16efecc04f2e"`
+	CreatedAt     time.Time
+	UpdatedAt     time.Time
+	DeletedAt     *time.Time `sql:"index" json:"-"`
+	Devices       []*Device
+	Organizations []*Organization `gorm:"many2many:user_organizations"`
+	UserName      string
+}
+
+func Migrate() *gormigrate.Migration {
+	migrationId := "20230314-0000"
+	return migrations.CreateMigrationFromActions(migrationId,
+		// ALTER user_organization to a pluralized table name user_organizations
+		migrations.RenameTableAction("user_organization", "user_organizations"),
+	)
+}

--- a/internal/docs/docs.go
+++ b/internal/docs/docs.go
@@ -311,7 +311,7 @@ const docTemplate = `{
                 "tags": [
                     "Organization"
                 ],
-                "summary": "Create a Organization",
+                "summary": "Create an Organization",
                 "parameters": [
                     {
                         "description": "Add Organization",
@@ -664,6 +664,54 @@ const docTemplate = `{
                 "responses": {
                     "200": {
                         "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.User"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/models.BaseError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/models.BaseError"
+                        }
+                    }
+                }
+            }
+        },
+        "/users/{id}/organizations/{organization}": {
+            "delete": {
+                "description": "Deletes an existing organization associated to a user",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "User"
+                ],
+                "summary": "Remove a User from an Organization",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "User ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Organization ID",
+                        "name": "organization",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content",
                         "schema": {
                             "$ref": "#/definitions/models.User"
                         }

--- a/internal/docs/swagger.json
+++ b/internal/docs/swagger.json
@@ -304,7 +304,7 @@
                 "tags": [
                     "Organization"
                 ],
-                "summary": "Create a Organization",
+                "summary": "Create an Organization",
                 "parameters": [
                     {
                         "description": "Add Organization",
@@ -657,6 +657,54 @@
                 "responses": {
                     "200": {
                         "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.User"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/models.BaseError"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/models.BaseError"
+                        }
+                    }
+                }
+            }
+        },
+        "/users/{id}/organizations/{organization}": {
+            "delete": {
+                "description": "Deletes an existing organization associated to a user",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "User"
+                ],
+                "summary": "Remove a User from an Organization",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "User ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Organization ID",
+                        "name": "organization",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content",
                         "schema": {
                             "$ref": "#/definitions/models.User"
                         }

--- a/internal/docs/swagger.yaml
+++ b/internal/docs/swagger.yaml
@@ -356,7 +356,7 @@ paths:
           description: Internal Server Error
           schema:
             $ref: '#/definitions/models.BaseError'
-      summary: Create a Organization
+      summary: Create an Organization
       tags:
       - Organization
   /organizations/{id}:
@@ -573,6 +573,38 @@ paths:
           schema:
             $ref: '#/definitions/models.BaseError'
       summary: Get User
+      tags:
+      - User
+  /users/{id}/organizations/{organization}:
+    delete:
+      description: Deletes an existing organization associated to a user
+      parameters:
+      - description: User ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Organization ID
+        in: path
+        name: organization
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: No Content
+          schema:
+            $ref: '#/definitions/models.User'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/models.BaseError'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/models.BaseError'
+      summary: Remove a User from an Organization
       tags:
       - User
 securityDefinitions:

--- a/internal/handlers/device.go
+++ b/internal/handlers/device.go
@@ -18,6 +18,7 @@ var (
 	errUserOrOrgNotFound = errors.New("user or organization not found")
 	errUserNotFound      = errors.New("user not found")
 	errDeviceNotFound    = errors.New("device not found")
+	errOrgNotFound       = errors.New("organization not found")
 )
 
 type errDuplicateDevice struct {
@@ -213,8 +214,8 @@ func (api *API) CreateDevice(c *gin.Context) {
 
 		var org models.Organization
 		if res := tx.Model(&org).
-			Joins("inner join user_organization on user_organization.organization_id=organizations.id").
-			Where("user_organization.user_id=? AND organizations.id=?", userId, request.OrganizationID).
+			Joins("inner join user_organizations on user_organizations.organization_id=organizations.id").
+			Where("user_organizations.user_id=? AND organizations.id=?", userId, request.OrganizationID).
 			First(&org); res.Error != nil {
 			return errUserOrOrgNotFound
 		}

--- a/internal/handlers/handlers_test.go
+++ b/internal/handlers/handlers_test.go
@@ -67,7 +67,7 @@ func (suite *HandlerTestSuite) SetupSuite() {
 func (suite *HandlerTestSuite) BeforeTest(_, _ string) {
 	suite.api.db.Exec("DELETE FROM users")
 	suite.api.db.Exec("DELETE FROM organizations")
-	suite.api.db.Exec("DELETE FROM user_organization")
+	suite.api.db.Exec("DELETE FROM user_organizations")
 	suite.api.db.Exec("DELETE FROM devices")
 	var err error
 	suite.testOrganizationID, err = suite.api.createUserIfNotExists(context.Background(), TestUserID, "testuser")

--- a/internal/models/organization.go
+++ b/internal/models/organization.go
@@ -10,7 +10,7 @@ import (
 // Organization contains Users and their Devices
 type Organization struct {
 	Base
-	Users       []*User `gorm:"many2many:user_organization;"`
+	Users       []*User `gorm:"many2many:user_organizations;"`
 	Devices     []*Device
 	Name        string `gorm:"uniqueIndex"`
 	Description string

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -16,7 +16,7 @@ type User struct {
 	UpdatedAt     time.Time
 	DeletedAt     *time.Time `sql:"index" json:"-"`
 	Devices       []*Device
-	Organizations []*Organization `gorm:"many2many:user_organization"`
+	Organizations []*Organization `gorm:"many2many:user_organizations"`
 	UserName      string
 }
 

--- a/internal/routers/routers.go
+++ b/internal/routers/routers.go
@@ -111,6 +111,7 @@ func NewAPIRouter(
 		private.GET("/users", api.ListUsers)
 		// private.PATCH("/users/:id", api.PatchUser)
 		private.DELETE("/users/:id", api.DeleteUser)
+		private.DELETE("/users/:id/organizations/:organization", api.DeleteUserFromOrganization)
 		// Feature Flags
 		private.GET("fflags", api.ListFeatureFlags)
 		private.GET("fflags/:name", api.GetFeatureFlag)


### PR DESCRIPTION
- Adds an endopint to remove a user from an organization and the associated nexctl cli operations. See comments for sample output.
- Changes the name of the db table user_organization to user_organizations to adhere to gorm's pluralizing of structs to snake_case for operations on that table.
- Enables orgDeletes and userDeletes by adding the clause.Associations deletes that remove the associations in user_organizations.