### PR TITLE
docs: Split up the user guide

### DIFF
--- a/docs/user-guide/agent.md
+++ b/docs/user-guide/agent.md
@@ -1,39 +1,12 @@
-# Nexodus User Guide
+# Deploying the Nexodus Agent
 
-This document covers the usage of Nexodus as a user of the service.
-
-## Using the Nexctl Utility
-
-`nexctl` is a CLI utility that is used to interact with the Nexodus Service. It provides command line options to get the existing configuration of the resources like Zone, Peer, User and Devices from the Nexodus Service. It also allows limited options to configure certain aspects of these resources. Please use `nexctl -h` to learn more about the available options.
-
-You can install `nexctl` using the following two ways
-
-### Install pre-built binary
-
-You can directly fetch the binary from the Nexodus AWS S3 bucket.
-
-```sh
-sudo curl -fsSL https://nexodus-io.s3.amazonaws.com/nexctl-linux-amd64 --output /usr/local/sbin/nexctl
-sudo chmod a+x /usr/local/sbin/nexctl
-```
-
-### Build from the source code
-
-You can clone the Nexodus repo and build the binary using
-
-```sh
-make dist/nexctl
-```
-
-## Deploying the Nexodus Agent
-
-### Deploying on a Node
+## Deploying on a Node
 
 The following sections contain general instructions to deploy the Nexodus agent on any node. The minimum requirement is that the node runs Linux, Darwin, or Windows-based Operating systems.
 
-#### Installing the Agent
+### Installing the Agent
 
-##### Install Script
+#### Install Script
 
 The Nexodus agent (`nexd`) is run on any node that will join a Nexodus Zone to communicate with other peers in that zone. This agent communicates with the Nexodus Controller and manages local wireguard configuration.
 
@@ -43,7 +16,7 @@ The `hack/nexodus_installer.sh` script will download the latest build of `nexd` 
 hack/nexodus_installer.sh
 ```
 
-##### RPM from a Copr Repository
+#### RPM from a Copr Repository
 
 A Fedora [Copr repository](https://copr.fedorainfracloud.org/coprs/russellb/nexodus/) is updated with new rpms after each new commit to the `main` branch that passes CI. The rpm will include `nexctl`, `nexd`, and integration with systemd.
 
@@ -59,7 +32,7 @@ Then you should be able to install Nexodus with:
 sudo dnf install nexodus
 ```
 
-##### Custom RPM Build
+#### Custom RPM Build
 
 You can also build a custom rpm from the git repository. You must have `mock` installed to build the package.
 
@@ -75,7 +48,7 @@ To install the rpm, you may use `dnf`.
 sudo dnf install ./dist/rpm/mock/nexodus-0-0.1.20230216git068fedd.fc37.src.rpm
 ```
 
-##### Systemd
+#### Systemd
 
 If you did not install `nexd` via the rpm, you can still use the systemd integration if you would like. The following commands will put the files in the right place.
 
@@ -85,7 +58,7 @@ sudo cp contrib/rpm/nexodus.sysconfig /etc/sysconfig/nexodus
 sudo systemctl daemon-reload
 ```
 
