### PR TITLE
Replace custom keepalives with wg built-in persistant keepalive

### DIFF
--- a/cmd/nexctl/connectivity.go
+++ b/cmd/nexctl/connectivity.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/briandowns/spinner"
+	"github.com/fatih/color"
+	"github.com/nexodus-io/nexodus/internal/nexodus"
+	"github.com/urfave/cli/v2"
+)
+
+// cmdConnStatus check the reachability of the node's peers and sort the return by hostname
+func cmdConnStatus(cCtx *cli.Context) error {
+	if err := checkVersion(); err != nil {
+		return err
+	}
+
+	// start spinner
+	s := spinner.New(spinner.CharSets[70], 100*time.Millisecond)
+	s.Suffix = " Running Probe..."
+	s.Start()
+
+	result, err := callNexdKeepalives()
+	if err != nil {
+		// clear spinner on error return
+		fmt.Print("\r \r")
+		return err
+	}
+	// stop spinner
+	s.Stop()
+	// clear spinner
+	fmt.Print("\r \r")
+
+	green := color.New(color.FgGreen).SprintFunc()
+	red := color.New(color.FgRed).SprintFunc()
+
+	checkmark := green("✓")
+	crossmark := red("x")
+
+	if err == nil {
+		w := newTabWriter()
+		fs := "%s\t%s\t%s\n"
+		fmt.Fprintf(w, fs, "HOSTNAME", "WIREGUARD ADDRESS", "CONNECTION STATUS")
+
+		keys := make([]string, 0, len(result))
+		for k := range result {
+			keys = append(keys, k)
+		}
+
+		sort.Slice(keys, func(i, j int) bool {
+			return result[keys[i]].Hostname < result[keys[j]].Hostname
+		})
+
+		for _, k := range keys {
+			v := result[k]
+			if v.IsReachable {
+				fmt.Fprintf(w, fs, v.Hostname, k, fmt.Sprintf("%s Reachable", checkmark))
+			} else {
+				fmt.Fprintf(w, fs, v.Hostname, k, fmt.Sprintf("%s Unreachable", crossmark))
+			}
+		}
+
+		w.Flush()
+	}
+
+	return err
+}
+
+func callNexdKeepalives() (map[string]nexodus.KeepaliveStatus, error) {
+	var result map[string]nexodus.KeepaliveStatus
+
+	keepaliveJson, err := callNexd("Connectivity")
+	if err != nil {
+		return result, fmt.Errorf("Failed to get nexd connectivity status: %w\n", err)
+	}
+
+	err = json.Unmarshal([]byte(keepaliveJson), &result)
+	if err != nil {
+		return result, fmt.Errorf("Failed to get unmarshall connecitivty results: %w\n", err)
+	}
+
+	return result, nil
+}

