### PR TITLE
fix: exclude the `qa` and `prod` tags from being used to described th…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ else
 endif
 
 NEXODUS_VERSION?=$(shell date +%Y.%m.%d)
-NEXODUS_RELEASE?=$(shell git describe --always)
+NEXODUS_RELEASE?=$(shell git describe --always --exclude qa --exclude prod)
 NEXODUS_LDFLAGS?=-X main.Version=$(NEXODUS_VERSION)-$(NEXODUS_RELEASE)
 NEXODUS_GCFLAGS?=
 


### PR DESCRIPTION
…e release.