### PR TITLE
ci: Add a periodic job for govulncheck

### DIFF
--- a/.github/workflows/govulncheck.yaml
+++ b/.github/workflows/govulncheck.yaml
@@ -1,0 +1,17 @@
+name: Vuln check
+on:
+  schedule: 
+    - cron: '0 */6 * * *'
+
+permissions: 
+  security-events: write
+
+jobs:
+  vuln-check:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Golang Vulncheck
+        uses: Templum/govulncheck-action@v0.10.0
+        


### PR DESCRIPTION
Run a tool that checks the Go vulnerability database for CVEs that affect our code. Dependabot checks for CVEs, too, but I thought we could turn this on for a while to see if it helps find anything else.

Find more info on the tool here: https://go.dev/blog/vuln