### PR TITLE
make: Fix parallel make

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,3 +1,5 @@
+run:
+  allow-parallel-runners: true
 linters:
   enable:
     - gosec


### PR DESCRIPTION
Running `make -j all` can speed things up a bit, but it broke on golangci-lint. It is configured by default to not allow parallel runs of this tool because it does its own concurrency (number of CPUs by default).

This configuration results in up to 3x NumCPUs of workers run by golangci-lint, but it's still faster overall.

It should be possible to tell make to run just the go-lint targets serially while allowing the rest to run in parallel, but I wasn't able to get it to work. .WAIT is a feature of gnu make 4.4 which is too new to depend on. I couldn't get .NONPARALLEL to work, but I'm sure that was my mistake and I just didn't spend enough time debugging. The docs for anyone interested are here:

https://www.gnu.org/software/make/manual/html_node/Parallel-Disable.html