### PR TITLE
nexd: Add egress UDP proxy support

### DIFF
--- a/Containerfile.nexd
+++ b/Containerfile.nexd
@@ -16,6 +16,14 @@ RUN CGO_ENABLED=0 go build \
     -ldflags="-extldflags=-static" \
     -o nexctl ./cmd/nexctl
 
+RUN CGO_ENABLED=0 go build \
+    -ldflags="-extldflags=-static" \
+    -o udping ./hack/udping
+
+RUN CGO_ENABLED=0 go build \
+    -ldflags="-extldflags=-static" \
+    -o udpong ./hack/udpong
+
 FROM fedora:latest as fedora
 
 RUN dnf update -qy && \
@@ -28,6 +36,7 @@ RUN dnf update -qy && \
     wireguard-tools \
     nftables \
     hostname \
+    netcat \
     && \
     dnf clean all -y &&\
     rm -rf /var/cache/yum
@@ -36,4 +45,5 @@ COPY --chmod=755 ./hack/update-ca.sh /update-ca.sh
 COPY --chmod=755 --from=build /src/nexd /bin/nexd
 COPY --chmod=755 --from=build /src/nexctl /bin/nexctl
 COPY --chmod=755 --from=build /go/bin/mkcert /bin/mkcert
-
+COPY --chmod=755 --from=build /src/udping /bin/udping
+COPY --chmod=755 --from=build /src/udpong /bin/udpong

--- a/docs/user-guide/nexd-proxy.md
+++ b/docs/user-guide/nexd-proxy.md
@@ -54,7 +54,7 @@ Egress proxy rules are specified with the `--egress` flag. This flag can be spec
 --egress protocol:port:destination:destination_port
 ```
 
-* `protocol` - must be `tcp`
+* `protocol` - may be `tcp` or `udp`
 * `port` - the port that `nexd` will accept connections to made to its IP address within the Nexodus organization this device is a member of.
 * `destination` - the IP address or hostname of the destination on a network accessible to the device that the proxy will forward traffic to.
 * `destination_port` - the port on the destination on a network accessible to the device that the proxy will forward traffic to.
@@ -75,6 +75,10 @@ flowchart TD
  dest(Source application connecting to port 443 on 10.10.100.151<br/><br/>Local Network IP: 10.10.100.152)-->|tcp|container
  end
 ```
+
+### UDP Proxy Behavior
+
+Since UDP is a connectionless protocol, `nexd proxy` must maintain its own state for each UDP flow to ensure that return traffic is forwarded appropriately. These flows time out after 60 seconds of inactivity.
 
 ## Demo Using Containers
 

--- a/go.mod
+++ b/go.mod
@@ -51,6 +51,7 @@ require (
 	gorm.io/driver/postgres v1.5.0
 	gorm.io/driver/sqlite v1.4.4
 	gorm.io/gorm v1.24.7-0.20230306060331-85eaf9eeda11
+	gvisor.dev/gvisor v0.0.0-20220817001344-846276b3dbc5
 )
 
 require (
@@ -129,7 +130,6 @@ require (
 	google.golang.org/appengine v1.6.7 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gotest.tools/v3 v3.4.0 // indirect
-	gvisor.dev/gvisor v0.0.0-20220817001344-846276b3dbc5 // indirect
 )
 
 require (

--- a/hack/udping/udping.go
+++ b/hack/udping/udping.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"time"
+)
+
+func main() {
+	// Parse command line arguments
+	if len(os.Args) != 3 {
+		fmt.Fprintf(os.Stderr, "Usage: %s <ip> <port>\n", os.Args[0])
+		os.Exit(1)
+	}
+	ip := os.Args[1]
+	port := os.Args[2]
+
+	// Create UDP address for destination
+	dstAddr, err := net.ResolveUDPAddr("udp", net.JoinHostPort(ip, port))
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Error resolving destination address:", err)
+		os.Exit(1)
+	}
+
+	// Create UDP address for source
+	srcAddr := &net.UDPAddr{}
+
+	// Create UDP connection
+	conn, err := net.ListenUDP("udp", srcAddr)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Error creating UDP connection:", err)
+		os.Exit(1)
+	}
+	defer conn.Close()
+
+	// Send UDP packet with payload "ping" to destination
+	_, err = conn.WriteToUDP([]byte("ping"), dstAddr)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Error sending UDP packet:", err)
+		os.Exit(1)
+	}
+
+	// Wait for UDP packet response
+	buffer := make([]byte, 1024)
+	err = conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Error setting read deadline:", err)
+	}
+	fmt.Printf("Waiting for pong response from %s for 5 seconds...\n", dstAddr.String())
+	n, addr, err := conn.ReadFromUDP(buffer)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Error receiving UDP packet:", err)
+		os.Exit(1)
+	}
+
+	// Print the response
+	fmt.Printf("Received %d bytes from %s: %s\n", n, addr.String(), string(buffer[:n]))
+}

