### PR TITLE
feat: nexd now uses the watch api to get device change events.

### DIFF
--- a/integration-tests/proxy_test.go
+++ b/integration-tests/proxy_test.go
@@ -16,7 +16,7 @@ import (
 
 // TestProxyEgress tests that nexd proxy can be used with a single egress rule
 func TestProxyEgress(t *testing.T) {
-	t.Parallel()
+	//t.Parallel()
 	helper := NewHelper(t)
 	require := helper.require
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
@@ -81,7 +81,7 @@ func TestProxyEgress(t *testing.T) {
 
 // TestProxyEgressUDP tests that nexd proxy can be used with a single UDP egress rule
 func TestProxyEgressUDP(t *testing.T) {
-	t.Parallel()
+	//t.Parallel()
 	helper := NewHelper(t)
 	require := helper.require
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
@@ -146,7 +146,7 @@ func TestProxyEgressUDP(t *testing.T) {
 
 // TestProxyEgress tests that nexd proxy can be used with multiple egress rules
 func TestProxyEgressMultipleRules(t *testing.T) {
-	t.Parallel()
+	//t.Parallel()
 	helper := NewHelper(t)
 	require := helper.require
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
@@ -219,7 +219,7 @@ func TestProxyEgressMultipleRules(t *testing.T) {
 
 // TestProxyIngress tests that nexd proxy with a single ingress rule
 func TestProxyIngress(t *testing.T) {
-	t.Parallel()
+	//t.Parallel()
 	helper := NewHelper(t)
 	require := helper.require
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
@@ -281,7 +281,7 @@ func TestProxyIngress(t *testing.T) {
 
 // TestProxyIngress tests that nexd proxy with multiple ingress rules
 func TestProxyIngressMultipleRules(t *testing.T) {
-	t.Parallel()
+	//t.Parallel()
 	helper := NewHelper(t)
 	require := helper.require
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
@@ -350,7 +350,7 @@ func TestProxyIngressMultipleRules(t *testing.T) {
 
 // TestProxyIngressAndEgress tests that a proxy can be used to both ingress and egress traffic
 func TestProxyIngressAndEgress(t *testing.T) {
-	t.Parallel()
+	//t.Parallel()
 	helper := NewHelper(t)
 	require := helper.require
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)

--- a/internal/api/public/model_models_add_invitation.go
+++ b/internal/api/public/model_models_add_invitation.go
@@ -13,5 +13,8 @@ package public
 // ModelsAddInvitation struct for ModelsAddInvitation
 type ModelsAddInvitation struct {
 	OrganizationId string `json:"organization_id,omitempty"`
-	UserId         string `json:"user_id,omitempty"`
+	// The user id to invite (one of username or user_id is required)
+	UserId string `json:"user_id,omitempty"`
+	// The username to invite (one of username or user_id is required)
+	UserName string `json:"user_name,omitempty"`
 }

--- a/internal/client/ResourceSyncer.go
+++ b/internal/client/ResourceSyncer.go
@@ -1,0 +1,1 @@
+package client


### PR DESCRIPTION
feat: add a Informer() api method that provides a locally cached device list that is synchronized with the apiserver using watch events.

* nexd now reconciles against informer and trigger new reconcile loops when the informer changes.
