### PR TITLE
Fix local e2e test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -307,10 +307,6 @@ jobs:
           docker load --input /tmp/nexd.tar
           docker load --input /tmp/envsubst.tar
 
-      - name: Build dist
-        run: |
-          make dist/nexd dist/nexctl
-
       - name: Setup KIND
         run: |
           OVERLAY=${{ matrix.overlay }} make setup-kind deploy-operators load-images deploy cacerts

--- a/Makefile
+++ b/Makefile
@@ -187,7 +187,7 @@ dist/.generate: $(SWAGGER_YAML) | dist
 	$(CMD_PREFIX) touch $@
 
 .PHONY: e2e
-e2e: e2eprereqs image-nexd ## Run e2e tests
+e2e: e2eprereqs dist/nexd dist/nexctl image-nexd ## Run e2e tests
 	go test -v --tags=integration ./integration-tests/... $(if $(NEX_TEST),-run $(NEX_TEST),)
 
 .PHONY: e2e-podman


### PR DESCRIPTION
While moving from test image to nexd image,
dist/nexd and dist/nexctl pre-req targets were
not added back. These binaries are needed to run
 the local e2e.

In Github CI job e2e was working because the job explictly build these binaries.

This patch adds the dist/nexd and dist/nexctl targets to e2e dependency, and removes the explict building of these binary in the build job, as it's not needed anymore.