### PR TITLE
nexctl: Add ability to get tunnel IP from nexd

### DIFF
--- a/cmd/nexctl/local_unix.go
+++ b/cmd/nexctl/local_unix.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"net/rpc/jsonrpc"
+	"path/filepath"
 
 	"github.com/nexodus-io/nexodus/internal/api"
 	"github.com/urfave/cli/v2"
@@ -91,7 +92,10 @@ func init() {
 func callNexd(method string) (string, error) {
 	conn, err := net.Dial("unix", api.UnixSocketPath)
 	if err != nil {
-		return "", fmt.Errorf("Failed to connect to nexd: %w\n", err)
+		conn, err = net.Dial("unix", filepath.Base(api.UnixSocketPath))
+		if err != nil {
+			return "", fmt.Errorf("Failed to connect to nexd: %w\n", err)
+		}
 	}
 	defer conn.Close()
 

--- a/cmd/nexctl/local_unix.go
+++ b/cmd/nexctl/local_unix.go
@@ -4,10 +4,11 @@ package main
 
 import (
 	"fmt"
-	"github.com/nexodus-io/nexodus/internal/api"
-	"github.com/urfave/cli/v2"
 	"net"
 	"net/rpc/jsonrpc"
+
+	"github.com/nexodus-io/nexodus/internal/api"
+	"github.com/urfave/cli/v2"
 )
 
 func init() {
@@ -45,6 +46,42 @@ func init() {
 						fmt.Printf("%s\n", err)
 					}
 					return nil
+				},
+			},
+			{
+				Name:  "get",
+				Usage: "Get a value from the local nexd instance",
+				Subcommands: []*cli.Command{
+					{
+						Name:  "tunnelip",
+						Usage: "Get the tunnel IP address",
+						Flags: []cli.Flag{
+							&cli.BoolFlag{
+								Name:    "ipv6",
+								Aliases: []string{"6"},
+								Usage:   "Get the IPv6 tunnel IP address",
+								Value:   false,
+							},
+						},
+						Action: func(cCtx *cli.Context) error {
+							var result string
+							var err error
+							if err := checkVersion(); err != nil {
+								return err
+							}
+							if cCtx.Bool("ipv6") {
+								result, err = callNexd("GetTunnelIPv6")
+							} else {
+								result, err = callNexd("GetTunnelIPv4")
+							}
+							if err != nil {
+								fmt.Printf("%s\n", err)
+								return err
+							}
+							fmt.Printf("%s\n", result)
+							return nil
+						},
+					},
 				},
 			},
 		},

