### PR TITLE
Resolve the bug blocking suite.T().Parallel() on all tests in e2e

### DIFF
--- a/integration-tests/util_test.go
+++ b/integration-tests/util_test.go
@@ -455,3 +455,22 @@ func (suite *NexodusIntegrationSuite) getOauth2Token(ctx context.Context, userid
 		Expiry:       time.Now().Add(time.Duration(jwt.ExpiresIn) * time.Second),
 	}
 }
+
+// getNodeHostname trims the container ID down to the node hostname
+func (suite *NexodusIntegrationSuite) getNodeHostname(ctx context.Context, ctr testcontainers.Container) (string, error) {
+	var hostname string
+	err := backoff.Retry(func() error {
+		cid := ctr.GetContainerID()
+		if len(cid) == 12 {
+			hostname = ctr.GetContainerID()
+		}
+		if len(cid) < 12 {
+			return fmt.Errorf("invalid container ID: %s", ctr.GetContainerID())
+		} else {
+			hostname = strings.TrimSpace(cid[:12])
+		}
+		return nil
+	}, backoff.WithContext(backoff.NewConstantBackOff(1*time.Second), ctx))
+
+	return hostname, err
+}


### PR DESCRIPTION
- This was a residual bug from zone removal where CIDRs collapsed into prefix that overlapped between orgs.
- Instead of TunnelIP we now use the CID for deletions resolving the bug that prevented concurrent testing.
- Also removed the Cleanup() as I think that was an issue as well. The containers get torn down regardless when the parent context exits. I've noticed a flake in GH with Cleanup that had to have been from a premature teardown. Either way, removing them doesn't add overhead since it's all concurrent anyways.