### PR TITLE
Remove the suite.fail from renNexd() in e2e

### DIFF
--- a/integration-tests/util_test.go
+++ b/integration-tests/util_test.go
@@ -280,14 +280,8 @@ func (suite *NexodusIntegrationSuite) runNexd(ctx context.Context, node testcont
 	suite.Require().NoError(err, fmt.Errorf("execution of copy command on %s failed: %v", nodeName, err))
 
 	// execute the nexd run script on the test container
-	out, err := suite.containerExec(ctx, node, []string{"/bin/bash", "-c", runScript})
-	if suite.T().Failed() {
-		suite.logger.Errorf("execution of command on %s failed: %s", nodeName, strings.Join(cmd, " "))
-		suite.logger.Errorf("output:\n%s", out)
-		suite.logger.Errorf("%+v", err)
-	} else {
-		suite.Require().NoError(err)
-	}
+	_, err = suite.containerExec(ctx, node, []string{"/bin/bash", "-c", runScript})
+	suite.Require().NoError(err)
 }
 
 func networkAddr(n *net.IPNet) net.IP {


### PR DESCRIPTION
- There isn't any output from the containerexec method so if there is a failure you simply get nil from err and a blank from output since that is a script getting piped to logs. The gather method collects logs for output and debugging. This changes it to just require the script is executed via containerexec.
- Also Im seeing a false positive on a test sourcing from this.