### PR TITLE
Makefile: Add NEXODUS_GCFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ endif
 NEXODUS_VERSION?=$(shell date +%Y.%m.%d)
 NEXODUS_RELEASE?=$(shell git describe --always)
 NEXODUS_LDFLAGS?=-X main.Version=$(NEXODUS_VERSION)-$(NEXODUS_RELEASE)
+NEXODUS_GCFLAGS?=
 
 # Crunchy DB operator does not work well on arm64, use an different overlay to work around it.
 UNAME_M := $(shell uname -m)
@@ -56,21 +57,21 @@ dist:
 
 dist/nexd: $(NEXD_DEPS) | dist
 	$(ECHO_PREFIX) printf "  %-12s $@\n" "[GO BUILD]"
-	$(CMD_PREFIX) CGO_ENABLED=0 go build -ldflags="$(NEXODUS_LDFLAGS)" -o $@ ./cmd/nexd
+	$(CMD_PREFIX) CGO_ENABLED=0 go build -gcflags="$(NEXODUS_GCFLAGS)" -ldflags="$(NEXODUS_LDFLAGS)" -o $@ ./cmd/nexd
 
 dist/nexctl: $(NEXCTL_DEPS) | dist
 	$(ECHO_PREFIX) printf "  %-12s $@\n" "[GO BUILD]"
-	$(CMD_PREFIX) CGO_ENABLED=0 go build -ldflags="$(NEXODUS_LDFLAGS)" -o $@ ./cmd/nexctl
+	$(CMD_PREFIX) CGO_ENABLED=0 go build -gcflags="$(NEXODUS_GCFLAGS)" -ldflags="$(NEXODUS_LDFLAGS)" -o $@ ./cmd/nexctl
 
 dist/nexd-%: $(NEXD_DEPS) | dist
 	$(ECHO_PREFIX) printf "  %-12s $@\n" "[GO BUILD]"
 	$(CMD_PREFIX) CGO_ENABLED=0 GOOS=$(word 2,$(subst -, ,$(basename $@))) GOARCH=$(word 3,$(subst -, ,$(basename $@))) \
-		go build -ldflags="$(NEXODUS_LDFLAGS)" -o $@ ./cmd/nexd
+		go build -gcflags="$(NEXODUS_GCFLAGS)" -ldflags="$(NEXODUS_LDFLAGS)" -o $@ ./cmd/nexd
 
 dist/nexctl-%: $(NEXCTL_DEPS) | dist
 	$(ECHO_PREFIX) printf "  %-12s $@\n" "[GO BUILD]"
 	$(CMD_PREFIX) CGO_ENABLED=0 GOOS=$(word 2,$(subst -, ,$(basename $@))) GOARCH=$(word 3,$(subst -, ,$(basename $@))) \
-		go build -ldflags="$(NEXODUS_LDFLAGS)" -o $@ ./cmd/nexctl
+		go build -gcflags="$(NEXODUS_GCFLAGS)" -ldflags="$(NEXODUS_LDFLAGS)" -o $@ ./cmd/nexctl
 
 .PHONY: clean
 clean: ## clean built binaries


### PR DESCRIPTION
Add NEXODUS_GCFLAGS to allow setting flags to be passed to `go tool compile`. No flags are specified here by default. They can be set when running `make` like this:

```
$ NEXODUS_GCFLAGS="-cpuprofile foo" make dist/nexd
```