### PR TITLE
e2e: Use types for sets of constants

### DIFF
--- a/integration-tests/integration_test.go
+++ b/integration-tests/integration_test.go
@@ -33,11 +33,16 @@ var hostDNSName string
 var ipamDriver string
 
 const (
-	nexctl    = "../dist/nexctl"
-	inetV4    = "-4"
-	inetV6    = "-6"
-	disableV6 = 0
-	enableV6  = 1
+	nexctl = "../dist/nexctl"
+	inetV4 = "-4"
+	inetV6 = "-6"
+)
+
+type v6Enable bool
+
+const (
+	disableV6 v6Enable = false
+	enableV6  v6Enable = true
 )
 
 func init() {

--- a/integration-tests/integration_test.go
+++ b/integration-tests/integration_test.go
@@ -34,9 +34,18 @@ var ipamDriver string
 
 const (
 	nexctl = "../dist/nexctl"
-	inetV4 = "-4"
-	inetV6 = "-6"
 )
+
+type ipFamily string
+
+const (
+	inetV4 ipFamily = "-4"
+	inetV6 ipFamily = "-6"
+)
+
+func (f ipFamily) String() string {
+	return string(f)
+}
 
 type v6Enable bool
 

--- a/integration-tests/util_test.go
+++ b/integration-tests/util_test.go
@@ -160,12 +160,12 @@ func newClient(ctx context.Context, username, password string) (*client.Client, 
 	return client.NewClient(ctx, "http://api.try.nexodus.127.0.0.1.nip.io", nil, client.WithPasswordGrant(username, password))
 }
 
-func getContainerIfaceIP(ctx context.Context, family, dev string, ctr testcontainers.Container) (string, error) {
+func getContainerIfaceIP(ctx context.Context, family ipFamily, dev string, ctr testcontainers.Container) (string, error) {
 	var ip string
 	err := backoff.Retry(func() error {
 		code, outputRaw, err := ctr.Exec(
 			ctx,
-			[]string{"ip", "--brief", family, "address", "show", dev},
+			[]string{"ip", "--brief", family.String(), "address", "show", dev},
 		)
 		if err != nil {
 			return err
@@ -195,11 +195,11 @@ func getContainerIfaceIP(ctx context.Context, family, dev string, ctr testcontai
 	return ip, err
 }
 
-func ping(ctx context.Context, ctr testcontainers.Container, family, address string) error {
+func ping(ctx context.Context, ctr testcontainers.Container, family ipFamily, address string) error {
 	err := backoff.Retry(func() error {
 		code, outputRaw, err := ctr.Exec(
 			ctx,
-			[]string{"ping", family, "-c", "2", "-w", "2", address},
+			[]string{"ping", family.String(), "-c", "2", "-w", "2", address},
 		)
 		if err != nil {
 			return err

--- a/integration-tests/util_test.go
+++ b/integration-tests/util_test.go
@@ -75,7 +75,7 @@ func (c FnConsumer) Accept(l testcontainers.Log) {
 }
 
 // CreateNode creates a container
-func (suite *NexodusIntegrationSuite) CreateNode(ctx context.Context, name string, networks []string, v6 int) testcontainers.Container {
+func (suite *NexodusIntegrationSuite) CreateNode(ctx context.Context, name string, networks []string, v6 v6Enable) testcontainers.Container {
 
 	// Host modifiers differ for a container for a container with and without v6 enabled
 	var hostConfSysctl map[string]string


### PR DESCRIPTION
Make the handling of the v6 arg more explicit by making it a named type with two constants that represent possible values. It is also now a boolean instead of an int, since it was really a boolean in practice.

Make a similar change for how IP family is passed around as a string. There were only 2 valid values, so make it a set of typed constants.