### PR TITLE
docs: Write up an end-to-end demo of nexd proxy

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -4,6 +4,7 @@ config:
   first-line-heading: false
   code-block-style: false
   no-duplicate-header: false
+  single-trailing-newline: false
 globs:
  - "**/*.md"
 ignores:


### PR DESCRIPTION
This section of the docs demonstrates how to run two docker containers with a nexd proxy in each one. These instructions just wroked for me against our prod deployment while tethered to a mobile network.