### PR TITLE
Fetch nexd and api-server logs and upload as artifacts in dev-ec2 workflow

### DIFF
--- a/.github/workflows/dev-ec2.yml
+++ b/.github/workflows/dev-ec2.yml
@@ -103,6 +103,7 @@ jobs:
 
       - name: Initialize the api-server Images
         run: |
+          mkdir -p ./ops/ansible/aws/nexd-logs/api-server
           ansible-playbook -vv ./hack/e2e-scripts/aws-e2e-pr-build.yml \
           --private-key nexodus.pem \
           -e "target_host=${{ vars.EC2_API_SERVER_ADDR }} pr_or_branch=${{ github.event.inputs.pr_or_branch }} ansible_user=ubuntu"
@@ -126,7 +127,23 @@ jobs:
             exit 1
           fi
 
+      - name: Gather api-server Server Logs
+        if: always()
+        run: |
+          ansible-playbook -vv \
+          ./hack/e2e-scripts/aws-e2e-pr-gather.yml \
+          --private-key nexodus.pem \
+          -e "target_host=${{ vars.EC2_API_SERVER_ADDR }} ansible_user=ubuntu"
+
       - name: Terminate EC2 Instances
         if: always()
         run: |
           ansible-playbook -vv ./ops/ansible/aws/terminate-instances.yml
+
+      - name: Upload nexd and api-server Logs to Artifacts
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: dev-ec2-artifacts
+          path: ./ops/ansible/aws/nexd-logs/
+          retention-days: 10

--- a/hack/e2e-scripts/aws-e2e-pr-gather.yml
+++ b/hack/e2e-scripts/aws-e2e-pr-gather.yml
@@ -1,0 +1,16 @@
+---
+- name: Export and copy api-server logs back to the runner
+  hosts: localhost
+  gather_facts: true
+  tasks:
+    - name: Gather api-server logs
+      shell: |
+        kubectl logs deployment/apiserver -n nexodus --kubeconfig /home/{{ ansible_user }}/.kube/config > api-server-logs.txt
+      delegate_to: "{{ target_host }}"
+
+    - name: Fetch api-server logs from the remote host to localhost
+      fetch:
+        src: /home/{{ ansible_user }}/api-server-logs.txt
+        dest: /home/runner/work/nexodus/nexodus/ops/ansible/aws/nexd-logs/api-server/
+        flat: yes
+      delegate_to: "{{ target_host }}"

--- a/ops/ansible/aws/deploy-mesh/tasks/main.yml
+++ b/ops/ansible/aws/deploy-mesh/tasks/main.yml
@@ -97,3 +97,19 @@
     --relay-only \
     {{ nexodus_url }} > nexodus-logs.txt 2>&1 &
   when: "'nexodusRelayNodes' in group_names"
+
+- name: Pause for 10 seconds for the onboard to complete to scrape the logs
+  pause:
+    seconds: 10
+
+- name: Display the nexd logs to stdout
+  become: yes
+  shell: |
+    cat /home/{{ ansible_user }}/nexodus-logs.txt
+
+- name: Copy file from remote host to local host
+  fetch:
+    src: /home/{{ ansible_user }}/nexodus-logs.txt
+    dest: ./nexd-logs/{{ ansible_hostname }}-nexodus-logs.txt
+    flat: yes
+  ignore_errors: yes

--- a/ops/ansible/aws/deploy-mesh/tasks/main.yml
+++ b/ops/ansible/aws/deploy-mesh/tasks/main.yml
@@ -107,7 +107,7 @@
   shell: |
     cat /home/{{ ansible_user }}/nexodus-logs.txt
 
-- name: Copy file from remote host to local host
+- name: Copy file from remote host to localhost
   fetch:
     src: /home/{{ ansible_user }}/nexodus-logs.txt
     dest: ./nexd-logs/{{ ansible_hostname }}-nexodus-logs.txt

--- a/ops/ansible/aws/deploy-relay/tasks/main.yml
+++ b/ops/ansible/aws/deploy-relay/tasks/main.yml
@@ -84,3 +84,19 @@
     --password '{{ nexodus_auth_password }}' \
     relay \
     {{ nexodus_url }} > nexodus-logs.txt 2>&1 &
+
+- name: Pause for 10 seconds for the onboard to complete to scrape the logs
+  pause:
+    seconds: 10
+
+- name: Display the nexd logs to stdout
+  become: yes
+  shell: |
+    cat /home/{{ ansible_user }}/nexodus-logs.txt
+
+- name: Copy file from remote host to local host
+  fetch:
+    src: /home/{{ ansible_user }}/nexodus-logs.txt
+    dest: ./nexd-logs/{{ ansible_hostname }}-nexodus-logs.txt
+    flat: yes
+  ignore_errors: yes

--- a/ops/ansible/aws/deploy-relay/tasks/main.yml
+++ b/ops/ansible/aws/deploy-relay/tasks/main.yml
@@ -94,7 +94,7 @@
   shell: |
     cat /home/{{ ansible_user }}/nexodus-logs.txt
 
-- name: Copy file from remote host to local host
+- name: Copy file from remote host to localhost
   fetch:
     src: /home/{{ ansible_user }}/nexodus-logs.txt
     dest: ./nexd-logs/{{ ansible_hostname }}-nexodus-logs.txt


### PR DESCRIPTION
This will improve debugging of `dev-ec2` workflows since agent nodes are ephemeral and the api-server may get queued directly into another workflow run.