### PR TITLE
Discovery without a designated disco node

### DIFF
--- a/cmd/nexctl/device.go
+++ b/cmd/nexctl/device.go
@@ -16,12 +16,12 @@ func listOrgDevices(c *public.APIClient, organizationID uuid.UUID, encodeOut str
 	}
 	if encodeOut == encodeColumn || encodeOut == encodeNoHeader {
 		w := newTabWriter()
-		fs := "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n"
+		fs := "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n"
 		if encodeOut != encodeNoHeader {
-			fmt.Fprintf(w, fs, "DEVICE ID", "HOSTNAME", "NODE ADDRESS IPV4", "NODE ADDRESS IPV6", "ENDPOINT IP", "PUBLIC KEY", "ORGANIZATION ID", "RELAY")
+			fmt.Fprintf(w, fs, "DEVICE ID", "HOSTNAME", "NODE ADDRESS IPV4", "NODE ADDRESS IPV6", "ENDPOINT IP", "PUBLIC KEY", "ORGANIZATION ID", "OS", "RELAY")
 		}
 		for _, dev := range devices {
-			fmt.Fprintf(w, fs, dev.Id, dev.Hostname, dev.TunnelIp, dev.TunnelIpV6, dev.LocalIp, dev.PublicKey, dev.OrganizationId, fmt.Sprintf("%t", dev.Relay))
+			fmt.Fprintf(w, fs, dev.Id, dev.Hostname, dev.TunnelIp, dev.TunnelIpV6, dev.LocalIp, dev.PublicKey, dev.OrganizationId, dev.Os, fmt.Sprintf("%t", dev.Relay))
 		}
 		w.Flush()
 
@@ -43,18 +43,18 @@ func listAllDevices(c *public.APIClient, encodeOut string) error {
 	}
 	if encodeOut == encodeColumn || encodeOut == encodeNoHeader {
 		w := newTabWriter()
-		fs := "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n"
+		fs := "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n"
 		if encodeOut != encodeNoHeader {
 			fmt.Fprintf(w, fs, "DEVICE ID", "HOSTNAME", "NODE ADDRESS",
 				"ENDPOINT IP", "PUBLIC KEY", "ORGANIZATION ID",
 				"LOCAL IP", "ALLOWED IPS", "TUNNEL IPV4", "TUNNEL IPV6",
 				"CHILD PREFIX", "ORG PREFIX IPV4", "ORG PREFIX IPV6",
-				"REFLEXIVE IPv4", "ENDPOINT LOCAL IPv4", "RELAY")
+				"REFLEXIVE IPv4", "ENDPOINT LOCAL IPv4", "OS", "RELAY")
 		}
 		for _, dev := range devices {
 			fmt.Fprintf(w, fs, dev.Id, dev.Hostname, dev.TunnelIp, dev.LocalIp, dev.PublicKey, dev.OrganizationId,
 				dev.LocalIp, dev.AllowedIps, dev.TunnelIp, dev.TunnelIpV6, dev.ChildPrefix, dev.OrganizationPrefix,
-				dev.OrganizationPrefixV6, dev.ReflexiveIp4, dev.EndpointLocalAddressIp4, fmt.Sprintf("%t", dev.Relay))
+				dev.OrganizationPrefixV6, dev.ReflexiveIp4, dev.EndpointLocalAddressIp4, dev.Os, fmt.Sprintf("%t", dev.Relay))
 		}
 		w.Flush()
 

--- a/integration-tests/device-api.feature
+++ b/integration-tests/device-api.feature
@@ -49,7 +49,8 @@ Feature: Device API
         "reflexive_ip4": "47.196.141.165",
         "endpoint_local_address_ip4": "172.17.0.3",
         "symmetric_nat": true,
