### PR TITLE
Resolve long timeouts in the case of an agent NAT binding change

### DIFF
--- a/internal/client/apiclient.go
+++ b/internal/client/apiclient.go
@@ -3,11 +3,13 @@ package client
 import (
 	"context"
 	"fmt"
-	"github.com/nexodus-io/nexodus/internal/api/public"
+	"net"
 	"net/http"
 	"net/url"
+	"time"
 
 	"github.com/coreos/go-oidc/v3/oidc"
+	"github.com/nexodus-io/nexodus/internal/api/public"
 	"golang.org/x/oauth2"
 )
 
@@ -27,7 +29,14 @@ func NewAPIClient(ctx context.Context, addr string, authcb func(string), options
 	clientConfig := public.NewConfiguration()
 	clientConfig.HTTPClient = &http.Client{
 		Transport: &http.Transport{
-			TLSClientConfig: opts.tlsConfig,
+			DialContext: (&net.Dialer{
+				Timeout:   30 * time.Second,
+				KeepAlive: 30 * time.Second,
+			}).DialContext,
+			TLSHandshakeTimeout:   5 * time.Second,
+			ResponseHeaderTimeout: 5 * time.Second,
+			ExpectContinueTimeout: 1 * time.Second,
+			TLSClientConfig:       opts.tlsConfig,
 		},
 	}
 	ctx = context.WithValue(ctx, oauth2.HTTPClient, clientConfig.HTTPClient)


### PR DESCRIPTION
- In the scenario where an agent's reflexive address changes, the time to re-establish polling for a Linux stack was 15m+ while OSX was 1-2m. Both unacceptably long. This gets them both down to < 1second.

Quick summary of each field:

- DialContext: This field specifies a function that establishes a network connection to a remote server. In this case, it uses a custom net.Dialer with a 30-second timeout and keep-alive interval.
- TLSHandshakeTimeout: This field specifies the maximum amount of time that the transport will wait for a TLS handshake to complete when establishing a secure connection.
- ResponseHeaderTimeout: This field specifies the maximum amount of time that the transport will wait for the response headers to be returned after sending a request.
- ExpectContinueTimeout: This field specifies the maximum amount of time that the transport will wait for a server to send a "100 Continue" response before sending the request body.

What also resolves the issue is `DisableKeepAlives`. This is less than deal since a client will negotiate a new connection for every request rather than reusing an existing but worth noting for future reference.

- Follow up tests to be added as part of #752