### PR TITLE
Makefile: drop go vet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,10 +95,6 @@ go-lint-%: go-lint-prereqs $(NEXD_DEPS) $(NEXCTL_DEPS) $(APISERVER_DEPS)
 	$(CMD_PREFIX) CGO_ENABLED=0 GOOS=$(word 3,$(subst -, ,$(basename $@))) GOARCH=amd64 \
 		golangci-lint run --timeout 5m ./...
 
-	$(ECHO_PREFIX) printf "  %-12s GOOS=$(word 3,$(subst -, ,$(basename $@)))\n" "[GO VET]"
-	$(CMD_PREFIX) CGO_ENABLED=0 GOOS=$(word 3,$(subst -, ,$(basename $@))) GOARCH=amd64 \
-		go vet ./...
-
 .PHONY: yaml-lint
 yaml-lint: ## Lint the yaml files
 	$(CMD_PREFIX) if ! which yamllint >/dev/null 2>&1; then \


### PR DESCRIPTION
This isn't needed since golangci-lint already runs this by default.

You can check which linters are used if you run the tool manually with the verbose flag, `-v`.

```
$ golangci-lint run -v ./...
...
INFO [lintersdb] Active 9 linters: [errcheck errorlint gosec gosimple govet ineffassign staticcheck typecheck unused]
...
```