-        "hostname": "bbac3081d5e8"
+        "hostname": "bbac3081d5e8",
+        "os": "linux"
       }
       """
     Then the response code should be 201
@@ -71,6 +72,7 @@ Feature: Device API
         "organization_id": "${organization_id}",
         "organization_prefix":"${response.organization_prefix}",
         "organization_prefix_v6":"${response.organization_prefix_v6}",
+        "os": "linux",
         "public_key": "${public_key}",
         "reflexive_ip4": "47.196.141.165",
         "relay": false,
@@ -106,6 +108,7 @@ Feature: Device API
         "organization_id": "${organization_id}",
         "organization_prefix":"${response.organization_prefix}",
         "organization_prefix_v6":"${response.organization_prefix_v6}",
+        "os": "linux",
         "public_key": "${public_key}",
         "reflexive_ip4": "47.196.141.165",
         "relay": false,
@@ -137,6 +140,7 @@ Feature: Device API
           "organization_id": "${organization_id}",
           "organization_prefix":"${response[0].organization_prefix}",
           "organization_prefix_v6":"${response[0].organization_prefix_v6}",
+          "os": "linux",
           "public_key": "${public_key}",
           "reflexive_ip4": "47.196.141.165",
           "relay": false,
@@ -205,6 +209,7 @@ Feature: Device API
         "organization_id": "${organization_id}",
         "organization_prefix":"${response.organization_prefix}",
         "organization_prefix_v6":"${response.organization_prefix_v6}",
+        "os": "linux",
         "public_key": "${public_key}",
         "reflexive_ip4": "47.196.141.165",
         "relay": false,

--- a/integration-tests/integration_test.go
+++ b/integration-tests/integration_test.go
@@ -18,13 +18,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/nexodus-io/nexodus/internal/api/public"
-	"github.com/nexodus-io/nexodus/internal/client"
-	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
-
 	"github.com/Nerzal/gocloak/v13"
 	"github.com/cenkalti/backoff/v4"
 	"github.com/cucumber/godog"
+	"github.com/nexodus-io/nexodus/internal/api/public"
+	"github.com/nexodus-io/nexodus/internal/client"
 	"github.com/nexodus-io/nexodus/internal/cucumber"
 	"github.com/nexodus-io/nexodus/internal/models"
 	"github.com/nexodus-io/nexodus/internal/nexodus"
@@ -33,6 +31,7 @@ import (
 	"github.com/testcontainers/testcontainers-go"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
+	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
 )
 
 var providerType testcontainers.ProviderType

--- a/internal/api/public/model_models_add_device.go
+++ b/internal/api/public/model_models_add_device.go
@@ -18,6 +18,7 @@ type ModelsAddDevice struct {
 	Hostname                string   `json:"hostname,omitempty"`
 	LocalIp                 string   `json:"local_ip,omitempty"`
 	OrganizationId          string   `json:"organization_id,omitempty"`
+	Os                      string   `json:"os,omitempty"`
 	PublicKey               string   `json:"public_key,omitempty"`
 	ReflexiveIp4            string   `json:"reflexive_ip4,omitempty"`
 	Relay                   bool     `json:"relay,omitempty"`

--- a/internal/api/public/model_models_device.go
+++ b/internal/api/public/model_models_device.go
@@ -23,6 +23,7 @@ type ModelsDevice struct {
 	OrganizationId          string   `json:"organization_id,omitempty"`
 	OrganizationPrefix      string   `json:"organization_prefix,omitempty"`
 	OrganizationPrefixV6    string   `json:"organization_prefix_v6,omitempty"`
+	Os                      string   `json:"os,omitempty"`
 	PublicKey               string   `json:"public_key,omitempty"`
 	ReflexiveIp4            string   `json:"reflexive_ip4,omitempty"`
 	Relay                   bool     `json:"relay,omitempty"`

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -13,6 +13,7 @@ import (
 	"github.com/nexodus-io/nexodus/internal/database/migration_20230327_0000"
 	"github.com/nexodus-io/nexodus/internal/database/migration_20230328_0000"
 	"github.com/nexodus-io/nexodus/internal/database/migration_20230401_0000"
+	"github.com/nexodus-io/nexodus/internal/database/migration_20230403_0000"
 	"github.com/nexodus-io/nexodus/internal/database/migrations"
 	"github.com/uptrace/opentelemetry-go-extra/otelgorm"
 	"go.opentelemetry.io/otel"
@@ -102,6 +103,7 @@ func Migrations() *migrations.Migrations {
 			migration_20230327_0000.Migrate(),
 			migration_20230328_0000.Migrate(),
 			migration_20230401_0000.Migrate(),
+			migration_20230403_0000.Migrate(),
 		},
 	}
 }

--- a/internal/database/migration_20230403_0000/20230403-0000.go
+++ b/internal/database/migration_20230403_0000/20230403-0000.go
@@ -1,0 +1,74 @@
+package migration_20230403_0000
+
+import (
+	"time"
+
+	"github.com/go-gormigrate/gormigrate/v2"
+	"github.com/google/uuid"
+	"github.com/lib/pq"
+	"github.com/nexodus-io/nexodus/internal/database/migrations"
+)
+
+// Base contains common columns for all tables.
+type Base struct {
+	ID        uuid.UUID  `gorm:"type:uuid;primary_key;" json:"id" example:"aa22666c-0f57-45cb-a449-16efecc04f2e"`
+	CreatedAt time.Time  `json:"-"`
+	UpdatedAt time.Time  `json:"-"`
+	DeletedAt *time.Time `sql:"index" json:"-"`
+}
+
+// Device is a unique, end-user device.
+// Devices belong to one User and may be onboarded into an organization
+type Device struct {
+	Base
+	UserID                   string
+	OrganizationID           uuid.UUID
+	PublicKey                string
+	LocalIP                  string
+	LocalIpV6                string
+	AllowedIPs               pq.StringArray `gorm:"type:text[]"`
+	TunnelIP                 string
+	TunnelIpV6               string
+	ChildPrefix              pq.StringArray `gorm:"type:text[]"`
+	Relay                    bool
+	Discovery                bool
+	OrganizationPrefix       string
+	OrganizationPrefixV6     string
+	ReflexiveIPv4            string
+	EndpointLocalAddressIPv4 string
+	SymmetricNat             bool
+	Hostname                 string
+	OS                       string
+}
+
+// Organization contains Users and their Devices
+type Organization struct {
+	Base
+	Users       []*User `gorm:"many2many:user_organizations;"`
+	Devices     []*Device
+	Name        string
+	Description string
+	IpCidr      string
+	IpCidrV6    string
+	HubZone     bool
+}
+
+// User is a person who uses Nexodus
+type User struct {
+	// Since the ID comes from the IDP, we have no control over the format...
+	ID            string `gorm:"primary_key;" json:"id" example:"aa22666c-0f57-45cb-a449-16efecc04f2e"`
+	CreatedAt     time.Time
+	UpdatedAt     time.Time
+	DeletedAt     *time.Time `sql:"index" json:"-"`
+	Devices       []*Device
+	Organizations []*Organization `gorm:"many2many:user_organizations"`
+	UserName      string
+}
+
+func Migrate() *gormigrate.Migration {
+	migrationId := "20230403-0000"
+	return migrations.CreateMigrationFromActions(migrationId,
+		// Add OS field to the Device and Organization tables
+		migrations.AddTableColumnAction(&Device{}, "os"),
+	)
+}

--- a/internal/database/migration_20230403_0000/20230403-0000.go
+++ b/internal/database/migration_20230403_0000/20230403-0000.go
@@ -1,68 +1,12 @@
 package migration_20230403_0000
 
 import (
-	"time"
-
 	"github.com/go-gormigrate/gormigrate/v2"
-	"github.com/google/uuid"
-	"github.com/lib/pq"
 	"github.com/nexodus-io/nexodus/internal/database/migrations"
 )
 
-// Base contains common columns for all tables.
-type Base struct {
-	ID        uuid.UUID  `gorm:"type:uuid;primary_key;" json:"id" example:"aa22666c-0f57-45cb-a449-16efecc04f2e"`
-	CreatedAt time.Time  `json:"-"`
-	UpdatedAt time.Time  `json:"-"`
-	DeletedAt *time.Time `sql:"index" json:"-"`
-}
-
-// Device is a unique, end-user device.
-// Devices belong to one User and may be onboarded into an organization
 type Device struct {
-	Base
-	UserID                   string
-	OrganizationID           uuid.UUID
-	PublicKey                string
-	LocalIP                  string
-	LocalIpV6                string
-	AllowedIPs               pq.StringArray `gorm:"type:text[]"`
-	TunnelIP                 string
-	TunnelIpV6               string
-	ChildPrefix              pq.StringArray `gorm:"type:text[]"`
-	Relay                    bool
-	Discovery                bool
-	OrganizationPrefix       string
-	OrganizationPrefixV6     string
-	ReflexiveIPv4            string
-	EndpointLocalAddressIPv4 string
-	SymmetricNat             bool
-	Hostname                 string
-	OS                       string
-}
-
-// Organization contains Users and their Devices
-type Organization struct {
-	Base
-	Users       []*User `gorm:"many2many:user_organizations;"`
-	Devices     []*Device
-	Name        string
-	Description string
-	IpCidr      string
-	IpCidrV6    string
-	HubZone     bool
-}
-
-// User is a person who uses Nexodus
-type User struct {
-	// Since the ID comes from the IDP, we have no control over the format...
-	ID            string `gorm:"primary_key;" json:"id" example:"aa22666c-0f57-45cb-a449-16efecc04f2e"`
-	CreatedAt     time.Time
-	UpdatedAt     time.Time
-	DeletedAt     *time.Time `sql:"index" json:"-"`
-	Devices       []*Device
-	Organizations []*Organization `gorm:"many2many:user_organizations"`
-	UserName      string
+	OS string
 }
 
 func Migrate() *gormigrate.Migration {

--- a/internal/docs/docs.go
+++ b/internal/docs/docs.go
@@ -1315,6 +1315,9 @@ const docTemplate = `{
                     "type": "string",
                     "example": "694aa002-5d19-495e-980b-3d8fd508ea10"
                 },
+                "os": {
+                    "type": "string"
+                },
                 "public_key": {
                     "type": "string"
                 },
@@ -1439,6 +1442,9 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "organization_prefix_v6": {
+                    "type": "string"
+                },
+                "os": {
                     "type": "string"
                 },
                 "public_key": {

--- a/internal/docs/swagger.json
+++ b/internal/docs/swagger.json
@@ -1308,6 +1308,9 @@
                     "type": "string",
                     "example": "694aa002-5d19-495e-980b-3d8fd508ea10"
                 },
+                "os": {
+                    "type": "string"
+                },
                 "public_key": {
                     "type": "string"
                 },
@@ -1432,6 +1435,9 @@
                     "type": "string"
                 },
                 "organization_prefix_v6": {
+                    "type": "string"
+                },
+                "os": {
                     "type": "string"
                 },
                 "public_key": {

--- a/internal/docs/swagger.yaml
+++ b/internal/docs/swagger.yaml
@@ -22,6 +22,8 @@ definitions:
       organization_id:
         example: 694aa002-5d19-495e-980b-3d8fd508ea10
         type: string
+      os:
+        type: string
       public_key:
         type: string
       reflexive_ip4:
@@ -107,6 +109,8 @@ definitions:
       organization_prefix:
         type: string
       organization_prefix_v6:
+        type: string
+      os:
         type: string
       public_key:
         type: string

--- a/internal/handlers/device.go
+++ b/internal/handlers/device.go
@@ -341,6 +341,7 @@ func (api *API) CreateDevice(c *gin.Context) {
 			EndpointLocalAddressIPv4: request.EndpointLocalAddressIPv4,
 			SymmetricNat:             request.SymmetricNat,
 			Hostname:                 request.Hostname,
+			Os:                       request.Os,
 		}
 
 		if res := tx.Create(&device); res.Error != nil {

--- a/internal/models/device.go
+++ b/internal/models/device.go
@@ -26,6 +26,7 @@ type Device struct {
 	EndpointLocalAddressIPv4 string         `json:"endpoint_local_address_ip4"`
 	SymmetricNat             bool           `json:"symmetric_nat"`
 	Hostname                 string         `json:"hostname"`
+	Os                       string         `json:"os"`
 }
 
 // AddDevice is the information needed to add a new Device.
@@ -43,6 +44,7 @@ type AddDevice struct {
 	EndpointLocalAddressIPv4 string    `json:"endpoint_local_address_ip4" example:"1.2.3.4"`
 	SymmetricNat             bool      `json:"symmetric_nat"`
 	Hostname                 string    `json:"hostname" example:"myhost"`
+	Os                       string    `json:"os"`
 }
 
 // UpdateDevice is the information needed to update a Device.

--- a/internal/nexodus/nexodus.go
+++ b/internal/nexodus/nexodus.go
@@ -454,15 +454,13 @@ func (ax *Nexodus) Start(ctx context.Context, wg *sync.WaitGroup) error {
 	})
 
 	// Experimental STUN discovery
-	if runtime.GOOS == Linux.String() {
-		util.GoWithWaitGroup(wg, func() {
-			util.RunPeriodically(ctx, time.Second*20, func() {
-				if err := ax.reconcileStun(device.Id); err != nil {
-					ax.logger.Debug(err)
-				}
-			})
+	util.GoWithWaitGroup(wg, func() {
+		util.RunPeriodically(ctx, time.Second*20, func() {
+			if err := ax.reconcileStun(device.Id); err != nil {
+				ax.logger.Debug(err)
+			}
 		})
-	}
+	})
 
 	for _, proxy := range ax.ingresProxies {
 		proxy.Start(ctx, wg, ax.userspaceNet)

--- a/internal/nexodus/nexodus.go
+++ b/internal/nexodus/nexodus.go
@@ -50,6 +50,11 @@ const (
 	NexdStatusRunning
 )
 
+const (
+	stunServer1 = "stun1.l.google.com:19302"
+	stunServer2 = "stun2.l.google.com:19302"
+)
+
 var (
 	invalidTokenGrant = errors.New("invalid_grant")
 )
@@ -92,6 +97,7 @@ type Nexodus struct {
 	hostname                 string
 	symmetricNat             bool
 	ipv6Supported            bool
+	os                       string
 	logger                   *zap.SugaredLogger
 	// See the NexdStatus* constants
 	status        int
@@ -155,10 +161,6 @@ func NewNexodus(
 	controllerURL.Host = "api." + controllerURL.Host
 	controllerURL.Path = ""
 
-	if err := checkOS(logger); err != nil {
-		return nil, err
-	}
-
 	hostname, err := os.Hostname()
 	if err != nil {
 		return nil, err
@@ -202,6 +204,10 @@ func NewNexodus(
 	}
 
 	if err := ax.checkUnsupportedConfigs(); err != nil {
+		return nil, err
+	}
+
+	if err := prepOS(logger); err != nil {
 		return nil, err
 	}
 
@@ -327,12 +333,12 @@ func (ax *Nexodus) Start(ctx context.Context, wg *sync.WaitGroup) error {
 
 	// If we are behind a symmetricNat, the endpoint ip discovered by a stun server is useless
 	if !ax.symmetricNat && ax.stun && localIP == "" {
-		ipPort, err := StunRequest(ax.logger, stunServer1, ax.listenPort)
+		ipPort, err := stunRequest(ax.logger, stunServer1, ax.listenPort)
 		if err != nil {
 			ax.logger.Warn("Unable to determine the public facing address, falling back to the local address")
 		} else {
-			localIP = ipPort.IP.String()
-			localEndpointPort = ipPort.Port
+			localIP = ipPort.Addr().String()
+			localEndpointPort = int(ipPort.Port())
 		}
 	}
 	if localIP == "" {
@@ -343,6 +349,8 @@ func (ax *Nexodus) Start(ctx context.Context, wg *sync.WaitGroup) error {
 		localIP = ip
 		localEndpointPort = ax.listenPort
 	}
+
+	ax.os = runtime.GOOS
 
 	ax.endpointLocalAddress = localIP
 	endpointSocket := net.JoinHostPort(localIP, fmt.Sprintf("%d", localEndpointPort))
@@ -358,6 +366,7 @@ func (ax *Nexodus) Start(ctx context.Context, wg *sync.WaitGroup) error {
 		SymmetricNat:            ax.symmetricNat,
 		Hostname:                ax.hostname,
 		Relay:                   ax.relay,
+		Os:                      ax.os,
 	}).Execute()
 	if err != nil {
 		var apiError *public.GenericOpenAPIError
@@ -444,6 +453,17 @@ func (ax *Nexodus) Start(ctx context.Context, wg *sync.WaitGroup) error {
 		})
 	})
 
+	// Experimental STUN discovery
+	if runtime.GOOS == Linux.String() {
+		util.GoWithWaitGroup(wg, func() {
+			util.RunPeriodically(ctx, time.Second*20, func() {
+				if err := ax.reconcileStun(device.Id); err != nil {
+					ax.logger.Debug(err)
+				}
+			})
+		})
+	}
+
 	for _, proxy := range ax.ingresProxies {
 		proxy.Start(ctx, wg, ax.userspaceNet)
 	}
@@ -477,6 +497,30 @@ func (ax *Nexodus) Keepalive() {
 	}
 
 	_ = probePeers(peerEndpoints, ax.logger)
+}
+
+func (ax *Nexodus) reconcileStun(deviceID string) error {
+	reflexiveIP, err := stunRequest(ax.logger, stunServer1, ax.listenPort)
+	if err != nil {
+		return fmt.Errorf("bpf stun request error: %w", err)
+	}
+
+	if ax.nodeReflexiveAddressIPv4 != reflexiveIP {
+		ax.logger.Infof("detected a NAT binding changed for this device %s from %s to %s, updating peers", deviceID, ax.nodeReflexiveAddressIPv4, reflexiveIP)
+		res, _, err := ax.client.DevicesApi.UpdateDevice(context.Background(), deviceID).Update(public.ModelsUpdateDevice{
+			LocalIp:      reflexiveIP.String(),
+			ReflexiveIp4: reflexiveIP.String(),
+		}).Execute()
+		if err != nil {
+			return fmt.Errorf("failed to update this device's new NAT binding, likely still reconnecting to the api-server, retrying in 20s: %w", err)
+		} else {
+			ax.logger.Debugf("update device response %+v", res)
+			ax.nodeReflexiveAddressIPv4 = reflexiveIP
+		}
+	}
+	ax.logger.Debugf("relfexive binding is %s", reflexiveIP)
+
+	return nil
 }
 
 func (ax *Nexodus) Reconcile(orgID string, firstTime bool) error {
@@ -560,6 +604,11 @@ func (ax *Nexodus) discoveryStateReconcile(orgID string) error {
 	}
 	// re-join peers with updated state from the discovery node
 	for _, peer := range peerListing {
+		// Uncomment to update Linux nodes that are getting reflexive changes via STUN as well
+		//if peer.Os == Linux.String() {
+		//	ax.logger.Debug("skipping Linux node")
+		//	continue
+		//}
 		// if the peer is behind a symmetric NAT, skip to the next peer
 		if peer.SymmetricNat {
 			ax.logger.Debugf("skipping symmetric NAT node %s", peer.LocalIp)
@@ -645,15 +694,15 @@ func (ax *Nexodus) checkUnsupportedConfigs() error {
 func (ax *Nexodus) symmetricNatDisco() error {
 
 	// discover the server reflexive address per ICE RFC8445
-	stunAddr, err := StunRequest(ax.logger, stunServer1, ax.listenPort)
+	stunAddr, err := stunRequest(ax.logger, stunServer1, ax.listenPort)
 	if err != nil {
 		return err
 	} else {
-		ax.nodeReflexiveAddressIPv4 = stunAddr.AddrPort()
+		ax.nodeReflexiveAddressIPv4 = stunAddr
 	}
 
 	isSymmetric := false
-	stunAddr2, err := StunRequest(ax.logger, stunServer2, ax.listenPort)
+	stunAddr2, err := stunRequest(ax.logger, stunServer2, ax.listenPort)
 	if err != nil {
 		return err
 	} else {

--- a/internal/nexodus/nexodus_darwin.go
+++ b/internal/nexodus/nexodus_darwin.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 
 	"go.uber.org/zap"
+	"strconv"
 )
 
 func (ax *Nexodus) setupInterfaceOS() error {

--- a/internal/nexodus/nexodus_darwin.go
+++ b/internal/nexodus/nexodus_darwin.go
@@ -7,7 +7,6 @@ import (
 	"strconv"
 
 	"go.uber.org/zap"
-	"strconv"
 )
 
 func (ax *Nexodus) setupInterfaceOS() error {

--- a/internal/nexodus/stun_darwin.go
+++ b/internal/nexodus/stun_darwin.go
@@ -1,0 +1,64 @@
+//go:build darwin
+
+package nexodus
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/libp2p/go-reuseport"
+	"github.com/pion/stun"
+	"go.uber.org/zap"
+	"net/netip"
+)
+
+func stunRequest(logger *zap.SugaredLogger, stunServer string, srcPort int) (netip.AddrPort, error) {
+
+	logger.Debugf("dialing stun server %s", stunServer)
+	conn, err := reuseport.Dial("udp4", fmt.Sprintf(":%d", srcPort), stunServer)
+	if err != nil {
+		logger.Errorf("stun dialing timed out %v", err)
+		return netip.AddrPort{}, fmt.Errorf("failed to dial stun server %s: %w", stunServer, err)
+	}
+	defer func() {
+		_ = conn.Close()
+	}()
+
+	c, err := stun.NewClient(conn)
+	if err != nil {
+		logger.Error(err)
+		return netip.AddrPort{}, err
+	}
+	defer func() {
+		_ = c.Close()
+	}()
+
+	// Building binding request with random transaction id.
+	message := stun.MustBuild(stun.TransactionID, stun.BindingRequest)
+	// Sending request to STUN server, waiting for response message.
+	var xorAddr stun.XORMappedAddress
+	if err := c.Do(message, func(res stun.Event) {
+		if res.Error != nil {
+			if res.Error.Error() == errors.New("transaction is timed out").Error() {
+				logger.Debugf("STUN transaction timed out, if this continues check if a firewall is blocking UDP connections to %s", stunServer)
+			} else {
+				logger.Debug(res.Error)
+			}
+			return
+		}
+		// Decoding XOR-MAPPED-ADDRESS attribute from message.
+		if err := xorAddr.GetFrom(res.Message); err != nil {
+			return
+		}
+	}); err != nil {
+		return netip.AddrPort{}, err
+	}
+
+	xorBinding, err := netip.ParseAddrPort(xorAddr.String())
+	if err != nil {
+		return netip.AddrPort{}, fmt.Errorf("failed to parse a valid address:port binding from the stun response: %w", err)
+	}
+	logger.Debugf("STUN: your public facing ip:port binding is: %s", xorBinding.String())
+
+	return xorBinding, nil
+}

--- a/internal/nexodus/stun_linux.go
+++ b/internal/nexodus/stun_linux.go
@@ -1,0 +1,232 @@
+//go:build linux
+
+package nexodus
+
+import (
+	"encoding/binary"
+	"fmt"
+	"net"
+	"net/netip"
+	"time"
+
+	"github.com/pion/stun"
+	"go.uber.org/zap"
+	"golang.org/x/net/bpf"
+	"golang.org/x/net/ipv4"
+)
+
+var (
+	stunTimeout = 5
+)
+
+type udpHeader struct {
+	srcPort  uint16
+	dstPort  uint16
+	length   uint16
+	checksum uint16
+}
+
+type stunResponse struct {
+	xorAddr    *stun.XORMappedAddress
+	otherAddr  *stun.OtherAddress
+	mappedAddr *stun.MappedAddress
+	software   *stun.Software
+}
+
+type stunSession struct {
+	conn        *ipv4.PacketConn
+	innerConn   net.PacketConn
+	LocalAddr   net.Addr
+	LocalPort   uint16
+	RemoteAddr  *net.UDPAddr
+	OtherAddr   *net.UDPAddr
+	messageChan chan *stun.Message
+}
+
+func stunRequest(logger *zap.SugaredLogger, stunSvr string, srcPort int) (netip.AddrPort, error) {
+	LocalListenPort := uint16(srcPort)
+
+	conn, err := stunConnect(logger, LocalListenPort, stunSvr)
+	defer conn.stunClose()
+	if err != nil {
+		return netip.AddrPort{}, fmt.Errorf("failed to stunConnect to the STUN server: %w", err)
+	}
+
+	request := stun.MustBuild(stun.TransactionID, stun.BindingRequest)
+	responseData, err := conn.stunTransact(logger, request, conn.RemoteAddr)
+	if err != nil {
+		return netip.AddrPort{}, fmt.Errorf("transaction error: %w", err)
+	}
+
+	response := stunMsgParse(logger, *responseData)
+	xorBinding, err := netip.ParseAddrPort(response.xorAddr.String())
+	if err != nil {
+		return netip.AddrPort{}, fmt.Errorf("failed to parse a valid address:port binding from the bpf stun response: %w", err)
+	}
+	logger.Debugf("reflexive binding is: %s\n", xorBinding.String())
+
+	return xorBinding, nil
+}
+
+func (c *stunSession) stunTransact(logger *zap.SugaredLogger, msg *stun.Message, addr net.Addr) (*stun.Message, error) {
+	_ = msg.NewTransactionID()
+	logger.Debugf("Send to %v: (%v bytes)\n", addr, msg.Length)
+	sendUdp := &udpHeader{
+		srcPort:  c.LocalPort,
+		dstPort:  uint16(c.RemoteAddr.Port),
+		length:   uint16(8 + len(msg.Raw)),
+		checksum: 0,
+	}
+
+	buf := make([]byte, 8)
+	binary.BigEndian.PutUint16(buf[0:], sendUdp.srcPort)
+	binary.BigEndian.PutUint16(buf[2:], sendUdp.dstPort)
+	binary.BigEndian.PutUint16(buf[4:], sendUdp.length)
+	binary.BigEndian.PutUint16(buf[6:], sendUdp.checksum)
+
+	if _, err := c.conn.WriteTo(append(buf, msg.Raw...), nil, addr); err != nil {
+		return nil, err
+	}
+	// wait for response
+	select {
+	case m, ok := <-c.messageChan:
+		if !ok {
+			return nil, fmt.Errorf("error reading STUN response")
+		}
+		return m, nil
+	case <-time.After(time.Duration(stunTimeout) * time.Second):
+		logger.Debugf("bpf STUN request timed out")
+		return nil, fmt.Errorf("timed out waiting for stun response")
+	}
+}
+
+// stunMsgParse parse the STUN response and return them in a stunResponse struct
+func stunMsgParse(logger *zap.SugaredLogger, msg stun.Message) stunResponse {
+	res := stunResponse{}
+	res.mappedAddr = &stun.MappedAddress{}
+	res.xorAddr = &stun.XORMappedAddress{}
+	res.otherAddr = &stun.OtherAddress{}
+
+	if res.xorAddr.GetFrom(&msg) != nil {
+		res.xorAddr = nil
+	}
+	if res.otherAddr.GetFrom(&msg) != nil {
+		res.otherAddr = nil
+	}
+	if res.mappedAddr.GetFrom(&msg) != nil {
+		res.mappedAddr = nil
+	}
+	if res.software.GetFrom(&msg) != nil {
+		res.software = nil
+	}
+
+	return res
+}
+
+func stunConnect(logger *zap.SugaredLogger, port uint16, addrStr string) (*stunSession, error) {
+	addr, err := net.ResolveUDPAddr("udp4", addrStr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve a UDP address: %w ", err)
+	}
+
+	conn, err := net.ListenPacket("ip4:udp", "0.0.0.0")
+	if err != nil {
+		return nil, fmt.Errorf("stun failed to listen on ipv4: %w", err)
+	}
+
+	bpfFilter, err := stunBpfFilter(port)
+	if err != nil {
+		return nil, err
+	}
+	p := ipv4.NewPacketConn(conn)
+	err = p.SetBPF(bpfFilter)
+	if err != nil {
+		return nil, fmt.Errorf("bpf filter attach error: %w", err)
+	}
+
+	mChan := stunListen(logger, p)
+
+	return &stunSession{
+		conn:        p,
+		innerConn:   conn,
+		LocalAddr:   p.LocalAddr(),
+		LocalPort:   port,
+		RemoteAddr:  addr,
+		messageChan: mChan,
+	}, nil
+
+}
+
+func stunListen(logger *zap.SugaredLogger, conn *ipv4.PacketConn) (messages chan *stun.Message) {
+	messages = make(chan *stun.Message)
+	go func() {
+		for {
+			buf := make([]byte, 1500)
+			n, _, addr, err := conn.ReadFrom(buf)
+			if err != nil {
+				close(messages)
+				return
+			}
+			logger.Debugf("Response from %v: (%v bytes)\n", addr, n)
+			// cut UDP header, cut postfix
+			buf = buf[8:n]
+
+			m := new(stun.Message)
+			m.Raw = buf
+			err = m.Decode()
+			if err != nil {
+				logger.Debugf("error decoding STUN msg: %v\n", err)
+				close(messages)
+				return
+			}
+			messages <- m
+		}
+	}()
+	return
+}
+
+func stunBpfFilter(port uint16) ([]bpf.RawInstruction, error) {
+	var (
+		ipOff              uint32 = 0
+		udpOff                    = ipOff + 5*4
+		payloadOff                = udpOff + 2*4
+		stunMagicCookieOff        = payloadOff + 4
+		stunMagicCookie    uint32 = 0x2112A442
+	)
+
+	r, err := bpf.Assemble([]bpf.Instruction{
+		bpf.LoadAbsolute{
+			Off:  udpOff + 2,
+			Size: 2,
+		},
+		bpf.JumpIf{
+			Cond:      bpf.JumpEqual,
+			Val:       uint32(port),
+			SkipFalse: 3,
+		},
+		bpf.LoadAbsolute{
+			Off:  stunMagicCookieOff,
+			Size: 4,
+		},
+		bpf.JumpIf{
+			Cond:      bpf.JumpEqual,
+			Val:       stunMagicCookie,
+			SkipFalse: 1,
+		},
+		bpf.RetConstant{
+			Val: 0xffff,
+		},
+		bpf.RetConstant{
+			Val: 0,
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("stun bpf filter failed: %v", err)
+	}
+
+	return r, nil
+}
+
+func (c *stunSession) stunClose() error {
+	return c.conn.Close()
+}

--- a/internal/nexodus/stun_linux.go
+++ b/internal/nexodus/stun_linux.go
@@ -221,7 +221,7 @@ func stunBpfFilter(port uint16) ([]bpf.RawInstruction, error) {
 		},
 	})
 	if err != nil {
-		return nil, fmt.Errorf("stun bpf filter failed: %v", err)
+		return nil, fmt.Errorf("stun bpf filter failed: %w", err)
 	}
 
 	return r, nil

--- a/internal/nexodus/stun_windows.go
+++ b/internal/nexodus/stun_windows.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/libp2p/go-reuseport"
 	"github.com/pion/stun"
+	"go.uber.org/zap"
 )
 
 func stunRequest(logger *zap.SugaredLogger, stunServer string, srcPort int) (netip.AddrPort, error) {

--- a/internal/nexodus/utils.go
+++ b/internal/nexodus/utils.go
@@ -111,11 +111,11 @@ func IsNAT(logger *zap.SugaredLogger, nodeOS, controller string, port string) (b
 		}
 		hostIP = linuxIP.String()
 	}
-	ipAndPort, err := StunRequest(logger, stunServer1, 0)
+	ipAndPort, err := stunRequest(logger, stunServer1, 0)
 	if err != nil {
 		return false, err
 	}
-	if hostIP != ipAndPort.IP.String() {
+	if hostIP != ipAndPort.Addr().String() {
 		return true, nil
 	}
 	return false, nil

--- a/internal/nexodus/utils_darwin.go
+++ b/internal/nexodus/utils_darwin.go
@@ -81,8 +81,8 @@ func binaryChecks() error {
 	return nil
 }
 
-// Check OS and report error if the OS is not supported.
-func checkOS(logger *zap.SugaredLogger) error {
+// prepOS perform OS specific OS changes
+func prepOS(logger *zap.SugaredLogger) error {
 	// ensure the osx wireguard directory exists
 	if err := CreateDirectory(WgDarwinConfPath); err != nil {
 		return fmt.Errorf("unable to create the wireguard config directory [%s]: %w", WgDarwinConfPath, err)

--- a/internal/nexodus/utils_linux.go
+++ b/internal/nexodus/utils_linux.go
@@ -197,8 +197,8 @@ func binaryChecks() error {
 	return nil
 }
 
-// Check OS and report error if the OS is not supported.
-func checkOS(logger *zap.SugaredLogger) error {
+// prepOS perform OS specific OS changes
+func prepOS(logger *zap.SugaredLogger) error {
 	// ensure the linux wireguard directory exists
 	if err := CreateDirectory(WgLinuxConfPath); err != nil {
 		return fmt.Errorf("unable to create the wireguard config directory [%s]: %w", WgLinuxConfPath, err)

--- a/internal/nexodus/utils_windows.go
+++ b/internal/nexodus/utils_windows.go
@@ -71,8 +71,8 @@ func binaryChecks() error {
 	return nil
 }
 
-// Check OS and report error if the OS is not supported.
-func checkOS(logger *zap.SugaredLogger) error {
+// prepOS perform OS specific OS changes
+func prepOS(logger *zap.SugaredLogger) error {
 	// ensure the windows wireguard directory exists
 	if err := CreateDirectory(WgWindowsConfPath); err != nil {
 		return fmt.Errorf("unable to create the wireguard config directory [%s]: %w", WgWindowsConfPath, err)

--- a/internal/nexodus/wg-peers.go
+++ b/internal/nexodus/wg-peers.go
@@ -42,7 +42,10 @@ func (ax *Nexodus) buildPeersConfig() {
 			// we found ourselves in the peer list
 			continue
 		}
-
+		// Fully disables discovery node peering from Linux nodes doing STUN discovery
+		//if value.Discovery && ax.os == Linux.String() {
+		//	continue
+		//}
 		var peerHub wgPeerConfig
 		// Build the relay peer entry that will be a CIDR block as opposed to a /32 host route. All nodes get this peer.
 		// This is the only peer a symmetric NAT node will get unless it also has a direct peering
@@ -64,14 +67,14 @@ func (ax *Nexodus) buildPeersConfig() {
 			value.AllowedIps = append(value.AllowedIps, value.ChildPrefix...)
 			peer := wgPeerConfig{
 				value.PublicKey,
-				value.LocalIp,
+				value.ReflexiveIp4,
 				value.AllowedIps,
 				persistentHubKeepalive,
 			}
 			peers = append(peers, peer)
 			ax.logger.Infof("Peer Node Configuration - Peer AllowedIps [ %s ] Peer Endpoint IP [ %s ] Peer Public Key [ %s ] TunnelIp IPv4 [ %s ] TunnelIp IPv6 [ %s ] Organization [ %s ]",
 				value.AllowedIps,
-				value.LocalIp,
+				value.ReflexiveIp4,
 				value.PublicKey,
 				value.TunnelIp,
 				value.TunnelIpV6,
@@ -80,7 +83,9 @@ func (ax *Nexodus) buildPeersConfig() {
 
 		// If both nodes are local, peer them directly to one another via their local addresses (includes symmetric nat nodes)
 		// The exception is if the peer is a relay node since that will get a peering with the org prefix supernet
+		//if ax.nodeReflexiveAddressIPv4.Addr().String() == parseIPfromAddrPort(value.ReflexiveIp4) && !value.Relay {
 		if ax.nodeReflexiveAddressIPv4.Addr().String() == parseIPfromAddrPort(value.ReflexiveIp4) && !value.Relay {
+
 			directLocalPeerEndpointSocket := net.JoinHostPort(value.EndpointLocalAddressIp4, peerPort)
 			ax.logger.Debugf("ICE candidate match for local address peering is [ %s ] with a STUN Address of [ %s ]", directLocalPeerEndpointSocket, value.ReflexiveIp4)
 			// the symmetric NAT peer
@@ -106,14 +111,14 @@ func (ax *Nexodus) buildPeersConfig() {
 			value.AllowedIps = append(value.AllowedIps, value.ChildPrefix...)
 			peer := wgPeerConfig{
 				value.PublicKey,
-				value.LocalIp,
+				value.ReflexiveIp4,
 				value.AllowedIps,
 				persistentKeepalive,
 			}
 			peers = append(peers, peer)
 			ax.logger.Infof("Peer Configuration - Peer AllowedIps [ %s ] Peer Endpoint IP [ %s ] Peer Public Key [ %s ] TunnelIp [ %s ] Organization [ %s ]",
 				value.AllowedIps,
-				value.LocalIp,
+				value.ReflexiveIp4,
 				value.PublicKey,
 				value.TunnelIp,
 				value.OrganizationId)


### PR DESCRIPTION
- Use bpf to send STUN requests sourced from the bound wg listener for Liinux.
- Use `SO_REUSEPORT` for wg userspace for Darwin.
- When a NAT binding change is detected via STUN requests, the node updates all peers without the need of a discovery node to distribute the state. This is currently for Linux for OSX nodes. Windows is a followup.
- #742 