--- a/integration-tests/helper_test.go
+++ b/integration-tests/helper_test.go
@@ -3,15 +3,6 @@ package integration_tests
 import (
 	"context"
 	"fmt"
-	"github.com/cenkalti/backoff/v4"
-	"github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/api/types/network"
-	"github.com/nexodus-io/nexodus/internal/nexodus"
-	"github.com/nexodus-io/nexodus/internal/util"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"github.com/testcontainers/testcontainers-go"
-	"go.uber.org/zap/zaptest"
 	"io"
 	"os/exec"
 	"path/filepath"
@@ -21,6 +12,16 @@ import (
 	"testing"
 	"time"
 	"unicode"
+
+	"github.com/cenkalti/backoff/v4"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/network"
+	"github.com/nexodus-io/nexodus/internal/nexodus"
+	"github.com/nexodus-io/nexodus/internal/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	"go.uber.org/zap/zaptest"
 )
 
 type Helper struct {

--- a/integration-tests/proxy_test.go
+++ b/integration-tests/proxy_test.go
@@ -65,7 +65,7 @@ func TestProxyEgress(t *testing.T) {
 	ctxTimeout, curlCancel := context.WithTimeout(ctx, 10*time.Second)
 	defer curlCancel()
 	success, err := util.CheckPeriodically(ctxTimeout, time.Second, func() (bool, error) {
-		output, err := helper.containerExec(ctx, node2, []string{"curl", "-s", "http://localhost"})
+		output, err := helper.containerExec(ctx, node2, []string{"curl", "-s", "http://127.0.0.1"})
 		if err != nil {
 			helper.Logf("Retrying curl for up to 10 seconds while waiting for peering to finish: %v -- %s", err, output)
 			return false, nil
@@ -75,6 +75,7 @@ func TestProxyEgress(t *testing.T) {
 	})
 	require.NoError(err)
 	require.True(success)
+	_, _ = helper.containerExec(ctx, node1, []string{"killall", "python3"})
 	wg.Wait()
 }
 
@@ -139,6 +140,7 @@ func TestProxyEgressUDP(t *testing.T) {
 	})
 	require.NoError(err)
 	require.True(success)
+	_, _ = helper.containerExec(ctx, node1, []string{"killall", "udpong"})
 	wg.Wait()
 }
 
@@ -195,12 +197,12 @@ func TestProxyEgressMultipleRules(t *testing.T) {
 	ctxTimeout, curlCancel := context.WithTimeout(ctx, 10*time.Second)
 	defer curlCancel()
 	success, err := util.CheckPeriodically(ctxTimeout, time.Second, func() (bool, error) {
-		output, err := helper.containerExec(ctx, node2, []string{"curl", "-s", "http://localhost"})
+		output, err := helper.containerExec(ctx, node2, []string{"curl", "-s", "http://127.0.0.1"})
 		if err != nil {
 			helper.Logf("Retrying curl for up to 10 seconds while waiting for peering to finish: %v -- %s", err, output)
 			return false, nil
 		}
-		output2, err := helper.containerExec(ctx, node2, []string{"curl", "-s", "http://localhost:81"})
+		output2, err := helper.containerExec(ctx, node2, []string{"curl", "-s", "http://127.0.0.1:81"})
 		if err != nil {
 			helper.Logf("Retrying curl for up to 10 seconds while waiting for peering to finish: %v -- %s", err, output2)
 			return false, nil
@@ -211,6 +213,7 @@ func TestProxyEgressMultipleRules(t *testing.T) {
 	})
 	require.NoError(err)
 	require.True(success)
+	_, _ = helper.containerExec(ctx, node1, []string{"killall", "python3"})
 	wg.Wait()
 }
 
@@ -272,6 +275,7 @@ func TestProxyIngress(t *testing.T) {
 	})
 	require.NoError(err)
 	require.True(success)
+	_, _ = helper.containerExec(ctx, node2, []string{"killall", "python3"})
 	wg.Wait()
 }
 
@@ -340,6 +344,7 @@ func TestProxyIngressMultipleRules(t *testing.T) {
 	})
 	require.NoError(err)
 	require.True(success)
+	_, _ = helper.containerExec(ctx, node2, []string{"killall", "python3"})
 	wg.Wait()
 }
 
