### PR TITLE
Remove go routines from nexd launch in e2e

### DIFF
--- a/integration-tests/util_test.go
+++ b/integration-tests/util_test.go
@@ -8,8 +8,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/Nerzal/gocloak/v13"
-	"github.com/google/uuid"
 	"io"
 	"net"
 	"os"
@@ -20,12 +18,13 @@ import (
 	"time"
 	"unicode"
 
+	"github.com/Nerzal/gocloak/v13"
 	"github.com/cenkalti/backoff/v4"
 	"github.com/docker/docker/api/types/network"
+	"github.com/google/uuid"
 	"github.com/nexodus-io/nexodus/internal/client"
 	"github.com/nexodus-io/nexodus/internal/nexodus"
 	"github.com/nexodus-io/nexodus/internal/util"
-
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
 )
@@ -268,7 +267,7 @@ func (suite *NexodusIntegrationSuite) runNexd(ctx context.Context, node testcont
 	cmd := []string{"/bin/nexd"}
 	cmd = append(cmd, args...)
 	cmd = append(cmd, "https://try.nexodus.local")
-	cmd = append(cmd, ">> /nexd.logs 2>&1")
+	cmd = append(cmd, ">> /nexd.logs 2>&1 &")
 
 	// write the nexd run command to a local file
 	nexodus.WriteToFile(suite.logger, strings.Join(cmd, " "), runScriptLocal, 0755)


### PR DESCRIPTION
- Now that we launch from a file for easier log piping we can remove the groutines.
- Fixed a teardown issue of a container in the TestRelay test.
- Bumped context timers for tshooting parallel tests.