### PR TITLE
nexd: Set default service URL

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,4 @@
 ui/node_modules
-Makefile
 !**/rootCA.pem
 Containerfile.*
 dist

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -234,7 +234,7 @@ jobs:
         id: build
         shell: bash
         run: |
-          CGO_ENABLED=0 make dist/${{ matrix.binary }}-${{ matrix.os }}-${{ matrix.arch }}${{ matrix.suffix }}
+          CGO_ENABLED=0 NEXODUS_BUILD_PROFILE=prod make dist/${{ matrix.binary }}-${{ matrix.os }}-${{ matrix.arch }}${{ matrix.suffix }}
           mkdir ${{ matrix.os }}-${{ matrix.arch }}
           cp dist/${{ matrix.binary }}-${{ matrix.os }}-${{ matrix.arch }}${{ matrix.suffix }} ${{ matrix.os }}-${{ matrix.arch }}/${{ matrix.binary }}${{ matrix.suffix }}
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -71,6 +71,8 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           target: ${{ matrix.target }}
+          build-args: |
+            BUILD_PROFILE=prod
 
   update-deployment:
     name: Update Deployment

--- a/Containerfile.nexd
+++ b/Containerfile.nexd
@@ -1,20 +1,20 @@
 FROM docker.io/library/golang:1.20-alpine as build
 
+ARG BUILD_PROFILE=dev
 WORKDIR /src
-COPY go.mod .
-COPY go.sum .
-RUN go mod download
-
-RUN cd / && CGO_ENABLED=0 go install filippo.io/mkcert@v1.4.4
-
 COPY . .
-RUN CGO_ENABLED=0 go build \
-    -ldflags="-extldflags=-static" \
-    -o nexd ./cmd/nexd
+RUN go mod download
+RUN apk add make git
 
-RUN CGO_ENABLED=0 go build \
-    -ldflags="-extldflags=-static" \
-    -o nexctl ./cmd/nexctl
+RUN CGO_ENABLED=0 NOISY_BUILD=y \
+    NEXODUS_LDFLAGS=-extldflags=-static \
+    NEXODUS_BUILD_PROFILE=$BUILD_PROFILE \
+    make dist/nexd
+
+RUN CGO_ENABLED=0 NOISY_BUILD=y \
+    NEXODUS_LDFLAGS=-extldflags=-static \
+    NEXODUS_BUILD_PROFILE=$BUILD_PROFILE \
+    make dist/nexctl
 
 RUN CGO_ENABLED=0 go build \
     -ldflags="-extldflags=-static" \
@@ -23,6 +23,8 @@ RUN CGO_ENABLED=0 go build \
 RUN CGO_ENABLED=0 go build \
     -ldflags="-extldflags=-static" \
     -o udpong ./hack/udpong
+
+RUN cd / && CGO_ENABLED=0 go install filippo.io/mkcert@v1.4.4
 
 FROM fedora:latest as fedora
 
@@ -42,8 +44,8 @@ RUN dnf update -qy && \
     rm -rf /var/cache/yum
 
 COPY --chmod=755 ./hack/update-ca.sh /update-ca.sh
-COPY --chmod=755 --from=build /src/nexd /bin/nexd
-COPY --chmod=755 --from=build /src/nexctl /bin/nexctl
+COPY --chmod=755 --from=build /src/dist/nexd /bin/nexd
+COPY --chmod=755 --from=build /src/dist/nexctl /bin/nexctl
 COPY --chmod=755 --from=build /go/bin/mkcert /bin/mkcert
 COPY --chmod=755 --from=build /src/udping /bin/udping
 COPY --chmod=755 --from=build /src/udpong /bin/udpong

--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,17 @@ endif
 
 NEXODUS_VERSION?=$(shell date +%Y.%m.%d)
 NEXODUS_RELEASE?=$(shell git describe --always --exclude qa --exclude prod)
-NEXODUS_LDFLAGS?=-X main.Version=$(NEXODUS_VERSION)-$(NEXODUS_RELEASE)
 NEXODUS_GCFLAGS?=
+
+NEXODUS_BUILD_PROFILE?=dev
+NEXODUS_LDFLAGS:=$(NEXODUS_LDFLAGS) -X main.Version=$(NEXODUS_VERSION)-$(NEXODUS_RELEASE)
+ifeq ($(NEXODUS_BUILD_PROFILE),dev)
+	NEXODUS_LDFLAGS+=-X main.DefaultServiceURL=https://try.nexodus.127.0.0.1.nip.io
+else ifeq ($(NEXODUS_BUILD_PROFILE),qa)
+	NEXODUS_LDFLAGS+=-X main.DefaultServiceURL=https://qa.nexodus.io
+else ifeq ($(NEXODUS_BUILD_PROFILE),prod)
+	NEXODUS_LDFLAGS+=-X main.DefaultServiceURL=https://try.nexodus.io
+endif
 
 SWAGGER_YAML:=internal/docs/swagger.yaml
 

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ dist/nexd: $(NEXD_DEPS) | dist
 
 dist/nexctl: $(NEXCTL_DEPS) | dist
 	$(ECHO_PREFIX) printf "  %-12s $@\n" "[GO BUILD]"
-	$(CMD_PREFIX) CGO_ENABLED=0 go build -gcflags="$(NEXODUS_GCFLAGS)" -ldflags="$(NEXODUS_LDFLAGS)" -o $@ ./cmd/nexctl
+	$(CMD_PREFIX) CGO_ENABLED=0 go build -gcflags="$(NEXODUS_GCFLAGS)" -ldflags="$(subst https://,https://api.,$(NEXODUS_LDFLAGS))" -o $@ ./cmd/nexctl
 
 dist/nexd-%: $(NEXD_DEPS) | dist
 	$(ECHO_PREFIX) printf "  %-12s $@\n" "[GO BUILD]"
