### PR TITLE
Ensure stun requests are IPv4

### DIFF
--- a/internal/nexodus/stun.go
+++ b/internal/nexodus/stun.go
@@ -2,10 +2,11 @@ package nexodus
 
 import (
 	"fmt"
+	"net"
+
 	"github.com/libp2p/go-reuseport"
 	"github.com/pion/stun"
 	"go.uber.org/zap"
-	"net"
 )
 
 const (
@@ -16,7 +17,7 @@ const (
 func StunRequest(logger *zap.SugaredLogger, stunServer string, srcPort int) (net.UDPAddr, error) {
 
 	logger.Debugf("dialing stun server %s", stunServer)
-	conn, err := reuseport.Dial("udp", fmt.Sprintf(":%d", srcPort), stunServer)
+	conn, err := reuseport.Dial("udp4", fmt.Sprintf(":%d", srcPort), stunServer)
 	if err != nil {
 		logger.Errorf("stun dialing timed out %v", err)
 		return net.UDPAddr{}, fmt.Errorf("failed to dial stun server %s: %w", stunServer, err)

--- a/internal/nexodus/utils.go
+++ b/internal/nexodus/utils.go
@@ -77,16 +77,19 @@ func ValidateCIDR(cidr string) error {
 // discoverGenericIPv4 opens a socket to the controller and returns the IP of the source dial
 func discoverGenericIPv4(logger *zap.SugaredLogger, controller string, port string) (string, error) {
 	controllerSocket := fmt.Sprintf("%s:%s", controller, port)
-	conn, err := net.Dial("udp", controllerSocket)
+	conn, err := net.Dial("udp4", controllerSocket)
 	if err != nil {
 		return "", err
 	}
 	conn.Close()
 	ipAddress := conn.LocalAddr().(*net.UDPAddr)
 	if ipAddress != nil {
-		ipPort := strings.Split(ipAddress.String(), ":")
-		logger.Debugf("Nodes discovered local address is [%s]", ipPort[0])
-		return ipPort[0], nil
+		ip, _, err := net.SplitHostPort(ipAddress.String())
+		if err != nil {
+			return "", err
+		}
+		logger.Debugf("Nodes discovered local address is [%s]", ip)
+		return ip, nil
 	}
 	return "", fmt.Errorf("failed to obtain the local IP")
 }


### PR DESCRIPTION
Fix stun requests to ensure they are always IPv4 and fix one only spot that assumed IPv4 but didn't force it.

```
commit ee2fa95a4a499831544f97be79d060a9d4e58df3 (HEAD -> v6fixes)
Author: Russell Bryant <rbryant@redhat.com>
Date:   Fri Mar 24 14:19:00 2023 -0400

    utils: Ensure discoverGenericIPv4 is actually IPv4
    
    Force this method to use IPv4 since that is the intent.
    
    In passing, using the net.SplitHostPort() method instead of manually
    splitting the string, as this is best practice to avoid accidental
    parsing mistakes (primarily with IPv6, but we should use the helper
    everywhere).
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>

commit 5f18f43b2dae76a1ec98b14465b64c4416d36c25
Author: Russell Bryant <rbryant@redhat.com>
Date:   Fri Mar 24 14:13:28 2023 -0400

    stun: Ensure we issue stun requests via IPv4
    
    Nexodus is still an IPv4-only system, so we must ensure that we're
    issuing stun requests via IPv4. This will need to be revisited as part
    of proper IPv6 support.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>

```