### PR TITLE
docs: Add proxy mode to docs home page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -7,13 +7,14 @@ Welcome to the Nexodus project documentation. A rendered version of these docs a
 
 ## Project Vision
 
-This project aims to provide connectivity between nodes deployed across heterogeneous environments (Edge, Public, Private, and Hybrid Cloud) with different visibilities (nodes in a Cloud VPC, nodes behind NAT, etc.). This solution is not specific to any infrastructure or application platform but focuses on providing IP connectivity between nodes and the container or VM workloads running on those nodes. This service is complementary to platforms-specific networking, as it can expand connectivity to places the platform could not reach otherwise.
+This project aims to provide connectivity between nodes deployed across heterogeneous environments (Edge, Public, Private, and Hybrid Cloud) with different visibilities (nodes in a Cloud VPC, nodes behind NAT, etc.). This solution is not specific to any infrastructure or application platform but focuses on providing connectivity between nodes and the container or VM workloads running on those nodes. This service is complementary to platforms-specific networking, as it can expand connectivity to places the platform could not reach otherwise.
 
 Some of the features and use cases that this project aims to support are:
 
 - **Edge networking** - connectivity to any node, anywhere
 - **Hybrid data center connectivity** - circumvents NAT challenges
 - **IP mobility** - /32 host routing allows addresses to be advertised anywhere with convergence times only limited by a round-trip time to a controller.
+- **L4 Proxy** - TCP and UDP proxy mode to allow for connectivity to and from services running in non-privileged application environments (containers, for example).
 - **Compliance** - Provide isolated connectivity among a set of nodes, even if they are running across multiple network administrative domains.
 - **Configurable Authentication** - Nexodus uses OpenID Connect (OIDC) for authentication, allowing you to choose from a broad ecosystem of OIDC providers. OIDC gateways are available to provide interoperability with other authentication schemes (i.e., LDAP).
 


### PR DESCRIPTION
Change "IP connectivity" to just "connectivity" since proxy mode allows more than just IP-level connectivity.

Add "L4 Proxy" as a line item on our home page to call out that while it's an L3 solution, there is also an L4 mode for non-privileged environments.