--- a/hack/udpong/udpong.go
+++ b/hack/udpong/udpong.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"os"
+)
+
+func main() {
+	// Parse command line arguments
+	if len(os.Args) != 2 {
+		fmt.Fprintf(os.Stderr, "Usage: %s <port>\n", os.Args[0])
+		os.Exit(1)
+	}
+	port := os.Args[1]
+
+	// Create UDP address for listening
+	addr, err := net.ResolveUDPAddr("udp", ":"+port)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Error resolving UDP address:", err)
+		os.Exit(1)
+	}
+
+	// Create UDP connection
+	conn, err := net.ListenUDP("udp", addr)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "Error creating UDP connection:", err)
+		os.Exit(1)
+	}
+	defer conn.Close()
+
+	// Wait for UDP packets
+	buffer := make([]byte, 1024)
+	for {
+		n, clientAddr, err := conn.ReadFromUDP(buffer)
+		if err != nil {
+			// Check if the error is a timeout error and continue if it is
+			var timeoutError net.Error
+			if errors.As(err, &timeoutError); timeoutError.Timeout() {
+				continue
+			}
+			fmt.Fprintln(os.Stderr, "Error receiving UDP packet:", err)
+			continue
+		}
+
+		// Send a response packet with payload "pong" to the source address
+		_, err = conn.WriteToUDP([]byte("pong"), clientAddr)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "Error sending UDP packet:", err)
+			continue
+		}
+
+		fmt.Printf("Received %d bytes from %s: %s\n", n, clientAddr.String(), string(buffer[:n]))
+	}
+}

--- a/internal/nexodus/userspace_proxy.go
+++ b/internal/nexodus/userspace_proxy.go
@@ -2,9 +2,11 @@ package nexodus
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net"
+	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -13,6 +15,7 @@ import (
 	"github.com/nexodus-io/nexodus/internal/util"
 	"go.uber.org/zap"
 	"golang.zx2c4.com/wireguard/tun/netstack"
+	"gvisor.dev/gvisor/pkg/tcpip/adapters/gonet"
 )
 
 type ProxyType int
@@ -37,7 +40,13 @@ type UsProxy struct {
 	destPort     int
 	logger       *zap.SugaredLogger
 	userspaceNet *netstack.Net
+	debugTraffic bool
 }
