### PR TITLE
Makefile: Move target timestamp tracking to dist/

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Setup Go
         uses: ./.github/actions/setup-go-env
       - name: Lint ${{ matrix.os }}
-        run: make .go-lint-${{ matrix.os }}
+        run: make dist/.go-lint-${{ matrix.os }}
 
   # these are a little slower to lint...
   go-lint-rest:
@@ -67,7 +67,7 @@ jobs:
       - name: Setup Go
         uses: ./.github/actions/setup-go-env
       - name: Lint ${{ matrix.os }}
-        run: make .go-lint-${{ matrix.os }}
+        run: make dist/.go-lint-${{ matrix.os }}
 
   ui-lint:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -17,11 +17,6 @@
 # misc
 *.idea
 .DS_Store
-.go-lint-*
-.gen-*
-.*-lint
-.generate
-.test-images
 
 #tests
 ./tests/*.json


### PR DESCRIPTION
Move all of the files used to track when a target last ran into dist/. This makes it so we don't have to update the `clean` target and `.gitignore` file for each new dotfile added.