@@ -418,7 +423,7 @@ func TestProxyIngressAndEgress(t *testing.T) {
 	ctxTimeout, curlCancel = context.WithTimeout(ctx, 10*time.Second)
 	defer curlCancel()
 	success, err = util.CheckPeriodically(ctxTimeout, time.Second, func() (bool, error) {
-		output, err := helper.containerExec(ctx, node2, []string{"curl", "-s", "http://localhost"})
+		output, err := helper.containerExec(ctx, node2, []string{"curl", "-s", "http://127.0.0.1"})
 		if err != nil {
 			helper.Logf("Retrying curl for up to 10 seconds while waiting for peering to finish: %v -- %s", err, output)
 			return false, nil
@@ -428,5 +433,7 @@ func TestProxyIngressAndEgress(t *testing.T) {
 	})
 	require.NoError(err)
 	require.True(success)
+	_, _ = helper.containerExec(ctx, node1, []string{"killall", "python3"})
+	_, _ = helper.containerExec(ctx, node2, []string{"killall", "python3"})
 	wg.Wait()
 }

--- a/integration-tests/proxy_test.go
+++ b/integration-tests/proxy_test.go
@@ -34,8 +34,6 @@ func TestProxyEgress(t *testing.T) {
 
 	// start nexodus on the nodes
 	helper.runNexd(ctx, node1, "--username", username, "--password", password, "relay", "--enable-discovery")
-
-	// validate nexd has started on the discovery node
 	err := helper.nexdStatus(ctx, node1)
 	require.NoError(err)
 
@@ -43,11 +41,11 @@ func TestProxyEgress(t *testing.T) {
 	require.NoError(err)
 
 	helper.runNexd(ctx, node2, "--username", username, "--password", password, "proxy", "--egress", fmt.Sprintf("tcp:80:%s", net.JoinHostPort(node1IP, "8080")))
+	err = helper.nexdStatus(ctx, node2)
+	require.NoError(err)
 
-	// TODO - This makes an assumption about ipam behavior that could change. We can't read the IP address
-	// from "wg0" for the proxy case as there's no wg0 interface. We need a new nexctl command to read the
-	// IP address from the running nexd.
-	node2IP := "100.100.0.2"
+	node2IP, err := getTunnelIP(ctx, helper, inetV4, node2)
+	require.NoError(err)
 
 	// ping node2 from node1 to verify basic connectivity over wireguard
 	// before moving on to exercising the proxy functionality.
@@ -101,21 +99,19 @@ func TestProxyEgressUDP(t *testing.T) {
 	helper.Logf("Starting nexd on node1")
 	// start nexodus on the nodes
 	helper.runNexd(ctx, node1, "--username", username, "--password", password, "relay", "--enable-discovery")
-
-	// validate nexd has started on the discovery node
 	err := helper.nexdStatus(ctx, node1)
 	require.NoError(err)
 
-	node1IP, err := getContainerIfaceIP(ctx, inetV4, "wg0", node1)
+	node1IP, err := getTunnelIP(ctx, helper, inetV4, node1)
 	require.NoError(err)
 
 	helper.Logf("Starting nexd on node2")
 	helper.runNexd(ctx, node2, "--username", username, "--password", password, "proxy", "--egress", fmt.Sprintf("udp:4242:%s", net.JoinHostPort(node1IP, "4242")))
+	err = helper.nexdStatus(ctx, node2)
+	require.NoError(err)
 
-	// TODO - This makes an assumption about ipam behavior that could change. We can't read the IP address
-	// from "wg0" for the proxy case as there's no wg0 interface. We need a new nexctl command to read the
-	// IP address from the running nexd.
-	node2IP := "100.100.0.2"
+	node2IP, err := getTunnelIP(ctx, helper, inetV4, node2)
+	require.NoError(err)
 
 	// ping node2 from node1 to verify basic connectivity over wireguard
 	// before moving on to exercising the proxy functionality.
@@ -166,22 +162,20 @@ func TestProxyEgressMultipleRules(t *testing.T) {
 
 	// start nexodus on the nodes
 	helper.runNexd(ctx, node1, "--username", username, "--password", password, "relay", "--enable-discovery")
-
-	// validate nexd has started on the discovery node
 	err := helper.nexdStatus(ctx, node1)
 	require.NoError(err)
 
-	node1IP, err := getContainerIfaceIP(ctx, inetV4, "wg0", node1)
+	node1IP, err := getTunnelIP(ctx, helper, inetV4, node1)
 	require.NoError(err)
 
 	helper.runNexd(ctx, node2, "--username", username, "--password", password, "proxy",
 		"--egress", fmt.Sprintf("tcp:80:%s", net.JoinHostPort(node1IP, "8080")),
 		"--egress", fmt.Sprintf("tcp:81:%s", net.JoinHostPort(node1IP, "8080")))
+	err = helper.nexdStatus(ctx, node2)
+	require.NoError(err)
 
-	// TODO - This makes an assumption about ipam behavior that could change. We can't read the IP address
-	// from "wg0" for the proxy case as there's no wg0 interface. We need a new nexctl command to read the
-	// IP address from the running nexd.
-	node2IP := "100.100.0.2"
+	node2IP, err := getTunnelIP(ctx, helper, inetV4, node2)
+	require.NoError(err)
 
 	// ping node2 from node1 to verify basic connectivity over wireguard
 	// before moving on to exercising the proxy functionality.
@@ -240,17 +234,15 @@ func TestProxyIngress(t *testing.T) {
 
 	// start nexodus on the nodes
 	helper.runNexd(ctx, node1, "--username", username, "--password", password, "relay", "--enable-discovery")
-
-	// validate nexd has started on the discovery node
 	err := helper.nexdStatus(ctx, node1)
 	require.NoError(err)
 
 	helper.runNexd(ctx, node2, "--username", username, "--password", password, "proxy", "--ingress", fmt.Sprintf("tcp:8080:%s", net.JoinHostPort("127.0.0.1", "8080")))
+	err = helper.nexdStatus(ctx, node2)
+	require.NoError(err)
 
-	// TODO - This makes an assumption about ipam behavior that could change. We can't read the IP address
-	// from "wg0" for the proxy case as there's no wg0 interface. We need a new nexctl command to read the
-	// IP address from the running nexd.
-	node2IP := "100.100.0.2"
+	node2IP, err := getTunnelIP(ctx, helper, inetV4, node2)
+	require.NoError(err)
 
 	// ping node2 from node1 to verify basic connectivity over wireguard
 	// before moving on to exercising the proxy functionality.
@@ -303,19 +295,17 @@ func TestProxyIngressMultipleRules(t *testing.T) {
 
 	// start nexodus on the nodes
 	helper.runNexd(ctx, node1, "--username", username, "--password", password, "relay", "--enable-discovery")
-
-	// validate nexd has started on the discovery node
 	err := helper.nexdStatus(ctx, node1)
 	require.NoError(err)
 
 	helper.runNexd(ctx, node2, "--username", username, "--password", password, "proxy",
 		"--ingress", fmt.Sprintf("tcp:8080:%s", net.JoinHostPort("127.0.0.1", "8080")),
 		"--ingress", fmt.Sprintf("tcp:8081:%s", net.JoinHostPort("127.0.0.1", "8080")))
+	err = helper.nexdStatus(ctx, node2)
+	require.NoError(err)
 
-	// TODO - This makes an assumption about ipam behavior that could change. We can't read the IP address
-	// from "wg0" for the proxy case as there's no wg0 interface. We need a new nexctl command to read the
-	// IP address from the running nexd.
-	node2IP := "100.100.0.2"
+	node2IP, err := getTunnelIP(ctx, helper, inetV4, node2)
+	require.NoError(err)
 
 	// ping node2 from node1 to verify basic connectivity over wireguard
 	// before moving on to exercising the proxy functionality.
@@ -378,17 +368,17 @@ func TestProxyIngressAndEgress(t *testing.T) {
 	err := helper.nexdStatus(ctx, node1)
 	require.NoError(err)
 
-	node1IP, err := getContainerIfaceIP(ctx, inetV4, "wg0", node1)
+	node1IP, err := getTunnelIP(ctx, helper, inetV4, node1)
 	require.NoError(err)
 
 	helper.runNexd(ctx, node2, "--username", username, "--password", password, "proxy",
 		"--ingress", fmt.Sprintf("tcp:8080:%s", net.JoinHostPort("127.0.0.1", "8080")),
 		"--egress", fmt.Sprintf("tcp:80:%s", net.JoinHostPort(node1IP, "8080")))
+	err = helper.nexdStatus(ctx, node2)
+	require.NoError(err)
 
-	// TODO - This makes an assumption about ipam behavior that could change. We can't read the IP address
-	// from "wg0" for the proxy case as there's no wg0 interface. We need a new nexctl command to read the
-	// IP address from the running nexd.
-	node2IP := "100.100.0.2"
+	node2IP, err := getTunnelIP(ctx, helper, inetV4, node2)
+	require.NoError(err)
 
 	// ping node2 from node1 to verify basic connectivity over wireguard
 	// before moving on to exercising the proxy functionality.

--- a/internal/nexodus/ctlserver.go
+++ b/internal/nexodus/ctlserver.go
@@ -32,3 +32,13 @@ func (ac *NexdCtl) Version(_ string, result *string) error {
 	*result = ac.ax.version
 	return nil
 }
+
+func (ac *NexdCtl) GetTunnelIPv4(_ string, result *string) error {
+	*result = ac.ax.TunnelIP
+	return nil
+}
+
+func (ac *NexdCtl) GetTunnelIPv6(_ string, result *string) error {
+	*result = ac.ax.TunnelIpV6
+	return nil
+}

--- a/internal/nexodus/ctlserver_unix.go
+++ b/internal/nexodus/ctlserver_unix.go
@@ -4,13 +4,15 @@ package nexodus
 
 import (
 	"context"
-	"github.com/nexodus-io/nexodus/internal/api"
 	"net"
 	"net/rpc"
 	"net/rpc/jsonrpc"
 	"os"
+	"path/filepath"
 	"sync"
 	"time"
+
+	"github.com/nexodus-io/nexodus/internal/api"
 
 	"github.com/nexodus-io/nexodus/internal/util"
 )
@@ -40,8 +42,12 @@ func (ax *Nexodus) CtlServerUnixStart(ctx context.Context, wg *sync.WaitGroup) {
 }
 
 func (ax *Nexodus) CtlServerUnixRun(ctx context.Context, ctlWg *sync.WaitGroup) error {
-	os.Remove(api.UnixSocketPath)
-	l, err := net.ListenUnix("unix", &net.UnixAddr{Name: api.UnixSocketPath, Net: "unix"})
+	socketPath := api.UnixSocketPath
+	if ax.userspaceMode {
+		socketPath = filepath.Base(socketPath)
+	}
+	os.Remove(socketPath)
+	l, err := net.ListenUnix("unix", &net.UnixAddr{Name: socketPath, Net: "unix"})
 	if err != nil {
 		ax.logger.Error("Error creating unix socket: ", err)
 		return err

--- a/internal/nexodus/nexodus.go
+++ b/internal/nexodus/nexodus.go
@@ -228,16 +228,8 @@ func (ax *Nexodus) SetStatus(status int, msg string) {
 
 func (ax *Nexodus) Start(ctx context.Context, wg *sync.WaitGroup) error {
 	var err error
-
-	// TODO
-	//
-	// We must deal with a lack of permissions and the possibility for there
-	// to be more than one instance of nexd running at the same time in this mode
-	// before we can enable it in this mode.
-	if !ax.userspaceMode {
-		if err := ax.CtlServerStart(ctx, wg); err != nil {
-			return fmt.Errorf("CtlServerStart(): %w", err)
-		}
+	if err := ax.CtlServerStart(ctx, wg); err != nil {
+		return fmt.Errorf("CtlServerStart(): %w", err)
 	}
 	var options []client.Option
 	if ax.stateDir != "" {


### PR DESCRIPTION
commit 0b63c243eb162eaadd1e86dbd2dcb6f2db47b0b5
Author: Russell Bryant <rbryant@redhat.com>
Date:   Fri Apr 14 20:25:49 2023 -0400

    nexctl: Add ability to get tunnel IPs from nexd
    
    Add a new command to `nexctl` to get the IPv4 or IPv6 tunnel addresses:
    
    * `nexctl nexd get tunnelip`
    * `nexctl nexd get tunnelip --ipv6`
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>

commit 1a5bd72d2d8d554b24b7a213a11adf54d3f2938d
Author: Russell Bryant <rbryant@redhat.com>
Date:   Fri Apr 14 21:07:09 2023 -0400

    nexd: Open a unix socket in proxy mode
    
    Turn on the unix socket interface for proxy mode. Instead of using
    `/run/nexd.sock`, it defaults to `nexd.sock`. This is a safer default
    as a place we can write to. The primary use case for this mode is a
    container, so it seems fine to me.
    
    Update `nexctl` to account for this possible path, as well.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>

commit 086db4affe80e49cd3bd7035d7aeaac56f14cbe4
Author: Russell Bryant <rbryant@redhat.com>
Date:   Fri Apr 14 20:58:27 2023 -0400

    e2e: Use nexctl nexd get tunnelip
    
    Update the proxy tests to make use of `nexctl nexd get tunnelip`. This
    resolves a TODO items where we didn't have a way to get the tunnel IP
    for `nexd` running in proxy mode since we didn't have a wireguard
    interface to look at.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>

commit a2ffb26687ae46c2ff42e6d6bd003b2fbbb323ec
Author: Russell Bryant <rbryant@redhat.com>
Date:   Sat Apr 15 13:09:15 2023 -0400

    e2e: Reduce blocking in proxy tests
    
    Explicitly kill the HTTP server processes before waiting for the
    associated goroutines to exit.
    
    Also use an IP instead of `localhost` to ensure the test isn't blocked on
    name resolution for any reason.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>