### PR TITLE
Build images with latest GA fedora

### DIFF
--- a/Containerfile.mock
+++ b/Containerfile.mock
@@ -1,4 +1,4 @@
-FROM fedora:38
+FROM fedora:latest
 
 RUN dnf -y update
 RUN dnf -y install mock make copr-cli txt2man groff

--- a/Containerfile.nexd
+++ b/Containerfile.nexd
@@ -21,7 +21,7 @@ RUN git clone https://github.com/FiloSottile/mkcert && cd mkcert && \
     CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build \
     -ldflags "-extldflags=-static -X main.Version=$(git describe --tags)"
 
-FROM fedora:36 as fedora
+FROM fedora:latest as fedora
 
 COPY --from=build-nexd /src/nexd /nexd
 COPY --from=build-mkcert /mkcert/mkcert /mkcert

--- a/Containerfile.test
+++ b/Containerfile.test
@@ -25,7 +25,7 @@ COPY --from=build /src/dist/nexctl /bin/nexctl
 COPY ./hack/update-ca.sh /update-ca.sh
 RUN chmod a+x /update-ca.sh
 
-FROM fedora:36 as fedora
+FROM fedora:latest as fedora
 RUN dnf update -qy && \
     dnf install --setopt=install_weak_deps=False -qy \
     ca-certificates \


### PR DESCRIPTION
The `test` and `nexd` images were built on `fedora:36`, but `37` is the latest GA version. The `latest` tag always points to the latest GA, so just use that.

The mock container used `38`, but `latest` is a better choice and should work just fine.