### PR TITLE
Add nexrc.env for easy sourcing of nexodus URLs

### DIFF
--- a/nexrc.env
+++ b/nexrc.env
@@ -1,0 +1,18 @@
+# This file can be sourced in your shell for convenience
+# so you don't have to remember the hostnames for local development, 
+# as well as the project's QA and production environments.
+#
+# Usage:
+# $ source nexrc.env
+#
+# Or update your shell's rc file to source this file automatically.
+# For example, if you use bash:
+# $ echo "if [ -f $PWD/nexrc.env ] ; then source $PWD/nexrc.env ; fi" >> ~/.bashrc
+
+# Local development using `make run-on-kind` or otherwise
+# using the `dev` kustomize overlay.
+NEX_DEV="https://try.nexodus.127.0.0.1.nip.io"
+
+# Public QA and production environments
+NEX_QA="https://qa.nexodus.io"
+NEX_PROD="https://try.nexodus.io"


### PR DESCRIPTION
I didn't want to type `try.nexodus.127.0.0.1.nip.io` all the time, so I made this to keep in my environment. I figured others may want the same so I put it in the repo.