### PR TITLE
Makefile: Allow running a specific e2e test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -166,7 +166,7 @@ generate: gen-docs ## Run all code generators and formatters
 
 .PHONY: e2e
 e2e: e2eprereqs test-images ## Run e2e tests
-	go test -v --tags=integration ./integration-tests/...
+	go test -v --tags=integration ./integration-tests/... $(if $(NEX_TEST),-run $(NEX_TEST),)
 
 .PHONY: e2e-podman
 e2e-podman: ## Run e2e tests on podman

--- a/docs/development/integration-tests.md
+++ b/docs/development/integration-tests.md
@@ -26,3 +26,11 @@ go test -c --tags=integration ./integration-tests/...
 # Run integration tests using rootful podman
 sudo NEXODUS_TEST_PODMAN=1 TESTCONTAINERS_RYUK_CONTAINER_PRIVILEGED=true ./integration-tests.test -test.v
 ```
+
+## Run a Specific Test
+
+You can run a specific integration test by setting `NEX_TEST`. For example:
+
+```console
+NEX_TEST=TestNexodusIntegrationSuite/TestProxyEgress make e2e
+```


### PR DESCRIPTION
To run a specific test, use the NEX_TEST variable:

```
NEX_TEST=TestNexodusIntegrationSuite/TestProxyEgress make e2e
```