### PR TITLE
Auto merge dependabot changes that pass CI

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,0 +1,9 @@
+pull_request_rules:
+  - name: automatic merge for Dependabot pull requests
+    conditions:
+      - author=dependabot[bot]
+      - check-success=build-workflow-complete
+      - label!=hold
+    actions:
+      merge:
+        method: merge

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -394,3 +394,10 @@ jobs:
           name: nexodus
           path: |
             ${{ steps.build-rpm.outputs.artifact-name }}
+
+  build-workflow-complete:
+    needs: ["build-binaries", "build-rpm", "go-unit", "e2e", "k8s-lint", "opa-lint", "ui-lint"]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Build Complete
+        run: echo "Build Complete"


### PR DESCRIPTION
Start experimenting with Mergify by creating an auto-merge rule for dependabot changes that pass CI.

A new "build-workflow-complete" job was added to capture the full completion of the build workflow. This makes configuration a lot simpler.

issue #852