+
+const (
+	udpMaxPayloadSize = 65507
+	udpTimeout        = time.Minute
+)
 
 func proxyTypeStr(ruleType ProxyType) (string, error) {
 	switch ruleType {
@@ -55,8 +64,7 @@ func proxyProtocol(protocol string) (ProxyProtocol, error) {
 	case "tcp":
 		return proxyProtocolTCP, nil
 	case "udp":
-		// TODO
-		return proxyProtocolUDP, fmt.Errorf("UDP proxy support not yet implemented")
+		return proxyProtocolUDP, nil
 	default:
 		return "", fmt.Errorf("Invalid protocol (%s)", protocol)
 	}
@@ -81,7 +89,6 @@ func (ax *Nexodus) UserspaceProxyAdd(ctx context.Context, wg *sync.WaitGroup, pr
 	parts := strings.Split(proxyRule, ":")
 	if len(parts) < 4 {
 		return fmt.Errorf("Invalid proxy rule format, must specify 4 colon-separated values (%s)", proxyRule)
-
 	}
 
 	protocol, err := proxyProtocol(parts[0])
@@ -105,13 +112,15 @@ func (ax *Nexodus) UserspaceProxyAdd(ctx context.Context, wg *sync.WaitGroup, pr
 		return err
 	}
 
+	debugTraffic, _ := strconv.ParseBool(os.Getenv("NEXD_PROXY_DEBUG_TRAFFIC"))
 	proxy := &UsProxy{
-		ruleType:   ruleType,
-		protocol:   protocol,
-		listenPort: port,
-		destHost:   destHost,
-		destPort:   destPort,
-		logger:     ax.logger.With("proxy", typeStr, "proxyRule", proxyRule),
+		ruleType:     ruleType,
+		protocol:     protocol,
+		listenPort:   port,
+		destHost:     destHost,
+		destPort:     destPort,
+		logger:       ax.logger.With("proxy", typeStr, "proxyRule", proxyRule),
+		debugTraffic: debugTraffic,
 	}
 
 	if ruleType == ProxyTypeEgress {
@@ -144,6 +153,198 @@ func (proxy *UsProxy) Start(ctx context.Context, wg *sync.WaitGroup, net *netsta
 }
 
 func (proxy *UsProxy) run(ctx context.Context, proxyWg *sync.WaitGroup) error {
+	switch proxy.protocol {
+	case proxyProtocolTCP:
+		return proxy.runTCP(ctx, proxyWg)
+	case proxyProtocolUDP:
+		return proxy.runUDP(ctx, proxyWg)
+	default:
+		return fmt.Errorf("Unexpected proxy protocol: %v", proxy.protocol)
+	}
+}
+
+func (proxy *UsProxy) runUDP(ctx context.Context, proxyWg *sync.WaitGroup) error {
+	switch proxy.ruleType {
+	case ProxyTypeEgress:
+		return proxy.runUDPEgress(ctx, proxyWg)
+	case ProxyTypeIngress:
+		return proxy.runUDPIngress(ctx, proxyWg)
+	default:
+		return fmt.Errorf("Unexpected proxy rule type: %v", proxy.ruleType)
+	}
+}
+
+type udpProxyConn struct {
+	// The client that originated a stream to the UDP proxy
+	clientAddr *net.UDPAddr
+	// The connection with the originator
+	conn *net.UDPConn
+	// The connection with the destination
+	proxyConn *gonet.UDPConn
+	// Notify when the connection is to be closed
+	closeChan chan string
+	// track the last time inbound traffic was received
+	lastActivity time.Time
+}
+
+func (proxy *UsProxy) runUDPEgress(ctx context.Context, proxyWg *sync.WaitGroup) error {
+	var conn *net.UDPConn
+	var err error
+
+	addr, err := net.ResolveUDPAddr("udp", fmt.Sprintf(":%d", proxy.listenPort))
+	if err != nil {
+		return fmt.Errorf("Failed to resolve UDP address: %w", err)
+	}
+	conn, err = net.ListenUDP("udp", addr)
+	if err != nil {
+		return fmt.Errorf("Failed to listen on UDP port: %w", err)
+	}
+	defer conn.Close()
+
+	buffer := make([]byte, udpMaxPayloadSize)
+	proxyConns := make(map[string]*udpProxyConn)
+	var clientAddr *net.UDPAddr
+	var n int
+	// a channel for being notified when a proxy connection is to be closed
+	closeChan := make(chan string)
+	defer close(closeChan)
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case clientAddrStr := <-closeChan:
+			// This connection has timed out, so drop our reference to it and close the connection
+			proxyConn := proxyConns[clientAddrStr]
+			if proxyConn == nil {
+				proxy.logger.Warn("No proxy connection found for client address:", clientAddrStr)
+				continue
+			}
+			if proxy.debugTraffic {
+				proxy.logger.Debug("Closing proxy connection for client:", clientAddrStr)
+			}
+			proxyConn.proxyConn.Close()
+			delete(proxyConns, clientAddrStr)
+		default:
+			// Read from the UDP socket, but don't block for more than a second
+			if err = conn.SetReadDeadline(time.Now().Add(1 * time.Second)); err != nil {
+				proxy.logger.Warn("Error setting UDP read deadline:", err)
+				continue
+			}
+			n, clientAddr, err = conn.ReadFromUDP(buffer)
+			if err != nil {
+				var timeoutError net.Error
+				if errors.As(err, &timeoutError); timeoutError.Timeout() {
+					continue
+				}
+				proxy.logger.Warn("Error reading from UDP client:", err)
+				continue
+			}
+			if proxy.debugTraffic {
+				proxy.logger.Debug("Read from UDP client:", clientAddr, n, buffer[:n])
+			}
+
+			var proxyConn *udpProxyConn
+			if proxyConn = proxyConns[clientAddr.String()]; proxyConn == nil {
+				proxyConn = &udpProxyConn{conn: conn, clientAddr: clientAddr, closeChan: closeChan}
+				err = proxy.createUDPProxyConn(ctx, proxyWg, proxyConn)
+				if err != nil {
+					proxy.logger.Warn("Error creating UDP proxy connection:", err)
+					continue
+				}
+				proxyConns[clientAddr.String()] = proxyConn
+			}
+			_, err = proxyConn.proxyConn.Write(buffer[:n])
+			if err != nil {
+				proxy.logger.Warn("Error writing to UDP proxy destination:", err)
+			} else if proxy.debugTraffic {
+				proxy.logger.Info("Wrote to UDP proxy destination:", proxyConn.proxyConn.RemoteAddr(), n, buffer[:n])
+			}
+			proxyConn.lastActivity = time.Now()
+		}
+	}
+}
+
+func (proxy *UsProxy) createUDPProxyConn(ctx context.Context, proxyWg *sync.WaitGroup, proxyConn *udpProxyConn) error {
+	newConn, err := proxy.userspaceNet.DialUDP(nil, &net.UDPAddr{Port: proxy.destPort, IP: net.ParseIP(proxy.destHost)})
+	if err != nil {
+		return fmt.Errorf("Error dialing UDP proxy destination: %w", err)
+	}
+	proxyConn.proxyConn = newConn
+
+	util.GoWithWaitGroup(proxyWg, func() {
+		buf := make([]byte, udpMaxPayloadSize)
+		var n int
+		// Handle proxying data from the destination back to the client.
+		// There is a different UDPConn per stream here because we use
+		// a different UDP source port for each stream.
+		timer := time.NewTimer(udpTimeout)
+	loop:
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-timer.C:
+				// The connection timed out based only on return traffic activity.
+				// Check to see if any traffic from the originating side has happened
+				// within the timeout period.
+				if time.Since(proxyConn.lastActivity) < udpTimeout {
+					timer.Reset(udpTimeout - time.Since(proxyConn.lastActivity))
+					continue
+				}
+				if proxy.debugTraffic {
+					proxy.logger.Debug("UDP proxy connection timed out after", udpTimeout)
+				}
+				break loop
+			default:
+				if err = proxyConn.proxyConn.SetReadDeadline(time.Now().Add(1 * time.Second)); err != nil {
+					proxy.logger.Warn("Error setting UDP read deadline:", err)
+					break loop
+				}
+				var clientAddr2 net.Addr
+				n, clientAddr2, err = proxyConn.proxyConn.ReadFrom(buf)
+				if err != nil {
+					var timeoutError net.Error
+					if errors.As(err, &timeoutError); timeoutError.Timeout() {
+						continue
+					}
+					proxy.logger.Warn("Error reading from UDP client:", err)
+					break loop
+				}
+				if proxy.debugTraffic {
+					proxy.logger.Debug("Read from UDP client:", clientAddr2, n, buf[:n])
+				}
+				_, err = proxyConn.conn.WriteToUDP(buf[:n], proxyConn.clientAddr)
+				if err != nil {
+					proxy.logger.Warn("Error writing back to original UDP source:", err)
+					break loop
+				}
+				if proxy.debugTraffic {
+					proxy.logger.Debug("Wrote to UDP proxy destination:", proxyConn.proxyConn.RemoteAddr(), n, buf[:n])
+				}
+				if !timer.Stop() {
+					<-timer.C
+				}
+				timer.Reset(udpTimeout)
+			}
+		}
+		proxyConn.closeChan <- proxyConn.clientAddr.String()
+	})
+
+	return nil
+}
+
+func (proxy *UsProxy) runUDPIngress(ctx context.Context, proxyWg *sync.WaitGroup) error {
+	// goConn, err = proxy.userspaceNet.ListenUDP(&net.UDPAddr{Port: proxy.listenPort})
+	// if err != nil {
+	// 	return fmt.Errorf("Failed to listen on UDP port: %w", err)
+	// }
+	// defer goConn.Close()
+
+	// TODO
+	return fmt.Errorf("Ingress UDP proxy not implemented yet")
+}
+
+func (proxy *UsProxy) runTCP(ctx context.Context, proxyWg *sync.WaitGroup) error {
 	var l net.Listener
 	var err error
 	if proxy.ruleType == ProxyTypeEgress {


### PR DESCRIPTION
commit 431a691824d38f34b41a4ccd8e78cc17323f1b06
Author: Russell Bryant <rbryant@redhat.com>
Date:   Thu Apr 13 13:48:50 2023 -0400

    nexd: Add more debug tools to container
    
    Add `nc` and a couple of custom UDP utilities to do the most trivial
    of UDP testing.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>

commit 2a57dc0155100e174e39ee043d1d8076b0b5c3a0
Author: Russell Bryant <russell.bryant@gmail.com>
Date:   Fri Apr 7 09:35:15 2023 -0400

    nexd: Add udp egress proxy support
    
    This commit introduces UDP egress proxy support. I will add ingress
    support in a follow-up change.
    
    UDP proxy support is a bit more complicated than TCP support. We need
    to allow return traffic back to each originating client, so we have to
    do our own primitive connection tracking from within the proxy. These
    flows time out after 1 minute of inactivity.
    
    This timeout may need to be configurable at some point. I pulled 1
    minute from the default value used by Envoy's UDP proxy support.
    
    After a flow times out, subsequent traffic from a client will be seen
    as a new flow to the proxy and a new UDP source port will be allocated
    for the associated traffic forwarded from the proxy.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>

commit 0ce5e8625f0309c196141555b7888a2ab39db4f8
Author: Russell Bryant <rbryant@redhat.com>
Date:   Fri Apr 14 15:20:53 2023 -0400

    e2e: Add TestProxyEgressUDP
    
    This test sets up a single egress UDP proxy rule. It ensures that a
    UDP packet makes it from a client, through the proxy, and to a server
    on another Nexodus device. It also ensures that a reply packet sent
    from that UDP server makes it back to the original client.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>