### PR TITLE
Register nodes with reflexive addr:port binding

### DIFF
--- a/internal/nexodus/utils.go
+++ b/internal/nexodus/utils.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/netip"
 	"os"
 	"os/exec"
 	"strings"
@@ -193,4 +194,14 @@ func LocalIPv4Address() net.IP {
 		}
 	}
 	return nil
+}
+
+// parseIPfromAddrPort splits an address:port string and returns the address as a string
+func parseIPfromAddrPort(addrPort string) string {
+	ip, err := netip.ParseAddrPort(addrPort)
+	if err != nil {
+		return ""
+	}
+
+	return ip.Addr().String()
 }

--- a/internal/nexodus/wg-peers.go
+++ b/internal/nexodus/wg-peers.go
@@ -82,7 +82,7 @@ func (ax *Nexodus) buildPeersConfig() {
 
 		// If both nodes are local, peer them directly to one another via their local addresses (includes symmetric nat nodes)
 		// The exception is if the peer is a relay node since that will get a peering with the org prefix supernet
-		if ax.nodeReflexiveAddress == value.ReflexiveIPv4 && !value.Relay {
+		if ax.nodeReflexiveAddressIPv4.Addr().String() == parseIPfromAddrPort(value.ReflexiveIPv4) && !value.Relay {
 			directLocalPeerEndpointSocket := net.JoinHostPort(value.EndpointLocalAddressIPv4, peerPort)
 			ax.logger.Debugf("ICE candidate match for local address peering is [ %s ] with a STUN Address of [ %s ]", directLocalPeerEndpointSocket, value.ReflexiveIPv4)
 			// the symmetric NAT peer


### PR DESCRIPTION
- Adds the entire STUN binding to the device registration as oppposed to just the IP addr. Also adds netip.AddrPort typing to the ax receiver.
