### PR TITLE
Add IPv6 support and tests for nexd TCP proxy

### DIFF
--- a/integration-tests/util_test.go
+++ b/integration-tests/util_test.go
@@ -300,7 +300,7 @@ func getOauth2Token(ctx context.Context, userid, password string) (*oauth2.Token
 	}, nil
 }
 
-var nonAlphanumericRegex = regexp.MustCompile(`[^a-zA-Z0-9\.\[\] ]+`)
+var nonAlphanumericRegex = regexp.MustCompile(`[^a-zA-Z0-9\.\[\]: ]+`)
 
 func clearString(str string) string {
 	return nonAlphanumericRegex.ReplaceAllString(str, "")

--- a/internal/nexodus/nexodus_userspace.go
+++ b/internal/nexodus/nexodus_userspace.go
@@ -17,7 +17,10 @@ const defaultDeviceName = "go"
 
 func (ax *Nexodus) setupInterfaceUS() error {
 	tun, tnet, err := netstack.CreateNetTUN(
-		[]netip.Addr{netip.MustParseAddr(ax.TunnelIP)},
+		[]netip.Addr{
+			netip.MustParseAddr(ax.TunnelIP),
+			netip.MustParseAddr(ax.TunnelIpV6),
+		},
 		// TODO - Is there something else that makes more sense as a DNS server?
 		// So far I don't think DNS will ever be used. If Nexodus has its own
 		// built-in DNS, that would make sense here.

--- a/internal/nexodus/wg.go
+++ b/internal/nexodus/wg.go
@@ -44,7 +44,7 @@ func (ax *Nexodus) addPeerUS(wgPeerConfig wgPeerConfig) error {
 
 	pubDecoded, err := base64.StdEncoding.DecodeString(wgPeerConfig.PublicKey)
 	if err != nil {
-		ax.logger.Errorf("Failed to decode wireguard private key: %w", err)
+		ax.logger.Errorf("Failed to decode wireguard public key: %w", err)
 		return err
 	}
 
@@ -182,7 +182,7 @@ func (ax *Nexodus) deletePeerUS(publicKey string) error {
 
 	pubDecoded, err := base64.StdEncoding.DecodeString(publicKey)
 	if err != nil {
-		ax.logger.Errorf("Failed to decode wireguard private key: %w", err)
+		ax.logger.Errorf("Failed to decode wireguard public key: %w", err)
 		return err
 	}
 	config := fmt.Sprintf("public_key=%s\nremove=true\n", hex.EncodeToString(pubDecoded))


### PR DESCRIPTION
commit 53040608902ded58a04a80ab4173d561729cf963
Author: Russell Bryant <rbryant@redhat.com>
Date:   Wed Apr 19 01:28:29 2023 -0400

    nexd: Add IPv6 tunnel IP to the userspace proxy device
    
    The userspace proxy device was configured only with the IPv4 tunnel
    address. This adds the IPv6 address to the device, as well.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>

commit 13f0f6148e30812f1f2cbbf620f72469d3f5f27f
Author: Russell Bryant <rbryant@redhat.com>
Date:   Wed Apr 19 01:29:30 2023 -0400

    e2e: Add IPv6 TCP proxy test coverage
    
    Test TCP ingress and egress proxy rules that cover:
    
    - v4 to v4
    - v4 to v6
    - v6 to v4
    - v6 to v6
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>