### PR TITLE
modify the qa-ec2 workflow for triggering via argcod notifications webhook

### DIFF
--- a/.github/workflows/qa-ec2.yml
+++ b/.github/workflows/qa-ec2.yml
@@ -9,6 +9,10 @@ on:
         default: 'small'
         type: string
 
+  repository_dispatch:
+    types:
+      - argocd-webhook
+
 jobs:
   deploy-ec2:
     name: deploy-ec2-e2e


### PR DESCRIPTION
Corresponds to: https://github.com/redhat-et/rosa-apps/pull/57
addresses: https://github.com/nexodus-io/nexodus/issues/548

This should enable the workflow to be triggered from a webhook on the nexodus side.