### PR TITLE
test: Fix tcp listener port conflict

### DIFF
--- a/internal/handlers/handlers_test.go
+++ b/internal/handlers/handlers_test.go
@@ -23,8 +23,9 @@ import (
 )
 
 const (
-	TestUserID  = "f606de8d-092d-4606-b981-80ce9f5a3b2a"
-	TestUser2ID = "3381dcaf-f61e-4671-8787-3e53490894ae"
+	TestUserID     = "f606de8d-092d-4606-b981-80ce9f5a3b2a"
+	TestUser2ID    = "3381dcaf-f61e-4671-8787-3e53490894ae"
+	ipamClientAddr = "http://localhost:9090"
 )
 
 type HandlerTestSuite struct {
@@ -57,7 +58,7 @@ func (suite *HandlerTestSuite) SetupSuite() {
 		}
 	}()
 
-	ipamClient := ipam.NewIPAM(suite.logger, ipam.TestIPAMClientAddr)
+	ipamClient := ipam.NewIPAM(suite.logger, ipamClientAddr)
 
 	fflags := fflags.NewFFlags(suite.logger)
 	store := inmem.New()

--- a/internal/ipam/ipam_test.go
+++ b/internal/ipam/ipam_test.go
@@ -30,7 +30,7 @@ func (suite *IpamTestSuite) SetupSuite() {
 	suite.ipam = NewIPAM(suite.logger, TestIPAMClientAddr)
 	suite.wg = sync.WaitGroup{}
 	suite.wg.Add(1)
-	listener, err := net.Listen("tcp", "[::1]:9090")
+	listener, err := net.Listen("tcp", "[::1]:9091")
 	suite.Require().NoError(err)
 
 	go func() {

--- a/internal/ipam/test_ipam_server.go
+++ b/internal/ipam/test_ipam_server.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	TestIPAMClientAddr = "http://localhost:9090"
+	TestIPAMClientAddr = "http://localhost:9091"
 )
 
 func NewTestIPAMServer() *http.Server {


### PR DESCRIPTION
These two suites both opened an ipam listener on the same TCP port, which I saw causing failures in CI.