### PR TITLE
nexd: Set state-dir by default

### DIFF
--- a/cmd/nexd/flags_unix.go
+++ b/cmd/nexd/flags_unix.go
@@ -7,6 +7,10 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
+const (
+	stateDirDefault = "/var/lib/nexd"
+)
+
 func init() {
 	additionalPlatformFlags = append(additionalPlatformFlags,
 		&cli.StringFlag{

--- a/cmd/nexd/flags_windows.go
+++ b/cmd/nexd/flags_windows.go
@@ -1,0 +1,7 @@
+//go:build windows
+
+package main
+
+const (
+	stateDirDefault = "C:/nexodus"
+)

--- a/cmd/nexd/main.go
+++ b/cmd/nexd/main.go
@@ -258,8 +258,8 @@ func main() {
 			},
 			&cli.StringFlag{
 				Name:    "state-dir",
-				Usage:   "Directory to store state in",
-				Value:   "",
+				Usage:   fmt.Sprintf("Directory to store state in, such as api tokens to reuse after interactive login. Defaults to'%s'", stateDirDefault),
+				Value:   stateDirDefault,
 				EnvVars: []string{"NEXD_STATE_DIR"},
 			},
 		},

--- a/internal/client/apiclient.go
+++ b/internal/client/apiclient.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/coreos/go-oidc/v3/oidc"
@@ -156,6 +157,14 @@ func loadTokenFromFile(file string) (*oauth2.Token, error) {
 
 // Saves a token to a file path.
 func saveTokenToFile(path string, token *oauth2.Token) error {
+	// Create the path to the file if it doesn't exist.
+	dir := filepath.Dir(path)
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		if err := os.MkdirAll(dir, 0600); err != nil {
+			return err
+		}
+	}
+	// Save the token to a file at the given path.
 	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
 		return err


### PR DESCRIPTION
Having this feature on provides a better user experience. The option is still present if another directory is desired. The default for linux and mac is a pretty standard location for this type of thing: /var/lib/nexd/. The default for windows is the same directory we're using for other nexd things on Windows (C:/nexd).