### PR TITLE
fix: nexodus would fail on startup if it could not fetch the jwks certs

### DIFF
--- a/internal/util/cache/memoize.go
+++ b/internal/util/cache/memoize.go
@@ -8,12 +8,14 @@ type memoizeResult[V any] struct {
 }
 
 type MemoizeCache[K comparable, V any] struct {
-	data *RWMutexTTLCache[K, memoizeResult[V]]
+	data     *RWMutexTTLCache[K, memoizeResult[V]]
+	errorTTL time.Duration
 }
 
-func NewMemoizeCache[K comparable, V any](defaultTTL time.Duration) *MemoizeCache[K, V] {
+func NewMemoizeCache[K comparable, V any](defaultTTL time.Duration, errorTTL time.Duration) *MemoizeCache[K, V] {
 	return &MemoizeCache[K, V]{
-		data: NewRWMutexTTLCache[K, memoizeResult[V]](defaultTTL),
+		data:     NewRWMutexTTLCache[K, memoizeResult[V]](defaultTTL),
+		errorTTL: errorTTL,
 	}
 }
 
@@ -22,21 +24,24 @@ func (c *MemoizeCache[K, V]) Memoize(key K, f func() V) V {
 }
 
 func (c *MemoizeCache[K, V]) MemoizeCanErr(key K, f func() (V, error)) (V, error) {
-	return c.MemoizeCanErrWithTTL(key, c.data.DefaultTTL, f)
+	return c.MemoizeCanErrWithTTL(key, c.data.DefaultTTL, c.errorTTL, f)
 }
 
 func (c *MemoizeCache[K, V]) MemoizeWithTTL(key K, ttl time.Duration, f func() V) V {
-	value, _ := c.MemoizeCanErrWithTTL(key, ttl, func() (V, error) {
+	value, _ := c.MemoizeCanErrWithTTL(key, ttl, ttl, func() (V, error) {
 		return f(), nil
 	})
 	return value
 }
 
-func (c *MemoizeCache[K, V]) MemoizeCanErrWithTTL(key K, ttl time.Duration, f func() (V, error)) (V, error) {
+func (c *MemoizeCache[K, V]) MemoizeCanErrWithTTL(key K, ttl time.Duration, errorTTL time.Duration, f func() (V, error)) (V, error) {
 	if result, found := c.data.Get(key); found {
 		return result.value, result.err
 	}
 	res, err := f()
+	if err != nil {
+		ttl = errorTTL
+	}
 	_, _ = c.data.PutWithTTL(key, memoizeResult[V]{
 		value: res,
 		err:   err,

--- a/internal/util/cache/memoize_test.go
+++ b/internal/util/cache/memoize_test.go
@@ -11,7 +11,7 @@ import (
 func TestMemoizeCache_Memoize(t *testing.T) {
 	t.Parallel()
 	require := require.New(t)
-	cache := NewMemoizeCache[string, string](time.Second * 1)
+	cache := NewMemoizeCache[string, string](time.Second*1, time.Second*1)
 
 	counter := int32(0)
 	pong := func() string {


### PR DESCRIPTION
We now fetch the jwk’s and the first API request, and retry again very 5 seconds if the fetch fails.