--- a/cmd/nexctl/main.go
+++ b/cmd/nexctl/main.go
@@ -74,6 +74,11 @@ func main() {
 				},
 			},
 			{
+				Name:   "connections",
+				Usage:  "Run a test of the nexd peer connectivity (host firewalls may block the ICMP probes)",
+				Action: cmdConnStatus,
+			},
+			{
 				Name:  "organization",
 				Usage: "Commands relating to organizations",
 				Subcommands: []*cli.Command{

--- a/docs/development/design/nexodus-connectivity.md
+++ b/docs/development/design/nexodus-connectivity.md
@@ -71,10 +71,9 @@ Respective Nexodus agents will fetch this information from the ApiServer, and ad
 
 #### Challenge 1 - what if the NAT mapping changes ?
 
-NAT mapping can change for various reasons such as NAT device restart, or mapping expiration due to no incoming/outgoing traffic. Mapping expiration issues can be resolved by enabling the `persistent keepalive` for each wireguard peer. Wireguard keepalive sends packet periodically to its peer, and that prevents NAT mapping expiration. But it doesn't help with the other reasons that can cause NAT mapping changes. There is no mechanism provided by wireguard that an Nexodus agent can use to determine the connection state (TODO: Need to explore latest handshake option, if that can help), and use that to trigger the STUN based discovery to determine the new NAT mapping (reflexive address).
+NAT mapping can change for various reasons such as NAT device restart, or mapping expiration due to no incoming/outgoing traffic. Mapping expiration issues can be resolved by enabling the `persistent keepalive` for each wireguard peer. Wireguard keepalive sends packet periodically to its peer, and that prevents NAT mapping expiration. But it doesn't help with the other reasons that can cause NAT mapping changes. There is no mechanism provided by wireguard that a Nexodus agent can use to determine the connection state (TODO: Need to explore latest handshake option, if that can help), and use that to trigger the STUN based discovery to determine the new NAT mapping (reflexive address). Currently, we set the keepalive for Wireguard peers to 20 seconds. This keepalive interval is aggressive enough to be compatible with the known firewall/middlebox connection tracking timers.
 
 > **Note**
-> Currently Nexodus agent does not configure wireguard keepalive for peers, but uses its own probe mechanism (sending ping to peers periodically) to determine the connection state. Currently it just does what wireguard keepalive is supposed to do.
 > **ThinkingHatOn**
 > do we want to extend it to help trigger the discovery for disconnected peers?
 

--- a/go.mod
+++ b/go.mod
@@ -4,11 +4,13 @@ go 1.19
 
 require (
 	github.com/Nerzal/gocloak/v13 v13.2.0
+	github.com/briandowns/spinner v1.23.0
 	github.com/bufbuild/connect-go v1.6.0
 	github.com/cockroachdb/cockroach-go/v2 v2.3.3
 	github.com/coreos/go-oidc/v3 v3.5.0
 	github.com/cucumber/godog v0.12.6
 	github.com/docker/docker v23.0.1+incompatible
+	github.com/fatih/color v1.13.0
 	github.com/gin-contrib/cors v1.4.0
 	github.com/gin-contrib/zap v0.1.0
 	github.com/gin-gonic/gin v1.9.0
@@ -86,6 +88,7 @@ require (
 	github.com/josharian/native v1.0.0 // indirect
 	github.com/klauspost/cpuid/v2 v2.0.9 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
+	github.com/mattn/go-colorable v0.1.12 // indirect
 	github.com/mattn/go-runewidth v0.0.14 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
 	github.com/mdlayher/genetlink v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -65,6 +65,8 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/briandowns/spinner v1.23.0 h1:alDF2guRWqa/FOZZYWjlMIx2L6H0wyewPxo/CH4Pt2A=
+github.com/briandowns/spinner v1.23.0/go.mod h1:rPG4gmXeN3wQV/TsAY4w8lPdIM6RX3yqeBQJSrbXjuE=
 github.com/bsm/ginkgo/v2 v2.5.0 h1:aOAnND1T40wEdAtkGSkvSICWeQ8L3UASX7YVCqQx+eQ=
 github.com/bsm/gomega v1.20.0 h1:JhAwLmtRzXFTx2AkALSLa8ijZafntmhSoU63Ok18Uq8=
 github.com/bufbuild/connect-go v1.6.0 h1:OCEB8JuEuvcY5lEKZCQE95CUscqkDtLnQceNhDgi92k=
@@ -158,6 +160,8 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.m
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210512163311-63b5d3c536b0/go.mod h1:hliV/p42l8fGbc6Y9bQ70uLwIvmJyVE5k4iMKlh8wCQ=
 github.com/envoyproxy/go-control-plane v0.9.10-0.20210907150352-cf90f659a021/go.mod h1:AFq3mo9L8Lqqiid3OhADV3RfLJnjiw63cSpi+fDTRC0=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
+github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=
+github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8vw=
 github.com/foxcpp/go-mockdns v1.0.0 h1:7jBqxd3WDWwi/6WhDvacvH1XsN3rOLXyHM1uhvIx6FI=
 github.com/frankban/quicktest v1.11.3/go.mod h1:wRf/ReqHper53s+kmmSZizM8NamnL3IM0I9ntUbOk+k=
@@ -408,6 +412,10 @@ github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN
 github.com/mailru/easyjson v0.7.6/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
+github.com/mattn/go-colorable v0.1.9/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
+github.com/mattn/go-colorable v0.1.12 h1:jF+Du6AlPIjs2BiUiQlKOX0rt3SujHxPnksPKZbaA40=
+github.com/mattn/go-colorable v0.1.12/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=
+github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 github.com/mattn/go-isatty v0.0.17 h1:BTarxUcIeDqL27Mc+vyvdWYSL28zpIhv3RoTdsLMPng=
 github.com/mattn/go-isatty v0.0.17/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
@@ -826,6 +834,7 @@ golang.org/x/sys v0.0.0-20191204072324-ce4227a45e2e/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20191228213918-04cbcbbfeed8/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200106162015-b016eb3dc98e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200113162924-86b910548bc1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200122134326-e047566fdf82/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200212091648-12a6c2dcc1e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/internal/nexodus/ctlconnectivty.go
+++ b/internal/nexodus/ctlconnectivty.go
@@ -1,0 +1,106 @@
+package nexodus
+
+import (
+	"encoding/json"
+	"fmt"
+	"go.uber.org/zap"
+	"net"
+)
+
+const batchSize = 10
+
+func (ac *NexdCtl) Connectivity(_ string, keepaliveResults *string) error {
+	res := ac.ax.connectivityProbe()
+	var err error
+
+	// Marshal the map into a JSON string.
+	keepaliveJson, err := json.Marshal(res)
+	if err != nil {
+		return fmt.Errorf("error marshalling connectivty results")
+	}
+
+	*keepaliveResults = string(keepaliveJson)
+
+	return nil
+}
+
+func (ax *Nexodus) connectivityProbe() map[string]KeepaliveStatus {
+	if ax.userspaceMode {
+		// TODO: to be addressed in #703 'nexd proxy: Add support for nexd keepalives'
+		ax.logger.Warn("nexctl connection checks are currently unsupported for nexd user space proxy")
+		return make(map[string]KeepaliveStatus)
+	}
+
+	peerStatusMap := make(map[string]KeepaliveStatus)
+
+	if !ax.relay {
+		for _, value := range ax.deviceCache {
+			// skip the node sourcing the probe
+			if ax.wireguardPubKey == value.PublicKey {
+				continue
+			}
+			pubKey := value.PublicKey
+			nodeAddr := value.TunnelIp
+			if net.ParseIP(value.TunnelIp) == nil {
+				ax.logger.Debugf("failed parsing an ip from the prefix %s", value.TunnelIp)
+				continue
+			}
+			hostname := value.Hostname
+			peerStatusMap[pubKey] = KeepaliveStatus{
+				WgIP:        nodeAddr,
+				IsReachable: false,
+				Hostname:    hostname,
+			}
+		}
+	}
+	connResults := probeConnectivity(peerStatusMap, ax.logger)
+
+	return connResults
+}
+
+// probeConnectivity check connectivity in batches to limit excessive traffic in the case of a large number of peers
+func probeConnectivity(peers map[string]KeepaliveStatus, logger *zap.SugaredLogger) map[string]KeepaliveStatus {
+	peerConnResultsMap := make(map[string]KeepaliveStatus)
+
+	peerKeys := make([]string, 0, len(peers))
+	for key := range peers {
+		peerKeys = append(peerKeys, key)
+	}
+
+	for i := 0; i < len(peerKeys); i += batchSize {
+		end := i + batchSize
+		if end > len(peerKeys) {
+			end = len(peerKeys)
+		}
+
+		batch := peerKeys[i:end]
+
+		c := make(chan struct {
+			KeepaliveStatus
+			IsReachable bool
+		})
+
+		for _, pubKey := range batch {
+			go runProbe(peers[pubKey], c)
+		}
+
+		for range batch {
+			result := <-c
+			ip := result.WgIP
+
+			if result.IsReachable {
+				logger.Debugf("connectivty probe [ %s ] is reachable", ip)
+			} else {
+				logger.Debugf("connectivty probe [ %s ] is not reachable", ip)
+			}
+
+			peerConnResultsMap[ip] = KeepaliveStatus{
+				WgIP:        result.WgIP,
+				IsReachable: result.IsReachable,
+				Hostname:    result.Hostname,
+			}
+		}
+	}
+
+	return peerConnResultsMap
+}


### PR DESCRIPTION
- Let wireguard manage keepalives. Set to a generally accepted best interval timer of 20s which is plenty to keep NAT bindings open on firewall/middleboxes. It is also one less thread nexd is maintaining. Would also make sense to catch any issues with it now rather than later. If it generates too much traffic in scale testing we can look to optimize as needed. Also it is more rigorously vetted in the wild with peer counts in the hundreds and beyond.

- Use the keepalive functions for a ctl function to probe for peer connectivity that the user can run. The function is batched so as not to fire off hundreds of simultaneous probes and to give priority to wg keepalives.