### PR TITLE
We do need to build binaries in build job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -311,6 +311,10 @@ jobs:
         run: |
           OVERLAY=${{ matrix.overlay }} make setup-kind deploy-operators load-images deploy cacerts
 
+      - name: Build dist
+        run: |
+          make dist/nexd dist/nexctl
+
       - name: Run e2e Tests
         run: |
           go test -v --tags=integration ./integration-tests/...


### PR DESCRIPTION
because it doesn't use make targets for running
integration test, it invokes directly.