### PR TITLE
docs: Update PR merge criteria

### DIFF
--- a/.github/workflows/enforce-labels.yml
+++ b/.github/workflows/enforce-labels.yml
@@ -1,0 +1,13 @@
+name: Enforce PR labels
+
+on:
+  pull_request:
+    types: [labeled, unlabeled, opened, edited, synchronize]
+jobs:
+  enforce-label:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: yogevbd/enforce-label-action@2.2.2
+      with:
+        BANNED_LABELS: "hold"
+        BANNED_LABELS_DESCRIPTION: "PR may not merge with ${bannedLabel.name} label."

--- a/docs/development/pull-requests.md
+++ b/docs/development/pull-requests.md
@@ -10,16 +10,19 @@ When contributing changes to this project, you must agree to the [DCO](DCO).
 Commits must include a `Signed-off-by:` header which certifies agreement with
 the terms of the [DCO](DCO).
 
-Using `-s` with `git commit` will automtaically add this header.
-
-## Merge Criteria
-
-Pull requests should receive at least one approval before merging. CI should also be passing. You may enable the [auto-merge feature](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/automatically-merging-a-pull-request) on a PR to have it be automatically merged once this criteria has been met.
+Using `-s` with `git commit` will automatically add this header.
 
 ## Requesting Reviews
 
 Use the GitHub reviewers field to request reviews from a specific individual. Be sure to also select "re-request review" after making changes in response to a past review to ensure the reviewer knows it's ready for another look.
 
+## Merge Criteria
+
+* Pull requests should receive at least one approval before merging.
+* CI should be passing.
+* Every person who is on the list of reviewers should be given a chance to weigh in before merging. 24 hours is a good general rule, but if the PR is small and the reviewers are all active, it's fine to merge sooner. If a PR is large, complex, or controversial, waiting longer would make sense. Use your best judgment.
+* The `hold` label must not be present on the PR. Ensure that whoever added the `hold` is OK with removing the label before the PR is merged. There is no timeout on the `hold` label for when someone else should remove it unless the reviewer who placed the hold is unavailable for a significant period.
+
 ## Exceptions
 
-These are guidelines, not hard rules. Committers have earned the trust of others to use their best judgement in each situation.
+These are guidelines, not hard rules. Committers have earned the trust of others to use their best judgment in each situation.


### PR DESCRIPTION
* Note that every person on the Reviewers list should be given a chance to review before merging.
* Document the `hold` label which is an even more explicit way to block merging for whatever reason.
* Fix some minor spelling mistakes.