### PR TITLE
Makefile: Run gen-openapi-client before linters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ go-lint-prereqs:
 		exit 1 ; \
 	fi
 
-dist/.go-lint-%: $(NEX_ALL_GO) | go-lint-prereqs gen-docs dist
+dist/.go-lint-%: $(NEX_ALL_GO) | go-lint-prereqs gen-docs dist gen-openapi-client
 	$(ECHO_PREFIX) printf "  %-12s GOOS=$(word 3,$(subst -, ,$@))\n" "[GO LINT]"
 	$(CMD_PREFIX) CGO_ENABLED=0 GOOS=$(word 3,$(subst -, ,$@)) GOARCH=amd64 \
 		golangci-lint run --timeout 5m ./...

--- a/Makefile
+++ b/Makefile
@@ -169,7 +169,7 @@ dist/.gen-openapi-client: internal/docs/swagger.yaml | dist
 		-t /src/hack/openapi-templates \
 		--ignore-file-override /src/.openapi-generator-ignore $(PIPE_DEV_NULL)
 	$(ECHO_PREFIX) printf "  %-12s ./...\n" "[GO FMT]"
-	$(CMD_PREFIX) go fmt ./... $(PIPE_DEV_NULL)
+	$(CMD_PREFIX) [ -z "$(shell gofmt -l .)" ] || (echo "$(shell gofmt -l .)" && exit 1)
 	$(CMD_PREFIX) touch $@
 
 .PHONY: opa-fmt
@@ -185,7 +185,7 @@ dist/.generate: dist/.gen-docs | dist
 	$(CMD_PREFIX) go mod tidy
 
 	$(ECHO_PREFIX) printf "  %-12s ./...\n" "[GO FMT]"
-	$(CMD_PREFIX) go fmt ./...
+	$(CMD_PREFIX) [ -z "$(shell gofmt -l .)" ] || (echo "$(shell gofmt -l .)" && exit 1)
 	$(CMD_PREFIX) touch $@
 
 .PHONY: e2e

--- a/pkg/oidcagent/.github/workflows/ci.yml
+++ b/pkg/oidcagent/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
 
     - name: Go Format
       run: |
-        go fmt ./...
+        [ -z "$(gofmt -l .)" ] || (echo "$(gofmt -l .)" && exit 1)
 
     - name: Build
       run: |


### PR DESCRIPTION
I got a failure on `make -j all` that shows a dependency issue where the linters ran before the api client code was in place:

```
WARN [runner] Can't run linter goanalysis_metalinter: buildir: failed to load package : could not load export data: no export data for "github.com/nexodus-io/nexodus/internal/api/public"
ERRO Running error: 1 error occurred:
        * can't run linter goanalysis_metalinter: buildir: failed to load package : could not load export data: no export data for "github.com/nexodus-io/nexodus/internal/api/public"
```