### PR TITLE
perf: use the wgctrl go module to dump the wg sessions.

### DIFF
--- a/internal/util/utils.go
+++ b/internal/util/utils.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"context"
+	"net"
 	"net/http"
 	"time"
 
@@ -28,4 +29,15 @@ func NewTestIPAMServer() *http.Server {
 		ReadHeaderTimeout: 1 * time.Minute,
 	}
 	return server
+}
+
+/* maybe we can use a generic version in the future...
+func ToStringSlice[S fmt.Stringer](items []S) (result []string) {
+*/
+
+func IPNetSliceToStringSlice(items []net.IPNet) (result []string) {
+	for _, i := range items {
+		result = append(result, i.String())
+	}
+	return
 }


### PR DESCRIPTION
Reduces our dependency on the wg binary.