### PR TITLE
Makefile: Ensure code gen runs before go-lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ go-lint-prereqs:
 		exit 1 ; \
 	fi
 
-dist/.go-lint-%: $(NEX_ALL_GO) | go-lint-prereqs gen-docs dist gen-openapi-client
+dist/.go-lint-%: $(NEX_ALL_GO) | go-lint-prereqs gen-docs dist gen-openapi-client $(wildcard internal/api/public/*.go)
 	$(ECHO_PREFIX) printf "  %-12s GOOS=$(word 3,$(subst -, ,$@))\n" "[GO LINT]"
 	$(CMD_PREFIX) CGO_ENABLED=0 GOOS=$(word 3,$(subst -, ,$@)) GOARCH=amd64 \
 		golangci-lint run --timeout 5m ./...
@@ -169,6 +169,8 @@ internal/api/public/client.go: internal/docs/swagger.yaml | dist
 		--ignore-file-override /src/.openapi-generator-ignore $(PIPE_DEV_NULL)
 	$(ECHO_PREFIX) printf "  %-12s ./...\n" "[GO FMT]"
 	$(CMD_PREFIX) [ -z "$(shell gofmt -l .)" ] || (echo "$(shell gofmt -l .)" && exit 1)
+
+internal/api/public/%.go: internal/api/public/client.go
 
 .PHONY: opa-fmt
 opa-fmt: ## Lint the OPA policies


### PR DESCRIPTION
I got the following error on a build:

```
$ make -j all
  [OPENAPI CLIENT GEN] internal/docs/swagger.yaml
make: *** No rule to make target `/Users/rbryant/go/src/github.com/nexodus-io/nexodus/internal/api/public/model_models_add_invitation.go', needed by `dist/.go-lint-linux'.  Stop.
make: *** Waiting for unfinished jobs....
```

It looks like go-lint tried to run at the same time as the client code gen, and it caught it at a time when one of the generated files didn't exist. The fix included here has two parts:

* Make a default target for all of these generated files which depends on the target for `client.go`.

* Set the `client.go` target as an order-only dependency of the go-lint targets. The `openapi-client-gen` order-only pre-req was not sufficient, as the dependency checked was the go source. All generated source will now be seen as depending on the generation of `client.go`.