### PR TITLE
nexd: Add core handling for userspace mode

### DIFF
--- a/cmd/nexd/main.go
+++ b/cmd/nexd/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"strconv"
 	"sync"
 	"syscall"
 
@@ -34,6 +35,9 @@ func nexdRun(cCtx *cli.Context, logger *zap.Logger) error {
 
 	ctx, _ := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGQUIT, syscall.SIGINT)
 
+	// TEMPORARY - this is a hack to allow us to run the userspace mode for demonstration purposes
+	userspaceMode, _ := strconv.ParseBool(os.Getenv("NEXD_USERSPACE_MODE_TEST"))
+
 	nexodus, err := nexodus.NewNexodus(
 		ctx,
 		logger.Sugar(),
@@ -51,7 +55,7 @@ func nexdRun(cCtx *cli.Context, logger *zap.Logger) error {
 		cCtx.Bool("discovery-node"),
 		cCtx.Bool("relay-only"),
 		cCtx.Bool("insecure-skip-tls-verify"),
-		Version, false,
+		Version, userspaceMode,
 	)
 	if err != nil {
 		logger.Fatal(err.Error())

--- a/go.mod
+++ b/go.mod
@@ -41,6 +41,7 @@ require (
 	golang.org/x/oauth2 v0.6.0
 	golang.org/x/sys v0.6.0
 	golang.org/x/term v0.6.0
+	golang.zx2c4.com/wireguard v0.0.0-20220920152132-bb719d3a6e2c
 	golang.zx2c4.com/wireguard/wgctrl v0.0.0-20221104135756-97bc4ad4a1cb
 	gorm.io/driver/postgres v1.5.0
 	gorm.io/driver/sqlite v1.4.4
@@ -72,6 +73,7 @@ require (
 	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/gofrs/uuid v4.2.0+incompatible // indirect
 	github.com/golang-jwt/jwt/v4 v4.5.0 // indirect
+	github.com/google/btree v1.0.1 // indirect
 	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.7.0 // indirect
 	github.com/hashicorp/go-immutable-radix v1.3.1 // indirect
@@ -117,10 +119,12 @@ require (
 	go.opentelemetry.io/proto/otlp v0.19.0 // indirect
 	golang.org/x/arch v0.0.0-20210923205945-b76863e36670 // indirect
 	golang.org/x/mod v0.8.0 // indirect
-	golang.zx2c4.com/wireguard v0.0.0-20220920152132-bb719d3a6e2c // indirect
+	golang.org/x/time v0.3.0 // indirect
+	golang.zx2c4.com/wintun v0.0.0-20211104114900-415007cec224 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gotest.tools/v3 v3.4.0 // indirect
+	gvisor.dev/gvisor v0.0.0-20220817001344-846276b3dbc5 // indirect
 )
 
 require (
@@ -167,7 +171,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/ugorji/go/codec v1.2.9 // indirect
-	github.com/vishvananda/netns v0.0.0-20210104183010-2eb08e3e575f // indirect
+	github.com/vishvananda/netns v0.0.0-20211101163701-50045581ed74 // indirect
 	github.com/xdg-go/pbkdf2 v1.0.0 // indirect
 	github.com/xdg-go/scram v1.1.2 // indirect
 	github.com/xdg-go/stringprep v1.0.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -283,6 +283,8 @@ github.com/golang/snappy v0.0.4 h1:yAGX7huGHXlcLOEtBnF4w7FQwA26wojNCwOYAEhLjQM=
 github.com/golang/snappy v0.0.4/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
+github.com/google/btree v1.0.1 h1:gK4Kx5IaGY9CD5sPJ36FHiBJ6ZXl0kilRiiCj+jdYp4=
+github.com/google/btree v1.0.1/go.mod h1:xXMiIv4Fb/0kKde4SpL7qlzvu5cMJDRkFDxJfI9uaxA=
 github.com/google/flatbuffers v1.12.1 h1:MVlul7pQNoDzWRLTw5imwYsl+usrS1TXG2H4jg6ImGw=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
@@ -591,8 +593,8 @@ github.com/vishvananda/netlink v1.2.1-beta.2 h1:Llsql0lnQEbHj0I1OuKyp8otXp0r3q0m
 github.com/vishvananda/netlink v1.2.1-beta.2/go.mod h1:twkDnbuQxJYemMlGd4JFIcuhgX83tXhKS2B/PRMpOho=
 github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17pCcGlemwknint6hfoeCVQrEMVwxRLRjXpq+BU=
 github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae/go.mod h1:DD4vA1DwXk04H54A1oHXtwZmA0grkVMdPxx/VGLCah0=
-github.com/vishvananda/netns v0.0.0-20210104183010-2eb08e3e575f h1:p4VB7kIXpOQvVn1ZaTIVp+3vuYAXFe3OJEvjbUYJLaA=
-github.com/vishvananda/netns v0.0.0-20210104183010-2eb08e3e575f/go.mod h1:DD4vA1DwXk04H54A1oHXtwZmA0grkVMdPxx/VGLCah0=
+github.com/vishvananda/netns v0.0.0-20211101163701-50045581ed74 h1:gga7acRE695APm9hlsSMoOoE65U4/TcqNj90mc69Rlg=
+github.com/vishvananda/netns v0.0.0-20211101163701-50045581ed74/go.mod h1:DD4vA1DwXk04H54A1oHXtwZmA0grkVMdPxx/VGLCah0=
 github.com/xdg-go/pbkdf2 v1.0.0 h1:Su7DPu48wXMwC3bs7MCNG+z4FhcyEuz5dlvchbq0B0c=
 github.com/xdg-go/pbkdf2 v1.0.0/go.mod h1:jrpuAogTd400dnrH08LKmI/xc1MbPOebTwRqcT5RDeI=
 github.com/xdg-go/scram v1.1.1/go.mod h1:RaEWvsqvNKKvBPvcKeFjrG2cJqOkHTiyTpzz23ni57g=
@@ -890,6 +892,7 @@ golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxb
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.3.0 h1:rg5rLMjNzMS1RkNLzCG38eapWhnYLFYXDXj2gOlr8j4=
+golang.org/x/time v0.3.0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3HoIrodX9oNMXvdceNzlUR8zjMvY=
@@ -943,6 +946,8 @@ golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.zx2c4.com/wintun v0.0.0-20211104114900-415007cec224 h1:Ug9qvr1myri/zFN6xL17LSCBGFDnphBBhzmILHsM5TY=
+golang.zx2c4.com/wintun v0.0.0-20211104114900-415007cec224/go.mod h1:deeaetjYA+DHMHg+sMSMI58GrEteJUUzzw7en6TJQcI=
 golang.zx2c4.com/wireguard v0.0.0-20220920152132-bb719d3a6e2c h1:Okh6a1xpnJslG9Mn84pId1Mn+Q8cvpo4HCeeFWHo0cA=
 golang.zx2c4.com/wireguard v0.0.0-20220920152132-bb719d3a6e2c/go.mod h1:enML0deDxY1ux+B6ANGiwtg0yAJi1rctkTpcHNAVPyg=
 golang.zx2c4.com/wireguard/wgctrl v0.0.0-20221104135756-97bc4ad4a1cb h1:9aqVcYEDHmSNb0uOWukxV5lHV09WqiSiCuhEgWNETLY=
@@ -1070,6 +1075,8 @@ gorm.io/gorm v1.24.7-0.20230306060331-85eaf9eeda11 h1:9qNbmu21nNThCNnF5i2R3kw2aL
 gorm.io/gorm v1.24.7-0.20230306060331-85eaf9eeda11/go.mod h1:L4uxeKpfBml98NYqVqwAdmV1a2nBtAec/cf3fpucW/k=
 gotest.tools/v3 v3.4.0 h1:ZazjZUfuVeZGLAmlKKuyv3IKP5orXcwtOwDQH6YVr6o=
 gotest.tools/v3 v3.4.0/go.mod h1:CtbdzLSsqVhDgMtKsx03ird5YTGB3ar27v0u/yKBW5g=
+gvisor.dev/gvisor v0.0.0-20220817001344-846276b3dbc5 h1:cv/zaNV0nr1mJzaeo4S5mHIm5va1W0/9J3/5prlsuRM=
+gvisor.dev/gvisor v0.0.0-20220817001344-846276b3dbc5/go.mod h1:TIvkJD0sxe8pIob3p6T8IzxXunlp6yfgktvTNp+DGNM=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/internal/nexodus/keys_linux.go
+++ b/internal/nexodus/keys_linux.go
@@ -7,18 +7,27 @@ import "fmt"
 // handleKeys will look for an existing key pair, if a pair is not found this method
 // will generate a new pair and write them to location on the disk depending on the OS
 func (ax *Nexodus) handleKeys() error {
-	publicKey := readKeyFile(ax.logger, linuxPublicKeyFile)
-	privateKey := readKeyFile(ax.logger, linuxPrivateKeyFile)
+	var pubKeyFile string
+	var privKeyFile string
+	if ax.userspaceMode {
+		pubKeyFile = workdirPublicKeyFile
+		privKeyFile = workdirPrivateKeyFile
+	} else {
+		pubKeyFile = linuxPublicKeyFile
+		privKeyFile = linuxPrivateKeyFile
+	}
+	publicKey := readKeyFile(ax.logger, pubKeyFile)
+	privateKey := readKeyFile(ax.logger, privKeyFile)
 	if publicKey != "" && privateKey != "" {
 		ax.wireguardPubKey = publicKey
 		ax.wireguardPvtKey = privateKey
-		ax.logger.Infof("Existing key pair found at [ %s ] and [ %s ]", linuxPublicKeyFile, linuxPrivateKeyFile)
+		ax.logger.Infof("Existing key pair found at [ %s ] and [ %s ]", pubKeyFile, privKeyFile)
 		return nil
 	}
 	ax.logger.Infof("No existing public/private key pair found, generating a new pair")
-	if err := ax.generateKeyPair(linuxPublicKeyFile, linuxPrivateKeyFile); err != nil {
+	if err := ax.generateKeyPair(pubKeyFile, privKeyFile); err != nil {
 		return fmt.Errorf("Unable to locate or generate a key/pair: %w", err)
 	}
-	ax.logger.Debugf("New keys were written to [ %s ] and [ %s ]", linuxPublicKeyFile, linuxPrivateKeyFile)
+	ax.logger.Debugf("New keys were written to [ %s ] and [ %s ]", pubKeyFile, privKeyFile)
 	return nil
 }

--- a/internal/nexodus/keys_windows.go
+++ b/internal/nexodus/keys_windows.go
@@ -7,19 +7,27 @@ import "fmt"
 // handleKeys will look for an existing key pair, if a pair is not found this method
 // will generate a new pair and write them to location on the disk depending on the OS
 func (ax *Nexodus) handleKeys() error {
-	publicKey := readKeyFile(ax.logger, windowsPublicKeyFile)
-	privateKey := readKeyFile(ax.logger, windowsPrivateKeyFile)
+	var pubKeyFile string
+	var privKeyFile string
+	if ax.userspaceMode {
+		pubKeyFile = workdirPublicKeyFile
+		privKeyFile = workdirPrivateKeyFile
+	} else {
+		pubKeyFile = windowsPublicKeyFile
+		privKeyFile = windowsPrivateKeyFile
+	}
+	publicKey := readKeyFile(ax.logger, pubKeyFile)
+	privateKey := readKeyFile(ax.logger, privKeyFile)
 	if publicKey != "" && privateKey != "" {
 		ax.wireguardPubKey = publicKey
 		ax.wireguardPvtKey = privateKey
-		ax.logger.Infof("Existing key pair found at [ %s ] and [ %s ]", windowsPublicKeyFile, windowsPrivateKeyFile)
+		ax.logger.Infof("Existing key pair found at [ %s ] and [ %s ]", pubKeyFile, privKeyFile)
 		return nil
 	}
 	ax.logger.Infof("No existing public/private key pair found, generating a new pair")
-	if err := ax.generateKeyPair(windowsPublicKeyFile, windowsPrivateKeyFile); err != nil {
+	if err := ax.generateKeyPair(pubKeyFile, privKeyFile); err != nil {
 		return fmt.Errorf("Unable to locate or generate a key/pair: %w", err)
 	}
-	ax.logger.Debugf("New keys were written to [ %s ] and [ %s ]", windowsPublicKeyFile, windowsPrivateKeyFile)
+	ax.logger.Debugf("New keys were written to [ %s ] and [ %s ]", pubKeyFile, privKeyFile)
 	return nil
-
 }

--- a/internal/nexodus/nexodus_linux.go
+++ b/internal/nexodus/nexodus_linux.go
@@ -46,7 +46,7 @@ func (ax *Nexodus) setupInterfaceOS() error {
 	_, err = RunCommand("ip", "address", "add", ax.wgLocalAddress, "dev", ax.tunnelIface)
 	if err != nil {
 		logger.Debugf("failed to assign an address to the local linux interface, attempting to flush the iface: %v\n", err)
-		wgIP := getIPv4Iface(ax.tunnelIface)
+		wgIP := ax.getIPv4Iface(ax.tunnelIface)
 		_, err = RunCommand("ip", "address", "del", wgIP.To4().String(), "dev", ax.tunnelIface)
 		if err != nil {
 			logger.Errorf("failed to assign an address to the local linux interface: %v\n", err)

--- a/internal/nexodus/nexodus_userspace.go
+++ b/internal/nexodus/nexodus_userspace.go
@@ -1,14 +1,79 @@
 package nexodus
 
 import (
+	"encoding/base64"
+	"encoding/hex"
 	"fmt"
+	"net/netip"
+
+	"go.uber.org/zap"
+	"golang.zx2c4.com/wireguard/conn"
+	"golang.zx2c4.com/wireguard/device"
+	"golang.zx2c4.com/wireguard/tun/netstack"
 )
 
 // This is the hardcoded default name of the netstack wireguard device
 const defaultDeviceName = "go"
 
 func (ax *Nexodus) setupInterfaceUS() error {
-	return fmt.Errorf("Not implemented")
+	tun, tnet, err := netstack.CreateNetTUN(
+		[]netip.Addr{netip.MustParseAddr(ax.wgLocalAddress)},
+		// TODO - Is there something else that makes more sense as a DNS server?
+		// So far I don't think DNS will ever be used. If Nexodus has its own
+		// built-in DNS, that would make sense here.
+		[]netip.Addr{netip.MustParseAddr("8.8.8.8")},
+		// Assume a standard 1500 minus our tunneling overhead
+		// TODO - make this configurable or dynamic. If there are
+		// multiple layers of tunneling involved, it may need to be
+		// even smaller. Consider running this inside a Kubernetes Pod,
+		// where the cluster SDN provider has already reduced the MTU
+		// to account for its own tunneling (Geneve, for example).
+		1420)
+	if err != nil {
+		ax.logger.Errorf("Failed to create userspace tunnel device: %w", err)
+		return err
+	}
+	ax.userspaceTun = tun
+	ax.userspaceNet = tnet
+	logger := &device.Logger{
+		Verbosef: device.DiscardLogf,
+		Errorf:   ax.logger.Errorf,
+	}
+	if ax.logger.Level() == zap.DebugLevel {
+		logger.Verbosef = ax.logger.Debugf
+	}
+	dev := device.NewDevice(ax.userspaceTun, conn.NewDefaultBind(), logger)
+	pvtDecoded, err := base64.StdEncoding.DecodeString(ax.wireguardPvtKey)
+	if err != nil {
+		ax.logger.Errorf("Failed to decode wireguard private key: %w", err)
+		return err
+	}
+	err = dev.IpcSet(fmt.Sprintf("private_key=%s", hex.EncodeToString(pvtDecoded)))
+	if err != nil {
+		ax.logger.Errorf("Failed to set private key: %w", err)
+		return err
+	}
+	err = dev.IpcSet(fmt.Sprintf("listen_port=%d", ax.listenPort))
+	if err != nil {
+		ax.logger.Errorf("Failed to set listen port: %w", err)
+		return err
+	}
+	err = dev.Up()
+	if err != nil {
+		ax.logger.Errorf("Failed to bring up userspace device: %w", err)
+		return err
+	}
+	ax.userspaceDev = dev
+
+	devName, err := tun.Name()
+	if err != nil {
+		ax.logger.Errorf("Failed to get userspace device name: %w", err)
+		return err
+	}
+	ax.logger.Infof("Successfully created userspace device: %s", devName)
+	ax.userspaceLastAddress = ax.wgLocalAddress
+
+	return nil
 }
 
 func (ax *Nexodus) defaultTunnelDevUS() string {

--- a/internal/nexodus/wg-deploy.go
+++ b/internal/nexodus/wg-deploy.go
@@ -17,7 +17,7 @@ func (ax *Nexodus) DeployWireguardConfig(newPeers []models.Device, firstTime boo
 		Peers:     ax.wgConfig.Peers,
 	}
 
-	if ax.wgLocalAddress != getIPv4Iface(ax.tunnelIface).String() {
+	if ax.wgLocalAddress != ax.getIPv4Iface(ax.tunnelIface).String() {
 		if err := ax.setupInterface(); err != nil {
 			return err
 		}

--- a/internal/nexodus/wg-iface.go
+++ b/internal/nexodus/wg-iface.go
@@ -3,8 +3,9 @@ package nexodus
 import (
 	"errors"
 	"fmt"
-	"go.uber.org/zap"
 	"net"
+
+	"go.uber.org/zap"
 )
 
 var interfaceErr = errors.New("interface setup error")
@@ -21,7 +22,19 @@ func ifaceExists(logger *zap.SugaredLogger, iface string) bool {
 }
 
 // getIPv4Iface get the IP of the specified net interface
-func getIPv4Iface(ifname string) net.IP {
+func (ax *Nexodus) getIPv4Iface(ifname string) net.IP {
+	if ax.userspaceMode {
+		return ax.getIPv4IfaceUS(ifname)
+	} else {
+		return ax.getIPv4IfaceOS(ifname)
+	}
+}
+
+func (ax *Nexodus) getIPv4IfaceUS(ifname string) net.IP {
+	return net.ParseIP(ax.userspaceLastAddress)
+}
+
+func (ax *Nexodus) getIPv4IfaceOS(ifname string) net.IP {
 	interfaces, _ := net.Interfaces()
 	for _, inter := range interfaces {
 		if inter.Name != ifname {


### PR DESCRIPTION
This is the next step for userspace-only mode support after PR #685.

This commit introduces the core networking and wireguard code for the 
userspace-only mode of operation. There is no real user-visible
behavior introduced yet. It is not exposed via `nexd` yet, but you can 
test out the core functionality with an env var.

You can observe with the following invocation of `nexd`. Note that
`root` or `sudo` are not required here. It is intended to be used
without any elevated permissions.

```
NEXD_LOGLEVEL=debug NEXD_USERSPACE_MODE_TEST=true dist/nexd --username kitteh1 --password floofykittens https://try.nexodus.local
```

If you watch the output, you'll see the userspace stack get 
initiatlized. All of the same discovery and peering that `nexd`
normally does will occur. One exception is that I have not yet 
implemented keepalives for this mode in `nexd`. Instead, I have
wireguard's native keepalives turned on for every 5 seconds.

For a peer it has successfully completed a handshake with, you'll see 
this debug message when the keepalives occur:

```
2023-03-31T12:05:39.485-0400DEBUG   device/send.go:82   peer(JuO2…16GM) - Sending keepalive packet
```

If you start `nexd` normally on another device with DEBUG logging
enabled, you should be able to observe that the keepalives sent by
`nexd` are successful to this new peer.

```
2023-03-31T16:09:05.081ZDEBUG   nexodus/keepalive.go:43 peer [ 100.100.0.2 ] is reachable
```

A follow-up commit will introduce features that make use of this,
namely the L4 proxy support proposed in
`docs/development/design/userspace-mode.md`.