### PR TITLE
Add a check for existing relay in the nexd agent

### DIFF
--- a/cmd/nexctl/device.go
+++ b/cmd/nexctl/device.go
@@ -15,12 +15,12 @@ func listOrgDevices(c *client.Client, organizationID uuid.UUID, encodeOut string
 	}
 	if encodeOut == encodeColumn || encodeOut == encodeNoHeader {
 		w := newTabWriter()
-		fs := "%s\t%s\t%s\t%s\t%s\t%s\n"
+		fs := "%s\t%s\t%s\t%s\t%s\t%s\t%s\n"
 		if encodeOut != encodeNoHeader {
-			fmt.Fprintf(w, fs, "DEVICE ID", "HOSTNAME", "NODE ADDRESS", "ENDPOINT IP", "PUBLIC KEY", "ZONE ID")
+			fmt.Fprintf(w, fs, "DEVICE ID", "HOSTNAME", "NODE ADDRESS", "ENDPOINT IP", "PUBLIC KEY", "ORGANIZATION ID", "RELAY")
 		}
 		for _, dev := range devices {
-			fmt.Fprintf(w, fs, dev.ID, dev.Hostname, dev.TunnelIP, dev.LocalIP, dev.PublicKey, dev.OrganizationID)
+			fmt.Fprintf(w, fs, dev.ID, dev.Hostname, dev.TunnelIP, dev.LocalIP, dev.PublicKey, dev.OrganizationID, fmt.Sprintf("%t", dev.Relay))
 		}
 		w.Flush()
 
@@ -42,16 +42,16 @@ func listAllDevices(c *client.Client, encodeOut string) error {
 	}
 	if encodeOut == encodeColumn || encodeOut == encodeNoHeader {
 		w := newTabWriter()
-		fs := "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n"
+		fs := "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n"
 		if encodeOut != encodeNoHeader {
 			fmt.Fprintf(w, fs, "DEVICE ID", "HOSTNAME", "NODE ADDRESS", "ENDPOINT IP", "PUBLIC KEY", "ORGANIZATION ID",
 				"LOCAL IP", "ALLOWED IPS", "TUNNEL IP", "CHILD PREFIX", "ORGANIZATION PREFIX", "REFLEXIVE IPv4",
-				"ENDPOINT LOCAL IPv4")
+				"ENDPOINT LOCAL IPv4", "RELAY")
 		}
 		for _, dev := range devices {
 			fmt.Fprintf(w, fs, dev.ID, dev.Hostname, dev.TunnelIP, dev.LocalIP, dev.PublicKey, dev.OrganizationID,
 				dev.LocalIP, dev.AllowedIPs, dev.TunnelIP, dev.ChildPrefix, dev.OrganizationPrefix, dev.ReflexiveIPv4,
-				dev.EndpointLocalAddressIPv4)
+				dev.EndpointLocalAddressIPv4, fmt.Sprintf("%t", dev.Relay))
 		}
 		w.Flush()
 

--- a/ui/src/pages/Devices.tsx
+++ b/ui/src/pages/Devices.tsx
@@ -64,6 +64,7 @@ export const DeviceShow = () => (
       <TextField label="Tunnel IP" source="tunnel_ip" />
       <TextField label="Local IP" source="local_ip" />
       <TextField label="Organization Prefix" source="organization_prefix" />
+      <TextField label="Relay Node" source="relay" />
       <ReferenceField
         label="User"
         source="user_id"


### PR DESCRIPTION
- This adds a check prior to a node joining an organization as a relay node to verify there isn't an existing one already in the database. If there is an existing relay, the agent exits with instructions to delete the device ID in order to join as a relay for the organization. Currently if two nodes join as a relay it is not handled and becomes a free for all as to which relay a node will add a tunnel with the org prefix.
- Also adds a device relay field to nexctl and the UI.