### PR TITLE
Add scale testing for use against the QA deployment

### DIFF
--- a/.github/workflows/qa-scale.yml
+++ b/.github/workflows/qa-scale.yml
@@ -1,0 +1,163 @@
+# This workflow is for scale testing against the Nexodus qa deployment
+name: qa-scale
+
+concurrency:
+  group: qa-scale
+
+on:
+  workflow_dispatch:
+    inputs:
+      deployment_size:
+        description: 'deployment size: small | medium | large | xlarge'
+        required: true
+        default: 'small'
+        type: string
+
+      pr_or_branch:
+        description: 'pull request number or branch name'
+        required: true
+        default: 'main'
+
+jobs:
+  deploy-qa:
+    name: deploy-qa-ec2
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+    env:
+      AWS_REGION: "us-east-1"
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      ANSIBLE_VAULT_PASSWORD_FILE: "vault-secret.txt"
+      ANSIBLE_PRIVATE_KEY_FILE: "nexodus.pem"
+      ANSIBLE_HOST_KEY_CHECKING: "false"
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Determine if pr_or_branch is a PR number
+        id: check_pr
+        run: |
+          if [[ "${{ github.event.inputs.pr_or_branch }}" =~ ^[0-9]+$ ]]; then
+            echo "is_pr=true" >> $GITHUB_OUTPUT
+          else
+            echo "is_pr=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Fetch and checkout PR
+        if: steps.check_pr.outputs.is_pr == 'true'
+        run: |
+          git fetch origin pull/${{ github.event.inputs.pr_or_branch }}/head:pr-${{ github.event.inputs.pr_or_branch }}
+          git checkout pr-${{ github.event.inputs.pr_or_branch }}
+
+      - name: Checkout branch
+        if: steps.check_pr.outputs.is_pr == 'false'
+        run: git checkout ${{ github.event.inputs.pr_or_branch }}
+
+      - name: Setup Go
+        uses: ./.github/actions/setup-go-env
+
+      - name: Build
+        run: |
+          make dist/nexd-linux-amd64
+
+      - name:  Copy Agent Binary to S3
+        run: |
+          aws s3 cp ./dist/nexd-linux-amd64 s3://nexodus-io/ec2-e2e/qa/
+
+      - name:  Build Keycloak Tool
+        run: |
+          go build -o ./ ./hack/e2e-scripts/kctool/
+
+      - name: Create a Keycloak User
+        id: kc-user
+        run: |
+          output=$(./kctool --create-user \
+            -ku "${{ secrets.KC_QA_USERNAME }}" \
+            -kp "${{ secrets.KC_QA_PASSWORD }}" \
+            -u qa \
+            -p "${{ secrets.QA_USER_PASSWORD }}" \
+            https://auth.qa.nexodus.io)
+          echo "USER=$output" >> $GITHUB_OUTPUT
+
+      - name: User results from Keycloak
+        run: echo "User is ${{ steps.kc-user.outputs.USER }}"
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Install Ansible and Dependencies
+        run: pip3.10 install boto boto3 ansible-vault ansible-core==2.13.3
+
+      - name: Install amazon.aws Ansible library
+        run: ansible-galaxy collection install amazon.aws
+
+      - name: Set Deployment Size to Small
+        if: github.event.inputs.deployment_size == 'small'
+        run: |
+          echo "${{ secrets.ANSIBLE_VARS_SMALL_QA }}" > ./ops/ansible/aws/vars.yml
+
+      - name: Set Deployment Size to Medium
+        if: github.event.inputs.deployment_size == 'medium'
+        run: |
+          echo "${{ secrets.ANSIBLE_VARS_MEDIUM_QA }}" > ./ops/ansible/aws/vars.yml
+
+      - name: Set Deployment Size to Large
+        if: github.event.inputs.deployment_size == 'large'
+        run: |
+          echo "${{ secrets.ANSIBLE_VARS_LARGE_QA }}" > ./ops/ansible/aws/vars.yml
+
+      - name: Set Deployment Size to XLarge
+        if: github.event.inputs.deployment_size == 'xlarge'
+        run: |
+          echo "${{ secrets.ANSIBLE_VARS_XLARGE_QA }}" > ./ops/ansible/aws/vars.yml
+
+      - name: Create Ansible Secrets
+        run: |
+          echo "${{ secrets.ANSIBLE_SSH_KEY }}" > nexodus.pem
+          chmod 0400 nexodus.pem
+          echo "${{ secrets.ANSIBLE_VAULT_PASSWORD }}" > vault-secret.txt
+          chmod 0400 vault-secret.txt
+
+      - name: Deploy EC2 Agent Nodes
+        run: |
+          ansible-playbook -vv ./ops/ansible/aws/deploy-ec2-qa.yml \
+          -i ./ops/ansible/aws/inventory.txt \
+          --private-key nexodus.pem \
+          --vault-password-file vault-secret.txt \
+          --extra-vars "nexodus_auth_uid=${{ steps.kc-user.outputs.USER }}" \
+          --extra-vars "nexodus_auth_password=${{ secrets.QA_USER_PASSWORD }}"
+
+      - name: Mesh Connectivity Results
+        run: |
+          set -e
+          cat ./ops/ansible/aws/connectivity-results.txt
+          if grep -q '0 unreachable' ./ops/ansible/aws/connectivity-results.txt; then
+            echo "Connectivity results contain '0 unreachable' nodes"
+          else
+            echo "Connectivity results do not contain '0 unreachable' nodes, check the connectivity results for details, failing this job"
+            exit 1
+          fi
+
+      - name: Gather api-server Server Logs
+        if: always()
+        run: |
+          ansible-playbook -vv \
+          ./hack/e2e-scripts/aws-e2e-pr-gather.yml \
+          --private-key nexodus.pem \
+          -e "target_host=${{ vars.EC2_API_SERVER_ADDR }} ansible_user=ubuntu"
+
+      - name: Terminate EC2 Instances
+        if: always()
+        run: |
+          ansible-playbook -vv ./ops/ansible/aws/terminate-instances.yml
+
+      - name: Upload nexd and api-server Logs to Artifacts
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: dev-ec2-artifacts
+          path: ./ops/ansible/aws/nexd-logs/
+          retention-days: 10

--- a/docs/development/scale-testing.md
+++ b/docs/development/scale-testing.md
@@ -1,0 +1,40 @@
+# Nexodus Scale Testing
+
+## Overview
+
+Scale testing involves running Ansible playbooks to deploy nodes that then attach to a Nexodus api-server deployment. The in-tree playbooks for running the tests can be found in [ops/ansible/](../../ops/ansible/).
+
+There are two workflows that can be used to measure scale and performance. The agent side is the same for both tests.
+
+- Agent nodes are deployed to EC2 and attach to the specified controller.
+- Ansible variables that set the node counts, api-server URLs, and EC2 details such as VPCs and security groups are stored in the repo's Github Secrets.
+- Agents are deployed across three different VPCs with no inbound rules except for the relay node, which requires port exposure for devices behind NATs incapable of traversal.
+- Playbooks are available for EC2, GCP, and Azure. Although these are occasionally validated, there is no difference with regard to NAT traversal, which is the primary validation.
+- Once agents have been attached, connectivity is verified and reported back to the Github runner for output.
+- Logs from all nodes are collected and uploaded to artifacts for postmortem analysis in the case of failures.
+
+### Agent Side Deployment
+
+Both scale workflow scenarios deploy agents in the same manner. There are three different profiles in which an agent can be launched. All three are tested simultaneously to validate interconnectivity between profiles:
+
+1. Numerous Nexodus agents running with default configurations. There are no firewall rules open to the nodes.
+2. One Nexodus relay node. The relay node handles connections for agent nodes that cannot perform NAT hole punching to open a NAT binding for other peers to connect to. This node has its listening port exposed to the internet to accept connections.
+3. Numerous relay-only nodes. These are started with the flag `--relay-only`, which sets the agent's mode to symmetric NAT, meaning it only peers to the relay node and not to any other agents. This is a traditional hub-and-spoke model that is being validated to ensure that connectivity can be established to all nodes by traversing the relay node, which has full mesh peering.
+
+### Workflow `dev-ec2`
+
+- This workflow is ideal for testing any PR for functionality not covered in e2e. Mocking up complete networks in runners with containers can quickly turn into spaghetti. This tests real-world NAT traversal with virtually no EC2 cost incurred with micro nodes. That said, the controller is currently running in a Kind deployment on a relatively small EC2 node (t2.xlarge), so it's likely to peak much sooner than the QA/prod environments. It is still very valuable to run potentially disruptive PRs through this test before merging.
+
+- [dev-ec2](https://github.com/nexodus-io/nexodus/actions/workflows/dev-ec2.yml) deploys both the api-server stack and the agent. This workflow clones either main or the specified PR number to a Kind stack running in an EC2 instance. Since this is self-signed, the playbooks have to take into account adding the certs and building and deploying the api-server. At the start of each deployment of this workflow, the images are built and loaded into Kind. Next, the kube deployments are restarted, and a database wipe is performed. From there, agent nodes are deployed with the rootCA of the controller and attached and validated. api-server logs are also gathered as part of this workflow.
+
+### Workflow `qa-scale`
+
+This workflow is for validating the production environment. The api-server/controller is already running an instance of what is in main. The workflow creates new user IDs for the workflow being run since the database is not being wiped before or after the workflow like it is in dev-ec2.
+
+- [qa-scale](https://github.com/nexodus-io/nexodus/actions/workflows/dev-ec2.yml) deploys the agents against the QA deployment. This deployment is a mirror of the production deployment in a different namespace. Code is validated in QA and then promoted to production. There is no option to deploy a particular PR to QA, it is running the latest main branch. Keep this in mind if you are picking a PR to test that interoperates with the current QA deployment.
+
+## Running the Tests
+
+To run the tests, simply go to the actions and choose the deployment size: small, medium, large, or xlarge. The node counts of these will change as we optimize the deployment. Next, choose the pull request number or branch name. This value would simply be a number or something like main. From there, you can watch the logs and troubleshoot any errors as part of debugging a PR, download logs from the artifacts zip at the end of the workflow, or see the successful or unsuccessful connectivity results in the Mesh Connectivity Results step of the workflow.
+
+Once the workflow completes, all the EC2 agent instances that were started are torn down, based on the EC2 tag set in the Ansible variables.

--- a/hack/e2e-scripts/kctool/kctool.go
+++ b/hack/e2e-scripts/kctool/kctool.go
@@ -1,0 +1,185 @@
+package main
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	"github.com/Nerzal/gocloak/v13"
+	"github.com/google/uuid"
+	"github.com/urfave/cli/v2"
+)
+
+type AppConfig struct {
+	CreateUser bool
+	DeleteUser bool
+	KcHost     string
+	KcUsername string
+	KcPassword string
+	User       string
+	Password   string
+}
+
+const (
+	userRealm   = "nexodus"
+	masterRealm = "master"
+)
+
+func main() {
+	app := &cli.App{
+		Flags: []cli.Flag{
+			&cli.BoolFlag{
+				Name:    "create-user",
+				Aliases: []string{"c"},
+				Usage:   "create a new user",
+			},
+			&cli.BoolFlag{
+				Name:    "delete-user",
+				Aliases: []string{"d"},
+				Usage:   "delete an existing user",
+			},
+			&cli.StringFlag{
+				Name:     "kc-username",
+				Aliases:  []string{"ku"},
+				Usage:    "Keycloak admin username",
+				Required: true,
+			},
+			&cli.StringFlag{
+				Name:     "kc-password",
+				Aliases:  []string{"kp"},
+				Usage:    "Keycloak admin password",
+				Required: true,
+			},
+			&cli.StringFlag{
+				Name:     "user",
+				Aliases:  []string{"u"},
+				Usage:    "Username of User ID for the user",
+				Required: true,
+			},
+			&cli.StringFlag{
+				Name:    "password",
+				Aliases: []string{"p"},
+				Usage:   "Password for the new user",
+			},
+		},
+		Action: func(c *cli.Context) error {
+			// Check if there is an argument for the Keycloak host.
+			if c.Args().Len() != 1 {
+				return cli.Exit("Please provide the Keycloak host URL as the last argument.", 1)
+			}
+
+			kcHost := c.Args().First()
+
+			config := &AppConfig{
+				CreateUser: c.Bool("create-user"),
+				DeleteUser: c.Bool("delete-user"),
+				KcHost:     kcHost,
+				KcUsername: c.String("kc-username"),
+				KcPassword: c.String("kc-password"),
+				User:       c.String("user"),
+				Password:   c.String("password"),
+			}
+
+			if config.CreateUser && config.DeleteUser {
+				return cli.Exit("please provide either --create-user or --delete-user, not both.", 1)
+			}
+
+			if config.CreateUser {
+				if config.Password == "" {
+					return cli.Exit("the flag --password is required for creating a user.", 1)
+				}
+				id, _ := uuid.NewUUID()
+				config.User = config.User + id.String()
+				config.createUser()
+			} else if config.DeleteUser {
+				config.deleteUser()
+			} else {
+				_ = cli.ShowAppHelp(c)
+			}
+
+			return nil
+		},
+	}
+
+	err := app.Run(os.Args)
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+func (config *AppConfig) createUser() {
+	ctx, done := context.WithTimeout(context.Background(), time.Second*10)
+	defer done()
+
+	userID, err := config.createNewUser(ctx)
+
+	if err != nil {
+		log.Fatalf("Failed to create a new user: %v", err)
+	} else {
+		fmt.Println(userID)
+	}
+}
+
+func (config *AppConfig) createNewUser(ctx context.Context) (string, error) {
+	keycloak := gocloak.NewClient(config.KcHost)
+
+	//nolint:gosec // This line is ignored because it's a test function
+	keycloak.RestyClient().SetTLSClientConfig(&tls.Config{InsecureSkipVerify: true})
+
+	token, err := keycloak.LoginAdmin(ctx, config.KcUsername, config.KcPassword, masterRealm)
+	if err != nil {
+		return "", fmt.Errorf("admin login to keycloak failed: %w", err)
+	}
+
+	userID, err := keycloak.CreateUser(ctx, token.AccessToken, userRealm, gocloak.User{
+		FirstName: gocloak.StringP("Test"),
+		LastName:  gocloak.StringP(config.User),
+		Email:     gocloak.StringP(config.User + "@redhat.com"),
+		Enabled:   gocloak.BoolP(true),
+		Username:  gocloak.StringP(config.User),
+	})
+	if err != nil {
+		return "", fmt.Errorf("user creation failed: %w", err)
+	}
+
+	err = keycloak.SetPassword(ctx, token.AccessToken, userID, userRealm, config.Password, false)
+	if err != nil {
+		return "", fmt.Errorf("user password setting failed: %w", err)
+	}
+
+	return config.User, nil
+}
+
+func (config *AppConfig) deleteUser() {
+	ctx, done := context.WithTimeout(context.Background(), time.Second*10)
+	defer done()
+
+	err := config.deleteKeycloakUser(ctx)
+	if err != nil {
+		log.Fatalf("Failed to delete user: %v", err)
+	} else {
+		fmt.Printf("Successfully deleted user ID %s\n", config.User)
+	}
+}
+
+func (config *AppConfig) deleteKeycloakUser(ctx context.Context) error {
+	keycloak := gocloak.NewClient(config.KcHost)
+
+	//nolint:gosec // This line is ignored because it's a test function
+	keycloak.RestyClient().SetTLSClientConfig(&tls.Config{InsecureSkipVerify: true})
+
+	token, err := keycloak.LoginAdmin(ctx, config.KcUsername, config.KcPassword, masterRealm)
+	if err != nil {
+		return fmt.Errorf("admin login to keycloak failed: %w", err)
+	}
+
+	err = keycloak.DeleteUser(ctx, token.AccessToken, userRealm, config.User)
+	if err != nil {
+		return fmt.Errorf("failed to delete user %s on realm: %s err: %w", config.User, userRealm, err)
+	}
+
+	return nil
+}

--- a/ops/ansible/aws/deploy-ec2-qa.yml
+++ b/ops/ansible/aws/deploy-ec2-qa.yml
@@ -1,0 +1,36 @@
+# QA roles get branched from here
+
+# Deploy the VMs
+- hosts: localhost
+  vars_files:
+    - vars.yml
+  roles:
+    - role: setup-ec2
+
+# Deploy and start the agent
+- hosts: nexodusNodes
+  vars_files:
+    - vars.yml
+  roles:
+    - role: qa/qa-deploy-mesh
+
+# Deploy and start the relay server (relay)
+- hosts: relayNode
+  vars_files:
+    - vars.yml
+  roles:
+    - role: qa/qa-deploy-relay
+
+# Deploy and start the relay only agents (--relay-only)
+- hosts: nexodusRelayNodes
+  vars_files:
+    - vars.yml
+  roles:
+    - role: qa/qa-deploy-mesh
+
+# Validate nodes by running a connectivity test from a spoke node to all peers
+- hosts:  "{{ groups['nexodusNodes'][0] }}"
+  vars_files:
+    - vars.yml
+  roles:
+    - role: validate-connectivity

--- a/ops/ansible/aws/qa/qa-deploy-mesh/tasks/main.yml
+++ b/ops/ansible/aws/qa/qa-deploy-mesh/tasks/main.yml
@@ -1,0 +1,78 @@
+---
+# tasks file for qa-deploy-mesh
+- name: Update repo cache
+  become: yes
+  apt:
+    update_cache: yes
+
+- name: Install dependencies
+  become: yes
+  apt:
+    name:
+      - wireguard
+      - fping
+      - iperf3
+      - nftables
+    state: latest
+
+# Binary URL is https://nexodus-io.s3.amazonaws.com/ec2-e2e/qa/nexd-linux-amd64
+- name: Download the Nexodus Agent Binary
+  shell: |
+    sudo curl {{ nexodus_binary }} --output /usr/local/sbin/nexd
+    sudo chmod +x /usr/local/sbin/nexd
+
+- name: Running The following nexd command
+  debug:
+    msg: "nexd --username {{ nexodus_auth_uid }} --password {{ nexodus_auth_password }} {{ nexodus_url }}"
+  when: "'nexodusNodes' in group_names"
+
+- name: Attach the Node Agent to the Controller
+  become: yes
+  shell: |
+    echo "Running command: nexd --username {{ nexodus_auth_uid }} --password {{ nexodus_auth_password }} {{ nexodus_url }}" > nexodus-logs.txt
+    nexd \
+    --username '{{ nexodus_auth_uid }}' \
+    --password '{{ nexodus_auth_password }}' \
+    {{ nexodus_url }} >> nexodus-logs.txt 2>&1 &
+  when: "'nexodusNodes' in group_names"
+
+- name: Running The following nexd command
+  debug:
+    msg: "nexd --username {{ nexodus_auth_uid }} --password {{ nexodus_auth_password }} --relay-only {{ nexodus_url }}"
+  when: "'nexodusRelayNodes' in group_names"
+
+- name: Attach the Relay Only Client to the Controller
+  become: yes
+  shell: |
+    echo "Running command: nexd --username {{ nexodus_auth_uid }} --password {{ nexodus_auth_password }} --relay-only {{ nexodus_url }}" > nexodus-logs.txt
+    nexd \
+    --username '{{ nexodus_auth_uid }}' \
+    --password '{{ nexodus_auth_password }}' \
+    --relay-only \
+    {{ nexodus_url }} >> nexodus-logs.txt 2>&1 &
+  when: "'nexodusRelayNodes' in group_names"
+
+- name: Pause for 10 seconds for the onboard to complete to scrape the logs
+  pause:
+    seconds: 10
+
+- name: Display the nexd logs to stdout
+  become: yes
+  shell: |
+    cat /home/{{ ansible_user }}/nexodus-logs.txt
+
+- name: Copy file from remote host to localhost
+  fetch:
+    src: /home/{{ ansible_user }}/nexodus-logs.txt
+    dest: ./nexd-logs/{{ ansible_hostname }}-nexodus-logs.txt
+    flat: yes
+  ignore_errors: yes
+  when: "'nexodusNodes' in group_names"
+
+- name: Copy file from remote host to localhost when the node is --relay-only (symmetric NAT)
+  fetch:
+    src: /home/{{ ansible_user }}/nexodus-logs.txt
+    dest: ./nexd-logs/{{ ansible_hostname }}-nexodus-relay-only-symmetric-nat-logs.txt
+    flat: yes
+  ignore_errors: yes
+  when: "'nexodusRelayNodes' in group_names"

--- a/ops/ansible/aws/qa/qa-deploy-relay/tasks/main.yml
+++ b/ops/ansible/aws/qa/qa-deploy-relay/tasks/main.yml
@@ -1,0 +1,53 @@
+---
+# tasks file for qa-deploy-relay
+- name: Update repo cache
+  become: yes
+  apt:
+    update_cache: yes
+
+- name: Install dependencies
+  become: yes
+  apt:
+    name:
+      - wireguard
+      - fping
+      - iperf3
+      - nftables
+    state: latest
+
+# Binary URL is https://nexodus-io.s3.amazonaws.com/ec2-e2e/qa/nexd-linux-amd64
+- name: Download the Nexodus Agent Binary
+  shell: |
+    sudo curl {{ nexodus_binary }} --output /usr/local/sbin/nexd
+    sudo chmod +x /usr/local/sbin/nexd
+
+- name: Running The following nexd command
+  debug:
+    msg: "nexd --stun --username '{{ nexodus_auth_uid }}' --password '{{ nexodus_auth_password }}' relay {{ nexodus_url }}"
+
+- name: Attach the Relay Node to the Controller
+  become: yes
+  shell: |
+    echo "Running command: nexd --stun --username {{ nexodus_auth_uid }} --password {{ nexodus_auth_password }} relay {{ nexodus_url }}" > nexodus-logs.txt
+    NEXD_LOGLEVEL=debug nexd \
+    --stun \
+    --username '{{ nexodus_auth_uid }}' \
+    --password '{{ nexodus_auth_password }}' \
+    relay \
+    {{ nexodus_url }} >> nexodus-logs.txt 2>&1 &
+
+- name: Pause for 10 seconds for the onboard to complete to scrape the logs
+  pause:
+    seconds: 10
+
+- name: Display the nexd logs to stdout
+  become: yes
+  shell: |
+    cat /home/{{ ansible_user }}/nexodus-logs.txt
+
+- name: Copy file from remote host to localhost
+  fetch:
+    src: /home/{{ ansible_user }}/nexodus-logs.txt
+    dest: ./nexd-logs/{{ ansible_hostname }}-relay-node-nexodus-logs.txt
+    flat: yes
+  ignore_errors: yes


### PR DESCRIPTION
- Adds a workflow for running qa playbooks against the qa env.
- Most of the playbooks were reusable from dev-ec2. Only 2 new sets were made since self-signed certs isn't a thing in QA.
- Added a tool to add and delete users to a keycloak instance which generates unique UIDs by the same method as in e2e.
- Scale sizing is chosen at dispatch, which sets the Ansible vars from GH secrets.
- Verified there is no credential leakage in any output.