### PR TITLE
nexd: Add an L4 proxy mode

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -2,6 +2,7 @@ config:
   line-length: false
   no-emphasis-as-header: false
   first-line-heading: false
+  code-block-style: false
 globs:
  - "**/*.md"
 ignores:

--- a/docs/user-guide/nexd-proxy.md
+++ b/docs/user-guide/nexd-proxy.md
@@ -1,0 +1,77 @@
+# Proxy Mode for `nexd`
+
+The normal mode of operation for `nexd` is to create a tunneled network interface on the device with an IP address within a Nexodus organization. Creating this network interface requires elevated privileges, so it is not usable in all environments.
+
+Containers are a common example of an environment where `nexd` cannot be run in its normal mode. In these cases, `nexd` can be run in `proxy` mode. In proxy mode, `nexd` will not create a tunneled network interface, but will instead operate as a layer 4 proxy.
+
+## Proxy Rules
+
+Proxy rules must be specified as command line flags to `nexd` after specifying the `proxy` subcommand.
+
+!!! warning "Beware of placement of flags to `nexd`"
+
+    `nexd` has both general flags and subcommand-specific flags. When running `nexd` in proxy mode, the subcommand-specific flags must be specified after the subcommand. For example, here is an example of providing a general flag, as well as a `proxy` subcommand-specific flag:
+
+    ```console
+    nexd --request-ip 100.100.0.50 proxy --ingress $INGRESS_PROXY_RULE
+    ```
+
+### Ingress Proxy
+
+Ingress proxy rules are specified with the `--ingress` flag. This flag can be specified multiple times to specify multiple ingress proxy rules. This is the format for an ingress proxy rule:
+
+```console
+--ingress protocol:port:destination_ip:destination_port
+```
+
+* `protocol` - must be `tcp`
+* `port` - the port on the host that the proxy will listen on for connections made from a network able to access this device.
+* `destination_ip` - the IP address of the destination within a Nexodus organization that the proxy will forward traffic to.
+* `destination_port` - the port on the destination within a Nexodus organization that the proxy will forward traffic to.
+
+Here is an example showing an ingress proxy rule:
+
+```console
+nexd proxy --ingress tcp:443:10.10.100.152:8443
+```
+
+```mermaid
+flowchart TD
+ linkStyle default interpolate basis
+ device1[Remote device running nexd<br/><br/>IP: 100.100.0.1<br/><br/>Initiates connection to 100.100.0.2:443]-->|tunnel|network{Nexodus Network<br/><br/>100.100.0.0/16}
+ network-->|tunnel|container[Container running nexd in proxy mode.<br/><br/>Nexodus IP: 100.100.0.2<br/>Local Network IP: 10.10.100.151<br/><br/>Accepts connections on 100.100.0.2:80 and forwards to 10.10.100.152:8443]
+
+ subgraph Local Network - 10.10.100.0/24
+ container-->|tcp|dest(Destination listening on port 8443<br/><br/>Local Network IP: 10.10.100.152)
+ end
+```
+
+### Egress Proxy
+
+Egress proxy rules are specified with the `--egress` flag. This flag can be specified multiple times to specify multiple egress proxy rules. This is the format for an egress proxy rule:
+
+```console
+--egress protocol:port:destination:destination_port
+```
+
+* `protocol` - must be `tcp`
+* `port` - the port that `nexd` will accept connections to made to its IP address within the Nexodus organization this device is a member of.
+* `destination` - the IP address or hostname of the destination on a network accessible to the device that the proxy will forward traffic to.
+* `destination_port` - the port on the destination on a network accessible to the device that the proxy will forward traffic to.
+
+Here is an example showing an egress proxy rule:
+
+```console
+nexd proxy --egress tcp:443:100.100.0.1:8443
+```
+
+```mermaid
+flowchart TD
+ linkStyle default interpolate basis
+ network{Nexodus Network<br/><br/>100.100.0.0/16}-->|tunnel|device1[Remote device running nexd <br/><br/>Nexodus IP: 100.100.0.1<br/><br/>Running a service that listens on TCP port 8443]
+ container[Container running nexd in proxy mode.<br/><br/>Nexodus IP: 100.100.0.2<br/>Local Network IP: 10.10.100.151<br/><br/>Accepts connections on 10.10.100.151:443 and forwards to 100.100.0.1:8443]-->|tunnel|network
+
+ subgraph Local Network - 10.10.100.0/24
+ dest(Source application connecting to port 443 on 10.10.100.151<br/><br/>Local Network IP: 10.10.100.152)-->|tcp|container
+ end
+```

