### PR TITLE
Flatten API responses and add more tests

### DIFF
--- a/cmd/nexctl/user.go
+++ b/cmd/nexctl/user.go
@@ -2,10 +2,8 @@ package main
 
 import (
 	"fmt"
-	"log"
-	"strings"
-
 	"github.com/nexodus-io/nexodus/internal/client"
+	"log"
 )
 
 func listUsers(c *client.Client, encodeOut string) error {
@@ -16,17 +14,13 @@ func listUsers(c *client.Client, encodeOut string) error {
 
 	if encodeOut == encodeColumn || encodeOut == encodeNoHeader {
 		w := newTabWriter()
-		fs := "%s\t%s\t%s\n"
+		fs := "%s\t%s\n"
 		if encodeOut != encodeNoHeader {
-			fmt.Fprintf(w, fs, "USER ID", "USER NAME", "ORGANIZATION ID")
+			fmt.Fprintf(w, fs, "USER ID", "USER NAME")
 		}
 
 		for _, user := range users {
-			var orgs []string
-			for _, o := range user.Organizations {
-				orgs = append(orgs, o.String())
-			}
-			fmt.Fprintf(w, fs, user.ID, user.UserName, strings.Join(orgs, ","))
+			fmt.Fprintf(w, fs, user.ID, user.UserName)
 		}
 
 		w.Flush()
@@ -88,16 +82,12 @@ func getCurrent(c *client.Client, encodeOut string) error {
 
 	if encodeOut == encodeColumn || encodeOut == encodeNoHeader {
 		w := newTabWriter()
-		fs := "%s\t%s\t%s\n"
+		fs := "%s\t%s\n"
 		if encodeOut != encodeNoHeader {
-			fmt.Fprintf(w, fs, "USER ID", "USER NAME", "ORGANIZATION ID")
+			fmt.Fprintf(w, fs, "USER ID", "USER NAME")
 		}
 
-		var orgs []string
-		for _, o := range user.Organizations {
-			orgs = append(orgs, o.String())
-		}
-		fmt.Fprintf(w, fs, user.ID, user.UserName, strings.Join(orgs, ","))
+		fmt.Fprintf(w, fs, user.ID, user.UserName)
 
 		w.Flush()
 

--- a/integration-tests/device-api.feature
+++ b/integration-tests/device-api.feature
@@ -9,20 +9,19 @@ Feature: Device API
 
     When I GET path "/api/users/me"
     Then the response code should be 200
-    Given I store the ".organizations[0]" selection from the response as ${organization_id}
     Given I store the ".id" selection from the response as ${user_id}
     And the response should match json:
       """
       {
-        "devices": [],
         "id": "${user_id}",
-        "invitations": [],
-        "organizations": [
-          "${organization_id}"
-        ],
         "username": "${response.username}"
       }
       """
+
+    When I GET path "/api/organizations"
+    Then the response code should be 200
+    Given I store the ${response[0].id} as ${organization_id}
+
 
     # Bob gets an empty list of devices..
     When I GET path "/api/devices"

--- a/integration-tests/invitation-api.feature
+++ b/integration-tests/invitation-api.feature
@@ -12,14 +12,24 @@ Feature: Invitations API
     Given I am logged in as "Johnson"
     When I GET path "/api/users/me"
     Then the response code should be 200
-    Given I store the ".organizations[0]" selection from the response as ${johnson_organization_id}
     Given I store the ".id" selection from the response as ${johnson_user_id}
+
+    When I GET path "/api/organizations"
+    Then the response code should be 200
+    Given I store the ${response[0].id} as ${johnson_organization_id}
+    Given I store the ${response[0]} as ${johnson_organization}
+
 
     Given I am logged in as "Thompson"
     When I GET path "/api/users/me"
     Then the response code should be 200
-    Given I store the ".organizations[0]" selection from the response as ${thompson_organization_id}
     Given I store the ".id" selection from the response as ${thompson_user_id}
+
+    When I GET path "/api/organizations"
+    Then the response code should be 200
+    Given I store the ${response[0].id} as ${thompson_organization_id}
+    Given I store the ${response[0]} as ${thompson_organization}
+
 
     # Current user is Thompson.. try to self add to Johnson's org.
     # this should not be allowed.
@@ -129,20 +139,11 @@ Feature: Invitations API
       """
 
     # Johnson should be in two orgs now...
-    When I GET path "/api/users/me"
+    When I GET path "/api/organizations"
     Then the response code should be 200
     And the response should match json:
       """
-      {
-        "devices": [],
-        "id": "${johnson_user_id}",
-        "invitations": [],
-        "organizations": [
-          "${johnson_organization_id}",
-          "${thompson_organization_id}"
-        ],
-        "username": "${response.username}"
-      }
+      [ ${johnson_organization}, ${thompson_organization} ]
       """
 
   Scenario: Receiver of invitation can delete the invitation
@@ -150,14 +151,21 @@ Feature: Invitations API
     Given I am logged in as "Johnson"
     When I GET path "/api/users/me"
     Then the response code should be 200
-    Given I store the ".organizations[0]" selection from the response as ${johnson_organization_id}
     Given I store the ".id" selection from the response as ${johnson_user_id}
+
+    When I GET path "/api/organizations"
+    Then the response code should be 200
+    Given I store the ${response[0].id} as ${johnson_organization_id}
 
     Given I am logged in as "Thompson"
     When I GET path "/api/users/me"
     Then the response code should be 200
-    Given I store the ".organizations[0]" selection from the response as ${thompson_organization_id}
     Given I store the ".id" selection from the response as ${thompson_user_id}
+
+    When I GET path "/api/organizations"
+    Then the response code should be 200
+    Given I store the ${response[0].id} as ${thompson_organization_id}
+
 
     # Create the invite.
     When I POST path "/api/invitations" with json body:
@@ -189,14 +197,20 @@ Feature: Invitations API
     Given I am logged in as "Johnson"
     When I GET path "/api/users/me"
     Then the response code should be 200
-    Given I store the ".organizations[0]" selection from the response as ${johnson_organization_id}
     Given I store the ".id" selection from the response as ${johnson_user_id}
+
+    When I GET path "/api/organizations"
+    Then the response code should be 200
+    Given I store the ${response[0].id} as ${johnson_organization_id}
 
     Given I am logged in as "Thompson"
     When I GET path "/api/users/me"
     Then the response code should be 200
-    Given I store the ".organizations[0]" selection from the response as ${thompson_organization_id}
     Given I store the ".id" selection from the response as ${thompson_user_id}
+
+    When I GET path "/api/organizations"
+    Then the response code should be 200
+    Given I store the ${response[0].id} as ${thompson_organization_id}
 
     # Create the invite.
     When I POST path "/api/invitations" with json body:

--- a/integration-tests/organization-api.feature
+++ b/integration-tests/organization-api.feature
@@ -12,15 +12,21 @@ Feature: Organization API
     Given I am logged in as "Oliver"
     When I GET path "/api/users/me"
     Then the response code should be 200
-    Given I store the ".organizations[0]" selection from the response as ${oliver_organization_id}
     Given I store the ".id" selection from the response as ${oliver_user_id}
+
+    When I GET path "/api/organizations"
+    Then the response code should be 200
+    Given I store the ${response[0].id} as ${oliver_organization_id}
 
     Given I am logged in as "Oscar"
     When I GET path "/api/users/me"
     Then the response code should be 200
-    Given I store the ".organizations[0]" selection from the response as ${oscar_organization_id}
     Given I store the ".id" selection from the response as ${oscar_user_id}
     Given I store the ".username" selection from the response as ${oscar_username}
+
+    When I GET path "/api/organizations"
+    Then the response code should be 200
+    Given I store the ${response[0].id} as ${oscar_organization_id}
 
     #
     # Oscar should only be able to see the orgs that he is a part of.
@@ -32,14 +38,10 @@ Feature: Organization API
         {
           "cidr": "100.100.0.0/16",
           "description": "${oscar_username}'s organization",
-          "devices": [],
           "hub_zone": true,
           "id": "${oscar_organization_id}",
           "name": "${oscar_username}",
-          "owner_id": "${oscar_user_id}",
-          "users": [
-            "${oscar_user_id}"
-          ]
+          "owner_id": "${oscar_user_id}"
         }
       ]
       """

--- a/integration-tests/organizations-devices-api.feature
+++ b/integration-tests/organizations-devices-api.feature
@@ -1,0 +1,147 @@
+Feature: Organization Devices API
+
+  Background:
+    Given a user named "Oliver" with password "testpass"
+    Given a user named "Oscar" with password "testpass"
+    Given a user named "EvilBob" with password "testpass"
+
+  Scenario: Show basic organization devices api in action
+
+    Given I am logged in as "EvilBob"
+    When I GET path "/api/users/me"
+    Then the response code should be 200
+    Given I store the ".id" selection from the response as ${evilbob_user_id}
+
+    #
+    # Lets puts add Oliver in Oscar's org.
+    #
+    Given I am logged in as "Oliver"
+    When I GET path "/api/users/me"
+    Then the response code should be 200
+    Given I store the ".id" selection from the response as ${oliver_user_id}
+
+    Given I am logged in as "Oscar"
+    When I GET path "/api/users/me"
+    Then the response code should be 200
+    Given I store the ".id" selection from the response as ${oscar_user_id}
+
+    When I GET path "/api/organizations"
+    Then the response code should be 200
+    Given I store the ${response[0].id} as ${organization_id}
+
+    When I POST path "/api/invitations" with json body:
+      """
+      {
+        "user_id": "${oliver_user_id}",
+        "organization_id": "${organization_id}"
+      }
+      """
+    Then the response code should be 201
+    Given I store the ".id" selection from the response as ${invitation_id}
+
+    Given I am logged in as "Oliver"
+    When I POST path "/api/invitations/${invitation_id}/accept"
+    Then the response code should be 204
+    And the response should match ""
+
+    # Each user can create devices in the org:
+    Given I generate a new public key as ${public_key}
+    When I POST path "/api/devices" with json body:
+      """
+      {
+        "user_id": "${oliver_user_id}",
+        "organization_id": "${organization_id}",
+        "public_key": "${public_key}",
+        "local_ip": "172.17.0.3:58664",
+        "tunnel_ip": "",
+        "child_prefix": null,
+        "relay": false,
+        "discovery": false,
+        "reflexive_ip4": "47.196.141.165",
+        "endpoint_local_address_ip4": "172.17.0.3",
+        "symmetric_nat": true,
+        "hostname": "oliver-laptop"
+      }
+      """
+    Then the response code should be 201
+    Given I store the ${response} as ${oliver_device}
+
+    Given I am logged in as "Oscar"
+    Given I generate a new public key as ${public_key}
+    When I POST path "/api/devices" with json body:
+      """
+      {
+        "user_id": "${oscar_user_id}",
+        "organization_id": "${organization_id}",
+        "public_key": "${public_key}",
+        "local_ip": "172.17.0.1:58664",
+        "tunnel_ip": "",
+        "child_prefix": null,
+        "relay": false,
+        "discovery": false,
+        "reflexive_ip4": "47.196.141.164",
+        "endpoint_local_address_ip4": "172.17.0.2",
+        "symmetric_nat": true,
+        "hostname": "oscar-pc"
+      }
+      """
+    Then the response code should be 201
+    Given I store the ${response} as ${oscar_device}
+
+    # Users that are not in the org should not be able to add devices to the org.
+    Given I am logged in as "EvilBob"
+    Given I generate a new public key as ${public_key}
+    When I POST path "/api/devices" with json body:
+      """
+      {
+        "user_id": "${evilbob_user_id}",
+        "organization_id": "${organization_id}",
+        "public_key": "${public_key}",
+        "local_ip": "172.17.0.21:58664",
+        "tunnel_ip": "",
+        "child_prefix": null,
+        "relay": false,
+        "discovery": false,
+        "reflexive_ip4": "47.196.141.124",
+        "endpoint_local_address_ip4": "172.17.2.2",
+        "symmetric_nat": true,
+        "hostname": "bob-pc"
+      }
+      """
+    Then the response code should be 404
+    And the response should match json:
+      """
+      { "error": "operation not allowed", "reason": "user or organization" }
+      """
+
+    # They both can see the devices
+    Given I am logged in as "Oscar"
+    When I GET path "/api/organizations/${organization_id}/devices"
+    Then the response code should be 200
+    And the response should match json:
+      """
+      [
+        ${oliver_device},
+        ${oscar_device}
+      ]
+      """
+
+    Given I am logged in as "Oliver"
+    When I GET path "/api/organizations/${organization_id}/devices"
+    Then the response code should be 200
+    And the response should match json:
+      """
+      [
+        ${oliver_device},
+        ${oscar_device}
+      ]
+      """
+
+    # Other user's should not see the devices.
+    Given I am logged in as "EvilBob"
+    When I GET path "/api/organizations/${organization_id}/devices"
+    Then the response code should be 404
+    And the response should match json:
+      """
+      { "error": "not found", "resource": "organization" }
+      """

--- a/integration-tests/organizations-users-api.feature
+++ b/integration-tests/organizations-users-api.feature
@@ -1,0 +1,78 @@
+Feature: Organization Users API
+
+  Background:
+    Given a user named "Oliver" with password "testpass"
+    Given a user named "Oscar" with password "testpass"
+    Given a user named "EvilBob" with password "testpass"
+
+  Scenario: Show basic organization users api in action
+
+    Given I am logged in as "EvilBob"
+    When I GET path "/api/users/me"
+    Then the response code should be 200
+
+    #
+    # Lets puts add Oliver in Oscar's org.
+    #
+    Given I am logged in as "Oliver"
+    When I GET path "/api/users/me"
+    Then the response code should be 200
+    Given I store the ".id" selection from the response as ${oliver_user_id}
+    Given I store the ${response} as ${oliver_user}
+
+    Given I am logged in as "Oscar"
+    When I GET path "/api/users/me"
+    Then the response code should be 200
+    Given I store the ".id" selection from the response as ${oscar_user_id}
+    Given I store the ${response} as ${oscar_user}
+
+    When I GET path "/api/organizations"
+    Then the response code should be 200
+    Given I store the ${response[0].id} as ${organization_id}
+
+    When I POST path "/api/invitations" with json body:
+      """
+      {
+        "user_id": "${oliver_user_id}",
+        "organization_id": "${organization_id}"
+      }
+      """
+    Then the response code should be 201
+    Given I store the ".id" selection from the response as ${invitation_id}
+
+    Given I am logged in as "Oliver"
+    When I POST path "/api/invitations/${invitation_id}/accept"
+    Then the response code should be 204
+    And the response should match ""
+
+    # They both can see the org users
+    Given I am logged in as "Oscar"
+    When I GET path "/api/organizations/${organization_id}/users"
+    Then the response code should be 200
+    And the response should match json:
+      """
+      [
+        ${oliver_user},
+        ${oscar_user}
+      ]
+      """
+
+    Given I am logged in as "Oliver"
+    When I GET path "/api/organizations/${organization_id}/users"
+    Then the response code should be 200
+    And the response should match json:
+      """
+      [
+        ${oliver_user},
+        ${oscar_user}
+      ]
+      """
+
+    # Other user's should not see the devices.
+    Given I am logged in as "EvilBob"
+    When I GET path "/api/organizations/${organization_id}/users"
+    Then the response code should be 404
+    And the response should match json:
+      """
+      { "error": "not found", "resource": "organization" }
+      """

--- a/integration-tests/steps_test.go
+++ b/integration-tests/steps_test.go
@@ -40,7 +40,7 @@ func (s *extender) aUserNamedWithPassword(username string, password string) erro
 	defer s.Suite.Mu.Unlock()
 
 	// user already exists...
-	if s.Suite.Users[username] != nil {
+	if s.Users[username] != nil {
 		return nil
 	}
 	ctx := s.Suite.Context
@@ -50,7 +50,7 @@ func (s *extender) aUserNamedWithPassword(username string, password string) erro
 		return err
 	}
 
-	s.Suite.Users[username] = &cucumber.TestUser{
+	s.Users[username] = &cucumber.TestUser{
 		Name:     username,
 		Password: password,
 		Subject:  userId,
@@ -61,7 +61,7 @@ func (s *extender) aUserNamedWithPassword(username string, password string) erro
 func (s *extender) storeUserId(name, varName string) error {
 	s.Suite.Mu.Lock()
 	defer s.Suite.Mu.Unlock()
-	user := s.Suite.Users[name]
+	user := s.Users[name]
 	if user != nil {
 		s.Variables[varName] = user.Subject
 	}
@@ -70,7 +70,7 @@ func (s *extender) storeUserId(name, varName string) error {
 
 func (s *extender) iAmLoggedInAs(username string) error {
 	s.Suite.Mu.Lock()
-	user := s.Suite.Users[username]
+	user := s.Users[username]
 	s.Suite.Mu.Unlock()
 
 	if user == nil {

--- a/integration-tests/users-api.feature
+++ b/integration-tests/users-api.feature
@@ -15,20 +15,18 @@ Feature: Users API
     Given I am logged in as "EvilUrsala"
     When I GET path "/api/users/me"
     Then the response code should be 200
-    Given I store the ".organizations[0]" selection from the response as ${organization_id}
     Given I store the ".id" selection from the response as ${ursala_id}
     And the response should match json:
       """
       {
-        "devices": [],
         "id": "${ursala_id}",
-        "invitations": [],
-        "organizations": [
-          "${organization_id}"
-        ],
         "username": "${response.username}"
       }
       """
+
+    When I GET path "/api/organizations"
+    Then the response code should be 200
+    Given I store the ${response[0].id} as ${organization_id}
 
     # EvilUrsala can only see her own user id...
     When I GET path "/api/users"
@@ -37,12 +35,7 @@ Feature: Users API
       """
       [
         {
-          "devices": [],
           "id": "${ursala_id}",
-          "invitations": [],
-          "organizations": [
-            "${organization_id}"
-          ],
           "username": "${response[0].username}"
         }
       ]
@@ -54,12 +47,7 @@ Feature: Users API
     And the response should match json:
       """
       {
-        "devices": [],
         "id": "${ursala_id}",
-        "invitations": [],
-        "organizations": [
-          "${organization_id}"
-        ],
         "username": "${response.username}"
       }
       """
@@ -86,10 +74,7 @@ Feature: Users API
     And the response should match json:
       """
       {
-        "devices": [],
         "id": "${ursala_id}",
-        "invitations": [],
-        "organizations": [],
         "username": "${response.username}"
       }
       """

--- a/internal/client/organization.go
+++ b/internal/client/organization.go
@@ -120,6 +120,37 @@ func (c *Client) GetOrganization(id uuid.UUID) (models.OrganizationJSON, error) 
 	return data, nil
 }
 
+func (c *Client) GetOrganizations() ([]models.OrganizationJSON, error) {
+	dest := c.baseURL.JoinPath(ORGANIZATIONS).String()
+
+	req, err := http.NewRequest(http.MethodGet, dest, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := c.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+
+	resBody, err := io.ReadAll(res.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if res.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to get organizations %d", res.StatusCode)
+	}
+
+	var data []models.OrganizationJSON
+	if err := json.Unmarshal(resBody, &data); err != nil {
+		return nil, err
+	}
+
+	return data, nil
+}
+
 // GetOrganizations gets an organization by ID
 func (c *Client) GetDeviceInOrganization(id uuid.UUID) ([]models.Device, error) {
 	dest := c.baseURL.JoinPath(fmt.Sprintf(ORGANIZATION_DEVICES, id.String())).String()

--- a/internal/cucumber/cucumber.go
+++ b/internal/cucumber/cucumber.go
@@ -48,7 +48,6 @@ import (
 func NewTestSuite() *TestSuite {
 	return &TestSuite{
 		ApiURL:    "http://localhost:8000",
-		Users:     map[string]*TestUser{},
 		nextOrgId: 20000000,
 	}
 }
@@ -71,7 +70,6 @@ type TestSuite struct {
 	Context   context.Context
 	ApiURL    string
 	Mu        sync.Mutex
-	Users     map[string]*TestUser
 	nextOrgId uint32
 	TlsConfig *tls.Config
 }
@@ -95,13 +93,14 @@ type TestScenario struct {
 	PathPrefix      string
 	sessions        map[string]*TestSession
 	Variables       map[string]interface{}
+	Users           map[string]*TestUser
 	hasTestCaseLock bool
 }
 
 func (s *TestScenario) User() *TestUser {
 	s.Suite.Mu.Lock()
 	defer s.Suite.Mu.Unlock()
-	return s.Suite.Users[s.CurrentUser]
+	return s.Users[s.CurrentUser]
 }
 
 func (s *TestScenario) Session() *TestSession {
@@ -280,6 +279,7 @@ var StepModules []func(ctx *godog.ScenarioContext, s *TestScenario)
 func (suite *TestSuite) InitializeScenario(ctx *godog.ScenarioContext) {
 	s := &TestScenario{
 		Suite:     suite,
+		Users:     map[string]*TestUser{},
 		sessions:  map[string]*TestSession{},
 		Variables: map[string]interface{}{},
 	}

--- a/internal/docs/docs.go
+++ b/internal/docs/docs.go
@@ -1022,12 +1022,6 @@ const docTemplate = `{
                 "description": {
                     "type": "string"
                 },
-                "devices": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/models.Device"
-                    }
-                },
                 "hubZone": {
                     "type": "boolean"
                 },
@@ -1049,12 +1043,6 @@ const docTemplate = `{
                 },
                 "ownerID": {
                     "type": "string"
-                },
-                "users": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/models.User"
-                    }
                 }
             }
         },
@@ -1100,28 +1088,10 @@ const docTemplate = `{
                 "createdAt": {
                     "type": "string"
                 },
-                "devices": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/models.Device"
-                    }
-                },
                 "id": {
                     "description": "Since the ID comes from the IDP, we have no control over the format...",
                     "type": "string",
                     "example": "aa22666c-0f57-45cb-a449-16efecc04f2e"
-                },
-                "invitations": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/models.Invitation"
-                    }
-                },
-                "organizations": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/models.Organization"
-                    }
                 },
                 "updatedAt": {
                     "type": "string"

--- a/internal/docs/swagger.json
+++ b/internal/docs/swagger.json
@@ -1015,12 +1015,6 @@
                 "description": {
                     "type": "string"
                 },
-                "devices": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/models.Device"
-                    }
-                },
                 "hubZone": {
                     "type": "boolean"
                 },
@@ -1042,12 +1036,6 @@
                 },
                 "ownerID": {
                     "type": "string"
-                },
-                "users": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/models.User"
-                    }
                 }
             }
         },
@@ -1093,28 +1081,10 @@
                 "createdAt": {
                     "type": "string"
                 },
-                "devices": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/models.Device"
-                    }
-                },
                 "id": {
                     "description": "Since the ID comes from the IDP, we have no control over the format...",
                     "type": "string",
                     "example": "aa22666c-0f57-45cb-a449-16efecc04f2e"
-                },
-                "invitations": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/models.Invitation"
-                    }
-                },
-                "organizations": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/models.Organization"
-                    }
                 },
                 "updatedAt": {
                     "type": "string"

--- a/internal/docs/swagger.yaml
+++ b/internal/docs/swagger.yaml
@@ -76,10 +76,6 @@ definitions:
     properties:
       description:
         type: string
-      devices:
-        items:
-          $ref: '#/definitions/models.Device'
-        type: array
       hubZone:
         type: boolean
       id:
@@ -95,10 +91,6 @@ definitions:
         type: string
       ownerID:
         type: string
-      users:
-        items:
-          $ref: '#/definitions/models.User'
-        type: array
     type: object
   models.UpdateDevice:
     properties:
@@ -129,23 +121,11 @@ definitions:
     properties:
       createdAt:
         type: string
-      devices:
-        items:
-          $ref: '#/definitions/models.Device'
-        type: array
       id:
         description: Since the ID comes from the IDP, we have no control over the
           format...
         example: aa22666c-0f57-45cb-a449-16efecc04f2e
         type: string
-      invitations:
-        items:
-          $ref: '#/definitions/models.Invitation'
-        type: array
-      organizations:
-        items:
-          $ref: '#/definitions/models.Organization'
-        type: array
       updatedAt:
         type: string
       userName:

--- a/internal/handlers/device.go
+++ b/internal/handlers/device.go
@@ -47,7 +47,7 @@ func (api *API) ListDevices(c *gin.Context) {
 
 	result := api.db.WithContext(ctx).Scopes(
 		api.DeviceIsOwnedByCurrentUser(c),
-		FilterAndPaginate(&models.Device{}, c),
+		FilterAndPaginate(&models.Device{}, c, "hostname"),
 	).Find(&devices)
 
 	if result.Error != nil {

--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -53,7 +53,7 @@ func (q *Query) GetFilter() (map[string]interface{}, error) {
 	return parts, nil
 }
 
-func FilterAndPaginate(model interface{}, c *gin.Context) func(db *gorm.DB) *gorm.DB {
+func FilterAndPaginate(model interface{}, c *gin.Context, orderBy string) func(db *gorm.DB) *gorm.DB {
 	return func(db *gorm.DB) *gorm.DB {
 		var query Query
 		if err := c.BindQuery(&query); err != nil {
@@ -62,6 +62,8 @@ func FilterAndPaginate(model interface{}, c *gin.Context) func(db *gorm.DB) *gor
 
 		if order, err := query.GetSort(); err == nil {
 			db = db.Order(order)
+		} else if orderBy != "" {
+			db = db.Order(orderBy)
 		}
 
 		if filter, err := query.GetFilter(); err == nil {

--- a/internal/handlers/organization.go
+++ b/internal/handlers/organization.go
@@ -144,14 +144,19 @@ func (api *API) ListOrganizations(c *gin.Context) {
 	defer span.End()
 	var orgs []models.Organization
 	result := api.db.WithContext(ctx).
-		Preload("Devices").
-		Preload("Users").
 		Scopes(api.OrganizationIsReadableByCurrentUser(c)).
-		Scopes(FilterAndPaginate(&models.Organization{}, c)).Find(&orgs)
+		Scopes(FilterAndPaginate(&models.Organization{}, c, "name")).
+		Find(&orgs)
+
 	if result.Error != nil {
-		c.JSON(http.StatusInternalServerError, models.NewApiInternalError(result.Error))
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			c.JSON(http.StatusNotFound, models.NewNotFoundError("organization"))
+		} else {
+			c.JSON(http.StatusInternalServerError, models.NewApiInternalError(result.Error))
+		}
 		return
 	}
+
 	c.JSON(http.StatusOK, orgs)
 }
 
@@ -181,14 +186,18 @@ func (api *API) GetOrganizations(c *gin.Context) {
 	}
 	var org models.Organization
 	result := api.db.WithContext(ctx).
-		Preload("Devices").
-		Preload("Users").
 		Scopes(api.OrganizationIsReadableByCurrentUser(c)).
 		First(&org, "id = ?", k.String())
-	if errors.Is(result.Error, gorm.ErrRecordNotFound) {
-		c.Status(http.StatusNotFound)
+
+	if result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			c.JSON(http.StatusNotFound, models.NewNotFoundError("organization"))
+		} else {
+			c.JSON(http.StatusInternalServerError, models.NewApiInternalError(result.Error))
+		}
 		return
 	}
+
 	c.JSON(http.StatusOK, org)
 }
 
@@ -206,6 +215,7 @@ func (api *API) GetOrganizations(c *gin.Context) {
 // @Failure		 500  {object}  models.BaseError
 // @Router       /organizations/{id}/devices [get]
 func (api *API) ListDevicesInOrganization(c *gin.Context) {
+
 	ctx, span := tracer.Start(c.Request.Context(), "ListDevicesInOrganization")
 	defer span.End()
 	k, err := uuid.Parse(c.Param("organization"))
@@ -214,19 +224,34 @@ func (api *API) ListDevicesInOrganization(c *gin.Context) {
 		return
 	}
 	var org models.Organization
-	res := api.db.WithContext(ctx).
-		Preload("Devices").
+	result := api.db.WithContext(ctx).
 		Scopes(api.OrganizationIsReadableByCurrentUser(c)).
 		First(&org, "id = ?", k.String())
 
-	if res.Error != nil {
-		c.JSON(http.StatusInternalServerError, models.NewApiInternalError(res.Error))
+	if result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			c.JSON(http.StatusNotFound, models.NewNotFoundError("organization"))
+		} else {
+			c.JSON(http.StatusInternalServerError, models.NewApiInternalError(result.Error))
+		}
 		return
 	}
+
+	var devices []*models.Device
+	result = api.db.WithContext(ctx).
+		Scopes(FilterAndPaginate(&models.Device{}, c, "hostname")).
+		Where("organization_id = ?", k.String()).
+		Find(&devices)
+
+	if result.Error != nil && !errors.Is(result.Error, gorm.ErrRecordNotFound) {
+		c.JSON(http.StatusInternalServerError, models.NewApiInternalError(result.Error))
+		return
+	}
+
 	// For pagination
 	c.Header("Access-Control-Expose-Headers", TotalCountHeader)
-	c.Header(TotalCountHeader, strconv.Itoa(len(org.Devices)))
-	c.JSON(http.StatusOK, org.Devices)
+	c.Header(TotalCountHeader, strconv.Itoa(len(devices)))
+	c.JSON(http.StatusOK, devices)
 }
 
 // GetDeviceInOrganization gets a device in a Organization
@@ -261,10 +286,15 @@ func (api *API) GetDeviceInOrganization(c *gin.Context) {
 	result := api.db.WithContext(ctx).
 		Scopes(api.OrganizationIsReadableByCurrentUser(c)).
 		First(&organization, "id = ?", orgId.String())
-	if errors.Is(result.Error, gorm.ErrRecordNotFound) {
-		c.JSON(http.StatusNotFound, models.NewNotFoundError("organization"))
+	if result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			c.JSON(http.StatusNotFound, models.NewNotFoundError("organization"))
+		} else {
+			c.JSON(http.StatusInternalServerError, models.NewApiInternalError(result.Error))
+		}
 		return
 	}
+
 	id, err := uuid.Parse(c.Param("id"))
 	if err != nil {
 		c.JSON(http.StatusBadRequest, models.NewBadPathParameterError("id"))
@@ -275,9 +305,12 @@ func (api *API) GetDeviceInOrganization(c *gin.Context) {
 	result = api.db.WithContext(ctx).
 		Where("organization_id = ?", orgId.String()).
 		First(&device, "id = ?", id.String())
-	if errors.Is(result.Error, gorm.ErrRecordNotFound) {
-		c.JSON(http.StatusNotFound, models.NewNotFoundError("device"))
-		return
+	if result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			models.NewNotFoundError("device")
+		} else {
+			c.JSON(http.StatusInternalServerError, models.NewApiInternalError(result.Error))
+		}
 	}
 	c.JSON(http.StatusOK, device)
 }
@@ -291,18 +324,35 @@ func (api *API) ListUsersInOrganization(c *gin.Context) {
 		return
 	}
 	var org models.Organization
-	res := api.db.WithContext(ctx).
-		Preload("Users").
+	result := api.db.WithContext(ctx).
 		Scopes(api.OrganizationIsReadableByCurrentUser(c)).
 		First(&org, "id = ?", k.String())
-	if res.Error != nil {
-		c.JSON(http.StatusInternalServerError, models.NewApiInternalError(res.Error))
+
+	if result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			c.JSON(http.StatusNotFound, models.NewNotFoundError("organization"))
+		} else {
+			c.JSON(http.StatusInternalServerError, models.NewApiInternalError(result.Error))
+		}
 		return
 	}
+
+	var users []*models.User
+	result = api.db.WithContext(ctx).
+		Joins("inner join user_organizations on user_organizations.user_id=users.id").
+		Where("user_organizations.organization_id = ?", k.String()).
+		Scopes(FilterAndPaginate(&models.User{}, c, "user_name")).
+		Find(&users)
+
+	if result.Error != nil && !errors.Is(result.Error, gorm.ErrRecordNotFound) {
+		c.JSON(http.StatusInternalServerError, models.NewApiInternalError(result.Error))
+		return
+	}
+
 	// For pagination
 	c.Header("Access-Control-Expose-Headers", TotalCountHeader)
-	c.Header(TotalCountHeader, strconv.Itoa(len(org.Users)))
-	c.JSON(http.StatusOK, org.Users)
+	c.Header(TotalCountHeader, strconv.Itoa(len(users)))
+	c.JSON(http.StatusOK, users)
 }
 
 // DeleteOrganization handles deleting an existing organization and associated ipam prefix
@@ -342,10 +392,16 @@ func (api *API) DeleteOrganization(c *gin.Context) {
 	}
 
 	var org models.Organization
-	if res := api.db.WithContext(ctx).
-		Scopes(api.OrganizationIsOwnedByCurrentUser(c)).
-		First(&org, "id = ?", orgID); res.Error != nil {
-		c.JSON(http.StatusNotFound, models.NewNotFoundError("organization"))
+	result := api.db.WithContext(ctx).
+		Scopes(api.OrganizationIsReadableByCurrentUser(c)).
+		First(&org, "id = ?", orgID)
+
+	if result.Error != nil {
+		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+			c.JSON(http.StatusNotFound, models.NewNotFoundError("organization"))
+		} else {
+			c.JSON(http.StatusInternalServerError, models.NewApiInternalError(result.Error))
+		}
 		return
 	}
 

--- a/internal/handlers/organization.go
+++ b/internal/handlers/organization.go
@@ -307,10 +307,11 @@ func (api *API) GetDeviceInOrganization(c *gin.Context) {
 		First(&device, "id = ?", id.String())
 	if result.Error != nil {
 		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
-			models.NewNotFoundError("device")
+			c.JSON(http.StatusNotFound, models.NewNotFoundError("device"))
 		} else {
 			c.JSON(http.StatusInternalServerError, models.NewApiInternalError(result.Error))
 		}
+		return
 	}
 	c.JSON(http.StatusOK, device)
 }

--- a/internal/handlers/organization_test.go
+++ b/internal/handlers/organization_test.go
@@ -150,10 +150,10 @@ func (suite *HandlerTestSuite) TestListOrganizations() {
 		var actual []models.OrganizationJSON
 		err = json.Unmarshal(body, &actual)
 		assert.NoError(err)
-
+		// The orgs are sorted by name..
 		assert.Len(actual, 1)
 		assert.Equal("4", res.Header().Get(TotalCountHeader))
-		assert.Equal("organization-c", actual[0].Name)
+		assert.Equal("testuser", actual[0].Name)
 	}
 
 }

--- a/internal/handlers/user.go
+++ b/internal/handlers/user.go
@@ -45,7 +45,9 @@ func (api *API) createUserIfNotExists(ctx context.Context, id string, userName s
 	defer span.End()
 	var user models.User
 	err := api.transaction(ctx, func(tx *gorm.DB) error {
-		res := tx.Preload("Organizations").First(&user, "id = ?", id)
+		res := tx.
+			Preload("Organizations").
+			First(&user, "id = ?", id)
 		if res.Error != nil {
 			if errors.Is(res.Error, gorm.ErrRecordNotFound) {
 				user.ID = id
@@ -120,8 +122,6 @@ func (api *API) GetUser(c *gin.Context) {
 	}
 
 	if res := api.db.WithContext(ctx).
-		Preload("Devices").
-		Preload("Organizations").
 		Scopes(api.UserIsCurrentUser(c)).
 		First(&user, "id = ?", userId); res.Error != nil {
 		c.JSON(http.StatusNotFound, models.NewNotFoundError("user"))
@@ -145,10 +145,8 @@ func (api *API) ListUsers(c *gin.Context) {
 	defer span.End()
 	users := make([]*models.User, 0)
 	result := api.db.WithContext(ctx).
-		Preload("Devices").
-		Preload("Organizations").
 		Scopes(api.UserIsCurrentUser(c)).
-		Scopes(FilterAndPaginate(&models.User{}, c)).
+		Scopes(FilterAndPaginate(&models.User{}, c, "user_name")).
 		Find(&users)
 
 	if result.Error != nil {

--- a/internal/handlers/user_test.go
+++ b/internal/handlers/user_test.go
@@ -26,5 +26,5 @@ func (suite *HandlerTestSuite) TestGetUser() {
 	err = json.Unmarshal(body, &actual)
 	require.NoError(err, string(body))
 
-	assert.Equal(1, len(actual.Organizations))
+	assert.NotEmpty(actual.ID)
 }

--- a/internal/models/organization.go
+++ b/internal/models/organization.go
@@ -22,32 +22,22 @@ type Organization struct {
 
 // Organization contains Users and their Devices
 type OrganizationJSON struct {
-	ID          uuid.UUID   `json:"id"`
-	OwnerID     string      `json:"owner_id" example:"aa22666c-0f57-45cb-a449-16efecc04f2e"`
-	Users       []string    `json:"-" example:"94deb404-c4eb-4097-b59d-76b024ff7867"`
-	Devices     []uuid.UUID `json:"-" example:"4902c991-3dd1-49a6-9f26-d82496c80aff"`
-	Name        string      `json:"name" example:"zone-red"`
-	Description string      `json:"description" example:"The Red Zone"`
-	IpCidr      string      `json:"cidr" example:"172.16.42.0/24"`
-	HubZone     bool        `json:"hub_zone"`
+	ID          uuid.UUID `json:"id"`
+	OwnerID     string    `json:"owner_id" example:"aa22666c-0f57-45cb-a449-16efecc04f2e"`
+	Name        string    `json:"name" example:"zone-red"`
+	Description string    `json:"description" example:"The Red Zone"`
+	IpCidr      string    `json:"cidr" example:"172.16.42.0/24"`
+	HubZone     bool      `json:"hub_zone"`
 }
 
 func (o Organization) MarshalJSON() ([]byte, error) {
 	org := OrganizationJSON{
 		ID:          o.ID,
 		OwnerID:     o.OwnerID,
-		Users:       make([]string, 0),
-		Devices:     make([]uuid.UUID, 0),
 		Name:        o.Name,
 		Description: o.Description,
 		IpCidr:      o.IpCidr,
 		HubZone:     o.HubZone,
-	}
-	for _, user := range o.Users {
-		org.Users = append(org.Users, user.ID)
-	}
-	for _, device := range o.Devices {
-		org.Devices = append(org.Devices, device.ID)
 	}
 	return json.Marshal(org)
 }

--- a/internal/models/organization.go
+++ b/internal/models/organization.go
@@ -10,10 +10,10 @@ import (
 // Organization contains Users and their Devices
 type Organization struct {
 	Base
-	OwnerID     string  `gorm:"owner_id;"`
-	Users       []*User `gorm:"many2many:user_organizations;"`
-	Devices     []*Device
-	Name        string `gorm:"uniqueIndex" sql:"index"`
+	OwnerID     string    `gorm:"owner_id;"`
+	Users       []*User   `gorm:"many2many:user_organizations;" json:"-"`
+	Devices     []*Device `json:"-"`
+	Name        string    `gorm:"uniqueIndex" sql:"index"`
 	Description string
 	IpCidr      string
 	HubZone     bool
@@ -24,8 +24,8 @@ type Organization struct {
 type OrganizationJSON struct {
 	ID          uuid.UUID   `json:"id"`
 	OwnerID     string      `json:"owner_id" example:"aa22666c-0f57-45cb-a449-16efecc04f2e"`
-	Users       []string    `json:"users" example:"94deb404-c4eb-4097-b59d-76b024ff7867"`
-	Devices     []uuid.UUID `json:"devices" example:"4902c991-3dd1-49a6-9f26-d82496c80aff"`
+	Users       []string    `json:"-" example:"94deb404-c4eb-4097-b59d-76b024ff7867"`
+	Devices     []uuid.UUID `json:"-" example:"4902c991-3dd1-49a6-9f26-d82496c80aff"`
 	Name        string      `json:"name" example:"zone-red"`
 	Description string      `json:"description" example:"The Red Zone"`
 	IpCidr      string      `json:"cidr" example:"172.16.42.0/24"`

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"time"
 
-	"github.com/google/uuid"
 	"gorm.io/gorm"
 )
 
@@ -22,28 +21,15 @@ type User struct {
 }
 
 type UserJSON struct {
-	ID            string        `json:"id" example:"aa22666c-0f57-45cb-a449-16efecc04f2e"`
-	Devices       []uuid.UUID   `json:"-" example:"4902c991-3dd1-49a6-9f26-d82496c80aff"`
-	Organizations []uuid.UUID   `json:"-" example:"94deb404-c4eb-4097-b59d-76b024ff7867"`
-	UserName      string        `json:"username" example:"admin"`
-	Invitations   []*Invitation `json:"-"`
+	ID       string `json:"id" example:"aa22666c-0f57-45cb-a449-16efecc04f2e"`
+	UserName string `json:"username" example:"admin"`
 }
 
 func (u User) MarshalJSON() ([]byte, error) {
 	user := UserJSON{
-		ID:            u.ID,
-		Devices:       make([]uuid.UUID, 0),
-		Organizations: make([]uuid.UUID, 0),
-		UserName:      u.UserName,
-		Invitations:   make([]*Invitation, 0),
+		ID:       u.ID,
+		UserName: u.UserName,
 	}
-	for _, device := range u.Devices {
-		user.Devices = append(user.Devices, device.ID)
-	}
-	for _, org := range u.Organizations {
-		user.Organizations = append(user.Organizations, org.ID)
-	}
-	user.Invitations = append(user.Invitations, u.Invitations...)
 	return json.Marshal(user)
 }
 

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -14,19 +14,19 @@ type User struct {
 	ID            string `gorm:"primary_key;" json:"id" example:"aa22666c-0f57-45cb-a449-16efecc04f2e"`
 	CreatedAt     time.Time
 	UpdatedAt     time.Time
-	DeletedAt     *time.Time `sql:"index" json:"-"`
-	Devices       []*Device
-	Organizations []*Organization `gorm:"many2many:user_organizations"`
+	DeletedAt     *time.Time      `sql:"index" json:"-"`
+	Devices       []*Device       `json:"-"`
+	Organizations []*Organization `gorm:"many2many:user_organizations" json:"-"`
 	UserName      string
-	Invitations   []*Invitation
+	Invitations   []*Invitation `json:"-"`
 }
 
 type UserJSON struct {
 	ID            string        `json:"id" example:"aa22666c-0f57-45cb-a449-16efecc04f2e"`
-	Devices       []uuid.UUID   `json:"devices" example:"4902c991-3dd1-49a6-9f26-d82496c80aff"`
-	Organizations []uuid.UUID   `json:"organizations" example:"94deb404-c4eb-4097-b59d-76b024ff7867"`
+	Devices       []uuid.UUID   `json:"-" example:"4902c991-3dd1-49a6-9f26-d82496c80aff"`
+	Organizations []uuid.UUID   `json:"-" example:"94deb404-c4eb-4097-b59d-76b024ff7867"`
 	UserName      string        `json:"username" example:"admin"`
-	Invitations   []*Invitation `json:"invitations"`
+	Invitations   []*Invitation `json:"-"`
 }
 
 func (u User) MarshalJSON() ([]byte, error) {

--- a/internal/nexodus/nexodus.go
+++ b/internal/nexodus/nexodus.go
@@ -261,17 +261,22 @@ func (ax *Nexodus) Start(ctx context.Context, wg *sync.WaitGroup) error {
 
 	user, err := ax.client.GetCurrentUser()
 	if err != nil {
-		return fmt.Errorf("get organization error: %w", err)
+		return fmt.Errorf("get user error: %w", err)
 	}
 
-	if len(user.Organizations) == 0 {
+	organizations, err := ax.client.GetOrganizations()
+	if err != nil {
+		return fmt.Errorf("get organizations error: %w", err)
+	}
+
+	if len(organizations) == 0 {
 		return fmt.Errorf("user does not belong to any organizations")
 	}
-	if len(user.Organizations) != 1 {
+	if len(organizations) != 1 {
 		return fmt.Errorf("user being in > 1 organization is not yet supported")
 	}
-	ax.logger.Infof("Device belongs in organization: %s", user.Organizations[0])
-	ax.organization = user.Organizations[0]
+	ax.logger.Infof("Device belongs in organization: %s (%s)", organizations[0].Name, organizations[0].ID)
+	ax.organization = organizations[0].ID
 
 	var localIP string
 	var localEndpointPort int


### PR DESCRIPTION
This adds more cucumber tests and it also 'flattens' the api responses.  Getting resource no longer joins the associated resources in the response.  This will allow us to have a more consistent data access cost per API request and make rate limiting work better.  This also simplifies the overall API.