@@ -82,7 +82,7 @@ dist/nexd-%: $(NEXD_DEPS) | dist
 dist/nexctl-%: $(NEXCTL_DEPS) | dist
 	$(ECHO_PREFIX) printf "  %-12s $@\n" "[GO BUILD]"
 	$(CMD_PREFIX) CGO_ENABLED=0 GOOS=$(word 2,$(subst -, ,$(basename $@))) GOARCH=$(word 3,$(subst -, ,$(basename $@))) \
-		go build -gcflags="$(NEXODUS_GCFLAGS)" -ldflags="$(NEXODUS_LDFLAGS)" -o $@ ./cmd/nexctl
+		go build -gcflags="$(NEXODUS_GCFLAGS)" -ldflags="$(subst https://,https://api.,$(NEXODUS_LDFLAGS))" -o $@ ./cmd/nexctl
 
 .PHONY: clean
 clean: ## clean built binaries

--- a/cmd/nexctl/main.go
+++ b/cmd/nexctl/main.go
@@ -24,6 +24,9 @@ const (
 // This variable is set using ldflags at build time. See Makefile for details.
 var Version = "dev"
 
+// Optionally set at build time using ldflags
+var DefaultServiceURL = "https://try.nexodus.io"
+
 var additionalPlatformCommands []*cli.Command = nil
 
 func main() {
@@ -40,7 +43,7 @@ func main() {
 			},
 			&cli.StringFlag{
 				Name:  "host",
-				Value: "https://api.try.nexodus.127.0.0.1.nip.io",
+				Value: DefaultServiceURL,
 				Usage: "Api server URL",
 			},
 			&cli.StringFlag{

--- a/cmd/nexd/main.go
+++ b/cmd/nexd/main.go
@@ -35,11 +35,14 @@ const (
 // This variable is set using ldflags at build time. See Makefile for details.
 var Version = "dev"
 
+// Optionally set at build time using ldflags
+var DefaultServiceURL = "https://try.nexodus.io"
+
 func nexdRun(cCtx *cli.Context, logger *zap.Logger, mode nexdMode) error {
-	controller := cCtx.Args().First()
-	if controller == "" {
-		logger.Info("<controller-url> required")
-		return nil
+	serviceURL := cCtx.Args().First()
+	if serviceURL == "" && DefaultServiceURL != "" {
+		logger.Info("No service URL provided, using default service URL", zap.String("url", DefaultServiceURL))
+		serviceURL = DefaultServiceURL
 	}
 
 	_, err := nexodus.CtlStatus(cCtx)
@@ -70,7 +73,7 @@ func nexdRun(cCtx *cli.Context, logger *zap.Logger, mode nexdMode) error {
 
 	nex, err := nexodus.NewNexodus(
 		logger.Sugar(),
-		controller,
+		serviceURL,
 		cCtx.String("username"),
 		cCtx.String("password"),
 		cCtx.Int("listen-port"),
@@ -138,7 +141,7 @@ func main() {
 	app := &cli.App{
 		Name:      "nexd",
 		Usage:     "Node agent to configure encrypted mesh networking with nexodus.",
-		ArgsUsage: "controller-url",
+		ArgsUsage: "service-url",
 		Commands: []*cli.Command{
 			{
 				Name:  "version",

--- a/contrib/rpm/nexodus.sysconfig
+++ b/contrib/rpm/nexodus.sysconfig
@@ -8,4 +8,5 @@
 #
 # If additional arguments are needed, add them prior to the URL.
 #
-NEXD_ARGS="https://try.nexodus.127.0.0.1.nip.io"
+#NEXD_ARGS="https://try.nexodus.127.0.0.1.nip.io"
+NEXD_ARGS="https://try.nexodus.io"

--- a/integration-tests/helper_test.go
+++ b/integration-tests/helper_test.go
@@ -336,6 +336,7 @@ func (helper *Helper) nexdStatus(ctx context.Context, ctr testcontainers.Contain
 	defer cancel()
 	running, _ := util.CheckPeriodically(timeoutCtx, time.Second, func() (bool, error) {
 		statOut, _ := helper.containerExec(ctx, ctr, []string{"/bin/nexctl", "nexd", "status"})
+		helper.Logf("nexd status: %s", statOut)
 		return strings.Contains(statOut, "Running"), nil
 	})
 	if running {

--- a/internal/nexodus/nexodus_linux.go
+++ b/internal/nexodus/nexodus_linux.go
@@ -20,6 +20,12 @@ func (ax *Nexodus) setupInterfaceOS() error {
 			logger.Debugf("failed to delete the ip link interface: %v\n", err)
 		}
 	}
+
+	if ax.TunnelIP == "" || ax.TunnelIpV6 == "" {
+		logger.Infof("Have not received full local node configuration from the service, skipping interface setup")
+		return nil
+	}
+
 	// create the wireguard ip link interface
 	_, err := RunCommand("ip", "link", "add", ax.tunnelIface, "type", "wireguard")
 	if err != nil {


### PR DESCRIPTION
If nexd is run without a service URL, use a default URL that is set at
build time. If no `NEXODUS_BUILD_PROFILE` is set, it will use the `dev`
profile which will use the local dev service URL. The build profile can
be set to `qa` or `prod` which will set `qa.nexodus.io` or
`try.nexodus.io` as the default URLs.

For the `nexd` container image that gets published to quay.io and the
binary builds published to s3, they are now build with the `prod`
profile in CI.

For those using the rpm, update the default in the sysconfig file
to our public service. This would be the most likely config for an
install using the package.

This change also updates `nexctl` with the same behavior.

Signed-off-by: Russell Bryant <rbryant@redhat.com>