### PR TITLE
Add more checks and messaging to the user for invalid urls

### DIFF
--- a/internal/nexodus/nexodus.go
+++ b/internal/nexodus/nexodus.go
@@ -154,7 +154,11 @@ func NewNexodus(
 
 	controllerURL, err := url.Parse(controller)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("invalid controller-url provided: %s error: %w, please use the following format https://<controller-url>", controller, err)
+	}
+
+	if !strings.HasPrefix(controller, "https://") {
+		return nil, fmt.Errorf("invalid controller-url provided: %s, please use the following format https://<controller-url>", controller)
 	}
 
 	// Force controller URL be api.${DOMAIN}


### PR DESCRIPTION
- An invalid controller URL will almost always hit the https check rather than the `url.Parse`. Virtually anything passes that check.
- Log what the user passed in case they typo subcommands that don't contain `--foo`, e.g. router|proxy|relay
