### PR TITLE
Add additional checks for relay nodes

### DIFF
--- a/integration-tests/integration_test.go
+++ b/integration-tests/integration_test.go
@@ -936,7 +936,7 @@ func (suite *NexodusIntegrationSuite) TestV6Disabled() {
 	})
 
 	// start nexodus on the nodes
-	suite.runNexd(ctx, node1, "--username", username, "--password", password, "--discovery-node", "--relay-node")
+	suite.runNexd(ctx, node1, "--username", username, "--password", password, "--discovery-node")
 	err := suite.nexdStatus(ctx, node1)
 	require.NoError(err)
 

--- a/integration-tests/util_test.go
+++ b/integration-tests/util_test.go
@@ -88,7 +88,8 @@ func (suite *NexodusIntegrationSuite) CreateNode(ctx context.Context, nameSuffix
 		}
 	} else {
 		hostConfSysctl = map[string]string{
-			"net.ipv4.ip_forward": "1",
+			"net.ipv4.ip_forward":          "1",
+			"net.ipv6.conf.all.forwarding": "1",
 		}
 	}
 

--- a/internal/nexodus/nexodus.go
+++ b/internal/nexodus/nexodus.go
@@ -387,13 +387,9 @@ func (ax *Nexodus) Start(ctx context.Context, wg *sync.WaitGroup) error {
 
 	// a hub router requires ip forwarding and iptables rules, OS type has already been checked
 	if ax.relay {
-		if err := enableForwardingIPv4(ax.logger); err != nil {
+		if err := ax.relayPrep(); err != nil {
 			return err
 		}
-		if err := enableForwardingIPv6(ax.logger); err != nil {
-			return err
-		}
-		relayIpTables(ax.logger, ax.tunnelIface)
 	}
 
 	if err := ax.Reconcile(ax.organization, true); err != nil {

--- a/internal/nexodus/wg-peers.go
+++ b/internal/nexodus/wg-peers.go
@@ -1,6 +1,7 @@
 package nexodus
 
 import (
+	"fmt"
 	"net"
 	"runtime"
 
@@ -154,13 +155,15 @@ func (ax *Nexodus) buildLocalConfig() {
 }
 
 // relayIpTables iptables for the relay node
-func relayIpTables(logger *zap.SugaredLogger, dev string) {
+func relayIpTables(logger *zap.SugaredLogger, dev string) error {
 	_, err := RunCommand("iptables", "-A", "FORWARD", "-i", dev, "-j", "ACCEPT")
 	if err != nil {
-		logger.Debugf("the relay node v4 iptables rule was not added: %v", err)
+		return fmt.Errorf("the relay node v4 iptables rule was not added: %w", err)
 	}
 	_, err = RunCommand("ip6tables", "-A", "FORWARD", "-i", dev, "-j", "ACCEPT")
 	if err != nil {
-		logger.Debugf("tthe relay node v6 ip6tables rule was not added: %v", err)
+		return fmt.Errorf("the relay node v6 ip6tables rule was not added: %w", err)
 	}
+
+	return nil
 }


### PR DESCRIPTION
- For container scenarios, check if v4/v6 forwarding is enabled in the proc fs before trying to set it. Setting it will fail in a container and an error will be returned. But when spawned with: --sysctl net.ipv4.ip_forward=1 --sysctl net.ipv6.conf.all.forwarding=1 nexd will pass the settings check and not try and modify the kernel setting.
- Added v6 fwding to the v6 disabled test container, both can be true at the same time (ipv6 disabled with ipv6 fwding enabled).
- Removed relay from the v6 disabled test to keep a v6 disabled container profile.