### PR TITLE
Add a nexd socket check for an existing process running

### DIFF
--- a/cmd/nexctl/main.go
+++ b/cmd/nexctl/main.go
@@ -75,14 +75,27 @@ func main() {
 				Usage: "Commands for interacting with the local instance of nexd",
 				Subcommands: []*cli.Command{
 					{
-						Name:   "version",
-						Usage:  "Display the nexd version",
-						Action: cmdLocalVersion,
+						Name:  "version",
+						Usage: "Display the nexd version",
+						Action: func(cCtx *cli.Context) error {
+							err := cmdLocalVersion(cCtx)
+							if err != nil {
+								fmt.Printf("%s\n", err)
+							}
+							return nil
+						},
 					},
 					{
-						Name:   "status",
-						Usage:  "Display the nexd status",
-						Action: cmdLocalStatus,
+						Name:  "status",
+						Usage: "Display the nexd status",
+						Action: func(cCtx *cli.Context) error {
+							c, err := cmdLocalStatus(cCtx)
+							fmt.Printf("%s", c)
+							if err != nil {
+								fmt.Printf("%s\n", err)
+							}
+							return nil
+						},
 					},
 				},
 			},

--- a/cmd/nexd/main.go
+++ b/cmd/nexd/main.go
@@ -162,6 +162,11 @@ func main() {
 				return nil
 			}
 
+			_, err = nexodus.CtlStatus(cCtx)
+			if err == nil {
+				return fmt.Errorf("existing nexd service already running")
+			}
+
 			ctx, _ := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGQUIT, syscall.SIGINT)
 
 			nexodus, err := nexodus.NewNexodus(

--- a/internal/nexodus/ctlstatus.go
+++ b/internal/nexodus/ctlstatus.go
@@ -1,0 +1,42 @@
+package nexodus
+
+import (
+	"fmt"
+	"net"
+	"net/rpc/jsonrpc"
+	"runtime"
+
+	"github.com/urfave/cli/v2"
+)
+
+func callNexd(method string) (string, error) {
+	conn, err := net.Dial("unix", "/run/nexd.sock")
+	if err != nil {
+		return "", fmt.Errorf("Failed to connect to nexd: %w\n", err)
+	}
+	defer conn.Close()
+
+	client := jsonrpc.NewClient(conn)
+
+	var result string
+	err = client.Call("NexdCtl."+method, nil, &result)
+	if err != nil {
+		return "", fmt.Errorf("Failed to execute method (%s): %w\n", method, err)
+	}
+
+	return result, nil
+}
+
+// CtlStatus attempt to retrieve the status of the nexd service
+func CtlStatus(cCtx *cli.Context) (string, error) {
+	if runtime.GOOS != Linux.String() {
+		return "", fmt.Errorf("nexd ctl interface not yet supported on %s", runtime.GOOS)
+	}
+
+	result, err := callNexd("Status")
+	if err != nil {
+		return "", err
+	}
+
+	return result, err
+}


### PR DESCRIPTION
- Add a check to prevent more than one nexd being initialized
- Added checks for OS on nexctl for unsupported OSs