--- a/internal/nexodus/nexodus.go
+++ b/internal/nexodus/nexodus.go
@@ -60,6 +60,8 @@ type userspaceWG struct {
 	userspaceDev  *device.Device
 	// the last address configured on the userspace wireguard interface
 	userspaceLastAddress string
+	ingresProxies        []*UsProxy
+	egressProxies        []*UsProxy
 }
 
 type Nexodus struct {
@@ -425,6 +427,13 @@ func (ax *Nexodus) Start(ctx context.Context, wg *sync.WaitGroup) error {
 			}
 		})
 	})
+
+	for _, proxy := range ax.ingresProxies {
+		proxy.Start(ctx, wg, ax.userspaceNet)
+	}
+	for _, proxy := range ax.egressProxies {
+		proxy.Start(ctx, wg, ax.userspaceNet)
+	}
 
 	return nil
 }

--- a/internal/nexodus/userspace_proxy.go
+++ b/internal/nexodus/userspace_proxy.go
@@ -1,0 +1,234 @@
+package nexodus
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/nexodus-io/nexodus/internal/util"
+	"go.uber.org/zap"
+	"golang.zx2c4.com/wireguard/tun/netstack"
+)
+
+type ProxyType int
+
+const (
+	ProxyTypeEgress ProxyType = iota
+	ProxyTypeIngress
+)
+
+type ProxyProtocol string
+
+const (
+	proxyProtocolTCP ProxyProtocol = "tcp"
+	proxyProtocolUDP ProxyProtocol = "udp"
+)
+
+type UsProxy struct {
+	ruleType     ProxyType
+	protocol     ProxyProtocol
+	listenPort   int
+	destHost     string
+	destPort     int
+	logger       *zap.SugaredLogger
+	userspaceNet *netstack.Net
+}
+
+func proxyTypeStr(ruleType ProxyType) (string, error) {
+	switch ruleType {
+	case ProxyTypeEgress:
+		return "egress", nil
+	case ProxyTypeIngress:
+		return "ingress", nil
+	default:
+		return "", fmt.Errorf("Invalid proxy rule type: %d", ruleType)
+	}
+}
+
+func proxyProtocol(protocol string) (ProxyProtocol, error) {
+	switch strings.ToLower(protocol) {
+	case "tcp":
+		return proxyProtocolTCP, nil
+	case "udp":
+		// TODO
+		return proxyProtocolUDP, fmt.Errorf("UDP proxy support not yet implemented")
+	default:
+		return "", fmt.Errorf("Invalid protocol (%s)", protocol)
+	}
+}
+
+func parsePort(portStr string) (int, error) {
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		return 0, fmt.Errorf("Invalid port (%s): %w", portStr, err)
+	}
+	return port, nil
+}
+
+func (ax *Nexodus) UserspaceProxyAdd(ctx context.Context, wg *sync.WaitGroup, proxyRule string, ruleType ProxyType) error {
+	typeStr, err := proxyTypeStr(ruleType)
+	if err != nil {
+		return err
+	}
+
+	// protocol:port:destination_ip:destination_port
+	ax.logger.Debugf("Adding userspace %s proxy rule: %s", typeStr, proxyRule)
+	parts := strings.Split(proxyRule, ":")
+	if len(parts) < 4 {
+		return fmt.Errorf("Invalid proxy rule format, must specify 4 colon-separated values (%s)", proxyRule)
+
+	}
+
+	protocol, err := proxyProtocol(parts[0])
+	if err != nil {
+		return err
+	}
+
+	port, err := parsePort(parts[1])
+	if err != nil {
+		return err
+	}
+
+	// Reassemble the string so that we parse IPv6 addresses correctly
+	destHostPort := strings.Join(parts[2:], ":")
+	destHost, destPortStr, err := net.SplitHostPort(destHostPort)
+	if err != nil {
+		return fmt.Errorf("Failed to parse destination host and port: %s", destHostPort)
+	}
+	destPort, err := parsePort(destPortStr)
+	if err != nil {
+		return err
+	}
+
+	proxy := &UsProxy{
+		ruleType:   ruleType,
+		protocol:   protocol,
+		listenPort: port,
+		destHost:   destHost,
+		destPort:   destPort,
+		logger:     ax.logger.With("proxy", typeStr, "proxyRule", proxyRule),
+	}
+
+	if ruleType == ProxyTypeEgress {
+		ax.egressProxies = append(ax.egressProxies, proxy)
+	} else {
+		ax.ingresProxies = append(ax.ingresProxies, proxy)
+	}
+
+	return nil
+}
+
+func (proxy *UsProxy) Start(ctx context.Context, wg *sync.WaitGroup, net *netstack.Net) {
+	proxy.userspaceNet = net
+	util.GoWithWaitGroup(wg, func() {
+		for {
+			// Use a different waitgroup here, because we want to make sure
+			// all of the subroutines have exited before we attempt to restart
+			// the proxy listener.
+			proxyWg := &sync.WaitGroup{}
+			err := proxy.run(ctx, proxyWg)
+			proxyWg.Wait()
+			if err == nil {
+				// No error means it shut down cleanly because it got a message to stop
+				break
+			}
+			proxy.logger.Debug("Proxy error, restarting: ", err)
+			time.Sleep(time.Second)
+		}
+	})
+}
+
+func (proxy *UsProxy) run(ctx context.Context, proxyWg *sync.WaitGroup) error {
+	var l net.Listener
+	var err error
+	if proxy.ruleType == ProxyTypeEgress {
+		l, err = net.Listen(fmt.Sprintf("%v", proxy.protocol), fmt.Sprintf(":%d", proxy.listenPort))
+	} else {
+		l, err = proxy.userspaceNet.ListenTCP(&net.TCPAddr{Port: proxy.listenPort})
+	}
+	if err != nil {
+		proxy.logger.Error("Error creating listener: ", err)
+		return err
+	}
+	defer l.Close()
+
+	// This routine will exit when the listener is closed intentionally,
+	// or some error occurs.
+	errChan := make(chan error)
+	util.GoWithWaitGroup(proxyWg, func() {
+		for {
+			conn, err := l.Accept()
+			if err != nil {
+				// Don't return an error if the context was canceled
+				if ctx.Err() == nil {
+					errChan <- err
+				}
+				break
+			}
+			util.GoWithWaitGroup(proxyWg, func() {
+				err = proxy.handleConnection(ctx, proxyWg, conn)
+				proxy.logger.Debugf("Connection from %s closed: %v", conn.RemoteAddr().String(), err)
+			})
+		}
+	})
+
+	// Handle new connections until we get notified to stop the CtlServer,
+	// or Accept() fails for some reason.
+	stopNow := false
+	for {
+		select {
+		case err = <-errChan:
+			// Accept() failed, collect the error and stop the CtlServer
+			stopNow = true
+			proxy.logger.Error("Error on Accept(): ", err)
+			break
+		case <-ctx.Done():
+			proxy.logger.Info("Stopping proxy due to context cancel")
+			stopNow = true
+			err = nil
+		}
+		if stopNow {
+			break
+		}
+	}
+
+	return err
+}
+
+func (proxy *UsProxy) handleConnection(ctx context.Context, proxyWg *sync.WaitGroup, inConn net.Conn) error {
+	defer inConn.Close()
+
+	proxyDest := net.JoinHostPort(proxy.destHost, fmt.Sprintf("%d", proxy.destPort))
+	proxy.logger.Debugf("Handling connection from %s, proxying to %s", inConn.RemoteAddr().String(), proxyDest)
+
+	var outConn net.Conn
+	var err error
+	protocolStr := fmt.Sprintf("%v", proxy.protocol)
+	if proxy.ruleType == ProxyTypeEgress {
+		outConn, err = proxy.userspaceNet.DialContext(ctx, protocolStr, proxyDest)
+	} else {
+		outConn, err = net.Dial(protocolStr, proxyDest)
+	}
+	if err != nil {
+		return err
+	}
+	defer outConn.Close()
+
+	util.GoWithWaitGroup(proxyWg, func() {
+		_, err := io.Copy(inConn, outConn)
+		if err != nil {
+			proxy.logger.Debugf("Error copying data from outConn to inConn: ", err)
+		}
+	})
+	_, err = io.Copy(outConn, inConn)
+	if err != nil {
+		proxy.logger.Debugf("Error copying data from inConn to outConn: ", err)
+	}
+
+	return nil
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,3 +52,7 @@ markdown_extensions:
         - name: mermaid
           class: mermaid
           format: !!python/name:pymdownx.superfences.fence_code_format
+  # The next 3 options enable admonitions (notes, warnings, etc.)
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences


### PR DESCRIPTION
This commit makes use of the ability to run entirely in userspace mode to implement basic L4 proxy functionality that requires no elevated privileges.

This mode can be used in a Kubernetes Pod where `nexd` is not able to create a new network device. It's possible to grant a pod the access it needs, but in many cases an application developer does not have this level of access available.

Multiple ingress or egress proxy rules may be specified at the same time, but they all must be specified as command line arguments. Runtime management of rules will come later.

Documentation on how to use this mode can be found in `docs/user-guide/nexd-proxy.md`. A preview of these docs can be found here: https://deploy-preview-700--nexodus-docs.netlify.app/user-guide/nexd-proxy/

Closes #187 