-##### Starting the Agent
+#### Starting the Agent
 
 > **Note**
 > In a self-signed dev environment, each agent machine needs to have the [imported cert](../deployment/nexodus-service.md#https) and the [host entry](../deployment/nexodus-service.md#add-required-dns-entries) detailed above.
@@ -108,7 +81,7 @@ If you would like `nexd` to run automatically on boot, run this command as well:
 sudo systemctl enable nexodus
 ```
 
-#### Interactive Enrollment
+### Interactive Enrollment
 
 If the agent is able to successfully reach the controller API, it will provide a one-time code to provide to the controller web UI to complete enrollment of this node into a Nexodus Zone. If you ran `nexd` manually, you will see a message like the following in your terminal:
 
@@ -138,7 +111,7 @@ Authentication succeeded.
 INFO[0570] Peer setup complete
 ```
 
-#### Verifying Agent Setup
+### Verifying Agent Setup
 
 Once the Agent has been started successfully, you should see a wireguard interface with an address assigned. For example, on Linux:
 
@@ -150,7 +123,7 @@ $ ip address show wg0
        valid_lft forever preferred_lft forever
 ```
 
-#### Verifying Organization Connectivity
+### Verifying Organization Connectivity
 
 Once more than one node has enrolled in the same Nexodus organization, you will see additional routes populated for reaching other nodes' endpoints in the same organization. For example, we have just added a second node to this zone. The new node's address in the Nexodus organization is 100.100.0.2. On Linux, we can check the routing table and see:
 
@@ -170,7 +143,7 @@ PING 100.100.0.2 (100.100.0.2) 56(84) bytes of data.
 
 You can explore the web UI by visiting the URL of the host you added in your `/etc/hosts` file. For example, `https://try.nexodus.local/`.
 
-#### Cleanup Agent From Node
+### Cleanup Agent From Node
 
 If you want to remove the node from the network, and want to clean up all the configuration done on the node. Fire away following commands:
 
@@ -185,11 +158,11 @@ sudo ip link del wg0
 
 Since the wireguard agents are userspace in both Windows and Darwin, the tunnel interface is removed when the agent process exits.
 
-### Deploying on Kubernetes-managed Nodes
+## Deploying on Kubernetes-managed Nodes
 
 Instructions mentioned in [Deploying on a Node](#deploying-on-a-node) can be used here to deploy the Nexodus agent on Kubernetes-managed nodes. However, deploying the agent across all the nodes in a sizable Kubernetes cluster can be a challenging task. The following section provides instructions to deploy Kubernetes style manifest to automate the deployment process.
 
-#### Setup the configuration
+### Setup the configuration
 
 Agent deployment in Kubernetes requires a few initial configuration details to successfully deploy the agent and onboard the node. This configuration is provided through `kustomization.yaml`. Make a copy of the sample [`kustomization.yaml.sample`](https://github.com/nexodus-io/nexodus/blob/main/deploy/nexodus-client/overlays/dev/kustomization.yaml.sample) and rename it to `kustomization.yaml`.
 
@@ -208,7 +181,7 @@ You can refer to [kustomization.yaml.sample](https://github.com/nexodus-io/nexod
 
 If you have set up your Nexodus stack with a non-default configuration, please copy the [sample](./../deploy/nexodus-client/overlays/sample/) directory and update the sample file accordingly to create a new overlay for your setup and deploy it.
 
-#### Deploying the Agent in the Kind Dev Environment
+### Deploying the Agent in the Kind Dev Environment
 
 If you're using the kind-based development environment, you can deploy the agent to each node in that cluster using this command:
 
@@ -220,7 +193,7 @@ Then you may skip down to the [Verify the deployment](#verify-the-deployment) se
 
 Otherwise, if you are working with another cluster, continue to the next section.
 
-#### Deploying the Nexodus Agent Manifest
+### Deploying the Nexodus Agent Manifest
 
 Once the configuration is set up, you can deploy Nexodus's manifest files.
 
@@ -233,7 +206,7 @@ It will deploy a DaemonSet in the newly created `Nexodus` namespace. DaemonSet d
 **Note**
 If your Kubernetes cluster enforces security context to deny privileged container deployment, you need to make sure that the security policy is added to the service account `nexodus` (created for the agent deployment) to allow the deployment.
 
-#### Controlling the Agent Deployment
+### Controlling the Agent Deployment
 
 By default, Nexodus agent is deployed using DaemonSet, so Kubernetes will deploy Nexodus agent pod on each worker node. This might not be the ideal strategy for onboarding Kubernetes worker nodes for many reasons. You can control the Nexodus agent deployment by configuring the `nodeAffinity` in the [node_selector.yaml](https://github.com/nexodus-io/nexodus/blob/main/deploy/nexodus-client/overlays/dev/node_selector.yaml).
 
@@ -271,7 +244,7 @@ Currently, the sample file provides two strategies to control the deployment, bu
 #                - <NODE_2>
 ```
 
-#### Verify the deployment
+### Verify the deployment
 
 Check that nexodus pod is running on the nodes
 
@@ -289,98 +262,10 @@ $ ip address show wg0
        valid_lft forever preferred_lft forever
 ```
 
-#### Cleanup Agent Pod From Node
+### Cleanup Agent Pod From Node
 
 Removing the Nexodus manifest will remove the Nexodus pod and clean up WireGuard configuration from the node as well.
 
 ```sh
 kubectl delete -k ./deploy/nexodus-client/overlays/dev
-```
-
-## Deploying the Nexodus Discovery and Relay Nodes
-
-- Relay Node - Nexodus Controller makes the best effort to establish a direct peering between the endpoints, but in some scenarios such as symmetric NAT, it's not possible to establish direct peering. To establish connectivity in those scenarios, Nexodus Controller uses Nexodus Relay to relay the traffic between the endpoints. To use this feature you need to onboard a Relay node to the Nexodus network. This **must** be the first device to join the Nexodus network to enable the traffic relay.
-- Discovery Node - A Discovery Node is used to enable NAT traversal for all peers to connect to one another if they are unable to make direct connections.
-
-Relay and Discovery can be run on the same or separate nodes. Both of these machines need to be reachable on a predictable Wireguard port such as 51820 and ideally at the top of your NAT cone such as running in a cloud where all endpoints can reach both the discovery and relay services for peering. There is only a need for one discovery and relay nodes in an organization, after those are joined you simply run the basic onboarding [Installing the agent](#installing-the-agent) .
-
-### Setup Nexodus Relay and Discovery Node
-
-Clone the Nexodus repository on a VM (or bare metal machine). Nexodus relay node must be reachable from all the endpoint nodes that want to join the Nexodus network. Follow the instruction in [Starting The Agent](#starting-the-agent) section to set up the node and install the `nexd` binary.
-
-```sh
-sudo nexd --discovery-node --relay-node --stun https://try.nexodus.local
-```
-
-You can list the available organizations using the following command
-
-```sh
-./nexctl  --username=kitteh1 --password=floofykittens organization list
-
-ORGANIZATION ID                          NAME          CIDR              DESCRIPTION                RELAY/HUB ENABLED
-dcab6a84-f522-4e9b-a221-8752d505fc18     default       100.100.1.0/20     Default Zone               false
-```
-
-#### Interactive OnBoarding
-
-```sh
-sudo nexd --discovery-node --relay-node --stun https://try.nexodus.local
-```
-
-It will print a URL on stdout to onboard the discovery/relay node
-
-```sh
-$ sudo nexd --discovery-node --relay-node --stun https://try.nexodus.local
-Your device must be registered with Nexodus.
-Your one-time code is: GTLN-RGKP
-Please open the following URL in your browser to sign in:
-https://auth.try.nexodus.local/device?user_code=GTLN-RGKP
-```
-
-Open the URL in your browser and provide the username and password that you used to create the zone, and follow the GUI's instructions. Once you are done granting access to the device in the GUI, the relay node will be OnBoarded to the Relay Zone.
-
-#### Silent OnBoarding
-
-To OnBoard devices without any browser involvement, you need to provide a username and password in the CLI command
-
-```sh
-nexd --discovery-node --relay-node --stun --username=kitteh1 --password=floofykittens https://try.nexodus.local
-```
-
-### Delete Organization
-
-To delete the organization,
-
-```sh
-nexctl  --username=kitteh1 --password=floofykittens organization delete --organization-id b130805a-c312-4f4a-8a8e-f57a2c7ab152
-```
-
-## Additional Features
-
-### Subnet Routers
-
-Typically, the Nexodus agent runs on every host that you intend to have connectivity to a Nexodus Organization. However, there may be some cases where you can't do that or don't want to. It is also possible to make a host act as a Subnet Router to provide connectivity between a Nexodus Organization and a host's local Subnet.
-
-In the following diagram, `Host X` acts as a Subnet Router, allowing all hosts within Nexodus Organization A to access `192.168.100.0/24`.
-
-To configure this scenario, the `nexd` agent on `Host X` must be run with the `--child-prefix` parameter.
-
-```sh
-sudo nexd --child-prefix 192.168.100.0/24 [...]
-```
-
-The subnet exposed to the Nexodus Zone may be a physical network the host is connected to, but it can also be a network local to the host. This works well for exposing a local subnet used for containers running on that host. A demo of this use case for containers can be found in [scenarios/containers-on-nodes.md](scenarios/containers-on-nodes.md).
-
-> **Note**
-> Subnet Routers do not perform NAT. Routes for hosts in `192.168.100.0/24` to reach Nexodus Zone A via `Host X` must be handled via local configuration that is appropriate for your network.
-
-```mermaid
-graph
-    subgraph "Nexodus Zone - 10.0.0.10/24"
-        x[Host X]<---> y
-        y[Host Y]<---> z[Host Z]
-        x<--->z
-    end
-
-    x <---> s[Subnet Accessible by Host X<br/>192.168.100.0/24]
 ```

--- a/docs/user-guide/discovery-and-relay.md
+++ b/docs/user-guide/discovery-and-relay.md
@@ -1,0 +1,49 @@
+# Deploying the Nexodus Discovery and Relay Nodes
+
+- Relay Node - Nexodus Controller makes the best effort to establish a direct peering between the endpoints, but in some scenarios such as symmetric NAT, it's not possible to establish direct peering. To establish connectivity in those scenarios, Nexodus Controller uses Nexodus Relay to relay the traffic between the endpoints. To use this feature you need to onboard a Relay node to the Nexodus network. This **must** be the first device to join the Nexodus network to enable the traffic relay.
+- Discovery Node - A Discovery Node is used to enable NAT traversal for all peers to connect to one another if they are unable to make direct connections.
+
+Relay and Discovery can be run on the same or separate nodes. Both of these machines need to be reachable on a predictable Wireguard port such as 51820 and ideally at the top of your NAT cone such as running in a cloud where all endpoints can reach both the discovery and relay services for peering. There is only a need for one discovery and relay nodes in an organization, after those are joined you simply run the basic onboarding [Installing the agent](agent.md#installing-the-agent) .
+
+## Setup Nexodus Relay and Discovery Node
+
+Clone the Nexodus repository on a VM (or bare metal machine). Nexodus relay node must be reachable from all the endpoint nodes that want to join the Nexodus network. Follow the instruction in [Starting The Agent](agent.md#starting-the-agent) section to set up the node and install the `nexd` binary.
+
+```sh
+sudo nexd --discovery-node --relay-node --stun https://try.nexodus.local
+```
+
+You can list the available organizations using the following command
+
+```sh
+./nexctl  --username=kitteh1 --password=floofykittens organization list
+
+ORGANIZATION ID                          NAME          CIDR              DESCRIPTION                RELAY/HUB ENABLED
+dcab6a84-f522-4e9b-a221-8752d505fc18     default       100.100.1.0/20     Default Zone               false
+```
+
+### Interactive OnBoarding
+
+```sh
+sudo nexd --discovery-node --relay-node --stun https://try.nexodus.local
+```
+
+It will print a URL on stdout to onboard the discovery/relay node
+
+```sh
+$ sudo nexd --discovery-node --relay-node --stun https://try.nexodus.local
+Your device must be registered with Nexodus.
+Your one-time code is: GTLN-RGKP
+Please open the following URL in your browser to sign in:
+https://auth.try.nexodus.local/device?user_code=GTLN-RGKP
+```
+
+Open the URL in your browser and provide the username and password that you used to create the zone, and follow the GUI's instructions. Once you are done granting access to the device in the GUI, the relay node will be OnBoarded to the Relay Zone.
+
+### Silent OnBoarding
+
+To OnBoard devices without any browser involvement, you need to provide a username and password in the CLI command
+
+```sh
+nexd --discovery-node --relay-node --stun --username=kitteh1 --password=floofykittens https://try.nexodus.local
+```

--- a/docs/user-guide/nexctl.md
+++ b/docs/user-guide/nexctl.md
@@ -1,0 +1,26 @@
+# Nexodus API Access with `nexctl`
+
+## Installation
+
+You can install `nexctl` using the following two ways
+
+### Install pre-built binary
+
+You can directly fetch the binary from the Nexodus AWS S3 bucket.
+
+```sh
+sudo curl -fsSL https://nexodus-io.s3.amazonaws.com/nexctl-linux-amd64 --output /usr/local/sbin/nexctl
+sudo chmod a+x /usr/local/sbin/nexctl
+```
+
+### Build from the source code
+
+You can clone the Nexodus repo and build the binary using
+
+```sh
+make dist/nexctl
+```
+
+## Using the Nexctl Utility
+
+`nexctl` is a CLI utility that is used to interact with the Nexodus Service. It provides command line options to get the existing configuration of the resources like Zone, Peer, User and Devices from the Nexodus Service. It also allows limited options to configure certain aspects of these resources. Please use `nexctl -h` to learn more about the available options.

--- a/docs/user-guide/subnet-routers.md
+++ b/docs/user-guide/subnet-routers.md
@@ -1,0 +1,27 @@
+# Subnet Routers
+
+Typically, the Nexodus agent runs on every host that you intend to have connectivity to a Nexodus Organization. However, there may be some cases where you can't do that or don't want to. It is also possible to make a host act as a Subnet Router to provide connectivity between a Nexodus Organization and a host's local Subnet.
+
+In the following diagram, `Host X` acts as a Subnet Router, allowing all hosts within Nexodus Organization A to access `192.168.100.0/24`.
+
+To configure this scenario, the `nexd` agent on `Host X` must be run with the `--child-prefix` parameter.
+
+```sh
+sudo nexd --child-prefix 192.168.100.0/24 [...]
+```
+
+The subnet exposed to the Nexodus Zone may be a physical network the host is connected to, but it can also be a network local to the host. This works well for exposing a local subnet used for containers running on that host. A demo of this use case for containers can be found in [scenarios/containers-on-nodes.md](scenarios/containers-on-nodes.md).
+
+> **Note**
+> Subnet Routers do not perform NAT. Routes for hosts in `192.168.100.0/24` to reach Nexodus Zone A via `Host X` must be handled via local configuration that is appropriate for your network.
+
+```mermaid
+graph
+    subgraph "Nexodus Zone - 10.0.0.10/24"
+        x[Host X]<---> y
+        y[Host Y]<---> z[Host Z]
+        x<--->z
+    end
+
+    x <---> s[Subnet Accessible by Host X<br/>192.168.100.0/24]
+```


### PR DESCRIPTION
The `user-guide.md` file has become a bit large. It's already under its own sub-folder in the docs, `user-guide`. Split it apart into more focused topics as a more scalable way to organize this information as we continue to grow.

In this change, we now have separate files for these topics which were previously combined in `user-guide.md`.

- The nexd agent
- Discovery and Relay modes
- nexctl
- Subnet Routers