### PR TITLE
Fix: the latest envoy change breaks the cucumber test.

### DIFF
--- a/integration-tests/feature-flags-api.feature
+++ b/integration-tests/feature-flags-api.feature
@@ -21,4 +21,5 @@ Feature: Feature Flags API
     Then the response code should be 401
     And the response should match:
       """
+      Jwt is missing
       """


### PR DESCRIPTION
Seems we send slightly different 401 responses.  We should likely give 401’s a json body to be more consistent with other errors our API has.