### PR TITLE
Remove the discovery functionality in the Relay node

### DIFF
--- a/cmd/nexd/main.go
+++ b/cmd/nexd/main.go
@@ -54,7 +54,6 @@ func nexdRun(cCtx *cli.Context, logger *zap.Logger, mode nexdMode) error {
 
 	userspaceMode := false
 	relayNode := false
-	discoveryNode := false
 	var childPrefix []string
 	switch mode {
 	case nexdModeAgent:
@@ -64,7 +63,6 @@ func nexdRun(cCtx *cli.Context, logger *zap.Logger, mode nexdMode) error {
 		logger.Info("Starting node agent with wireguard driver and router function")
 	case nexdModeRelay:
 		relayNode = true
-		discoveryNode = cCtx.Bool("enable-discovery")
 		logger.Info("Starting relay agent with wireguard driver")
 	case nexdModeProxy:
 		userspaceMode = true
@@ -84,7 +82,6 @@ func nexdRun(cCtx *cli.Context, logger *zap.Logger, mode nexdMode) error {
 		childPrefix,
 		cCtx.Bool("stun"),
 		relayNode,
-		discoveryNode,
 		cCtx.Bool("relay-only"),
 		cCtx.Bool("insecure-skip-tls-verify"),
 		Version,
@@ -206,21 +203,6 @@ func main() {
 					}
 
 					return nexdRun(cCtx, logger, nexdModeRelay)
-				},
-				Flags: []cli.Flag{
-					&cli.BoolFlag{
-						Name:     "enable-discovery",
-						Usage:    "Set if this node is to be the discovery node for NAT traversal in an organization",
-						Value:    false,
-						EnvVars:  []string{"NEXD_ENABLE_DISCOVERY"},
-						Required: false,
-						Action: func(ctx *cli.Context, discoNode bool) error {
-							if discoNode && runtime.GOOS != nexodus.Linux.String() {
-								return fmt.Errorf("Discovery node is only supported for Linux Operating System")
-							}
-							return nil
-						},
-					},
 				},
 			},
 		},

--- a/docs/development/design/nexodus-connectivity.md
+++ b/docs/development/design/nexodus-connectivity.md
@@ -79,15 +79,7 @@ NAT mapping can change for various reasons such as NAT device restart, or mappin
 
 *So how are we solving this problem?*
 
-Currently, we use a Discovery node to solve this problem. Discovery nodes can be any node that is reachable through a public ip address (or at the least, reachable on 51820 by all nodes looking to peer). Introducing the Discovery node adds an additional step in the provisioning flow. Given that each node runs the keepalive to all its peers, Discovery nodes will always have an updated reflexive address of its peer.
-
-> **Note**
-> Discovery nodes run the same Nexodus agent, but it runs with Discovery node configuration. To run Nexodus agent as a Discovery Node, you need to provide `--stun relay --enable-discovery` option during onboarding of the node. Please refer to the [Deploying Nexodus Relay](../../deployment/nexodus-service.md#deploying-the-nexodus-relay) section for details about deploying a relay node.
-
-The Discovery Node periodically fetches the wireguard peer configuration and sends the updated state (peer's endpoint-ip) to the Nexodus ApiServer. When the node's Nexodus agent fetches the new state from ApiServer, they update their peer configuration with the new endpoint ip to reconcile the broken connections between the peers. In order to maintain consitent peering and connectivity in a mobile and edge driven world, constant reconciliation is required to adjust to networks with middlebox and network state churn.
-
-> **ThinkingHatOn**
-> Assuming a Discovery node is in AWS cloud, I assume we have a similar risk of NAT mapping change? If yes, Elastic IP is probably a better option for Discovery nodes.
+Nexodus agent, sends the stun request using the port that is used by wireguard to tunnel the packets. If the stun request respond with different port in reflexive address from what is present in the current wireguard config, it updates the port information and send updated device information to API Server and get it distributed with other peers in the organization. In order to maintain consistent peering and connectivity in a mobile and edge driven world, constant state reconciliation is required to adjust to networks with middlebox and network state churn.
 
 #### Challenge 2 - Multiple nodes behind same NAT
 

--- a/docs/user-guide/discovery-and-relay.md
+++ b/docs/user-guide/discovery-and-relay.md
@@ -1,16 +1,15 @@
-# Deploying the Nexodus Discovery and Relay Nodes
+# Deploying the Nexodus Relay Nodes
 
 - Relay Node - Nexodus Controller makes the best effort to establish a direct peering between the endpoints, but in some scenarios such as symmetric NAT, it's not possible to establish direct peering. To establish connectivity in those scenarios, Nexodus Controller uses Nexodus Relay to relay the traffic between the endpoints. To use this feature you need to onboard a Relay node to the Nexodus network. This **must** be the first device to join the Nexodus network to enable the traffic relay.
-- Discovery Node - A Discovery Node is used to enable NAT traversal for all peers to connect to one another if they are unable to make direct connections.
 
-Relay and Discovery can be run on the same or separate nodes. Both of these machines need to be reachable on a predictable Wireguard port such as 51820 and ideally at the top of your NAT cone such as running in a cloud where all endpoints can reach both the discovery and relay services for peering. There is only a need for one discovery and relay nodes in an organization, after those are joined you simply run the basic onboarding [Installing the agent](agent.md#installing-the-agent) .
+Relay node needs to be reachable on a predictable Wireguard port such as 51820 and ideally at the top of your NAT cone such as running in a Cloud where all endpoints can reach relay service for peering. There is only a need for one relay node in an organization, after node joins you simply run the basic onboarding [Installing the agent](agent.md#installing-the-agent) .
 
-## Setup Nexodus Relay and Discovery Node
+## Setup Nexodus Relay Node
 
 Clone the Nexodus repository on a VM (or bare metal machine). Nexodus relay node must be reachable from all the endpoint nodes that want to join the Nexodus network. Follow the instruction in [Starting The Agent](agent.md#starting-the-agent) section to set up the node and install the `nexd` binary.
 
 ```sh
-sudo nexd --stun relay --enable-discovery https://try.nexodus.127.0.0.1.nip.io
+sudo nexd --stun relay https://try.nexodus.127.0.0.1.nip.io
 ```
 
 You can list the available organizations using the following command
@@ -25,13 +24,13 @@ dcab6a84-f522-4e9b-a221-8752d505fc18     default       100.100.1.0/20     Defaul
 ### Interactive OnBoarding
 
 ```sh
-sudo nexd --stun relay --enable-discovery https://try.nexodus.127.0.0.1.nip.io
+sudo nexd --stun relay https://try.nexodus.127.0.0.1.nip.io
 ```
 
-It will print a URL on stdout to onboard the discovery/relay node
+It will print a URL on stdout to onboard the relay node
 
 ```sh
-$ sudo nexd --stun relay --enable-discovery https://try.nexodus.127.0.0.1.nip.io
+$ sudo nexd --stun relay https://try.nexodus.127.0.0.1.nip.io
 Your device must be registered with Nexodus.
 Your one-time code is: GTLN-RGKP
 Please open the following URL in your browser to sign in:
@@ -45,5 +44,5 @@ Open the URL in your browser and provide the username and password that you used
 To OnBoard devices without any browser involvement, you need to provide a username and password in the CLI command
 
 ```sh
-nexd --stun --username=kitteh1 --password=floofykittens relay --enable-discovery https://try.nexodus.127.0.0.1.nip.io
+nexd --stun --username=kitteh1 --password=floofykittens relay https://try.nexodus.127.0.0.1.nip.io
 ```

--- a/integration-tests/integration_test.go
+++ b/integration-tests/integration_test.go
@@ -32,9 +32,9 @@ func TestBasicConnectivity(t *testing.T) {
 	defer stop()
 
 	// start nexodus on the nodes
-	helper.runNexd(ctx, node1, "--username", username, "--password", password, "relay", "--enable-discovery")
+	helper.runNexd(ctx, node1, "--username", username, "--password", password, "relay")
 
-	// validate nexd has started on the discovery node
+	// validate nexd has started on the relay node
 	err := helper.nexdStatus(ctx, node1)
 	require.NoError(err)
 
@@ -170,9 +170,9 @@ func TestRequestIPOrganization(t *testing.T) {
 	defer stop()
 
 	// start nexodus on the nodes
-	helper.runNexd(ctx, node1, "--username", username, "--password", password, "relay", "--enable-discovery")
+	helper.runNexd(ctx, node1, "--username", username, "--password", password, "relay")
 
-	// validate nexd has started on the discovery node
+	// validate nexd has started on the relay node
 	err := helper.nexdStatus(ctx, node1)
 	require.NoError(err)
 
@@ -203,9 +203,9 @@ func TestRequestIPOrganization(t *testing.T) {
 	// restart nexodus and ensure the nodes receive the same re-quested address
 	helper.Log("Restarting nexodus on two spoke nodes and re-joining")
 	helper.runNexd(ctx, node1, "--username", username, "--password", password,
-		fmt.Sprintf("--request-ip=%s", node1IP), "relay", "--enable-discovery")
+		fmt.Sprintf("--request-ip=%s", node1IP), "relay")
 
-	// validate nexd has started on the discovery node
+	// validate nexd has started on the relay node
 	err = helper.nexdStatus(ctx, node1)
 	require.NoError(err)
 
@@ -245,9 +245,9 @@ func TestHubOrganization(t *testing.T) {
 	defer stop()
 
 	// start nexodus on the nodes
-	helper.runNexd(ctx, node1, "--username", username, "--password", password, "relay", "--enable-discovery")
+	helper.runNexd(ctx, node1, "--username", username, "--password", password, "relay")
 
-	// validate nexd has started on the discovery node
+	// validate nexd has started on the relay node
 	err := helper.nexdStatus(ctx, node1)
 	require.NoError(err)
 
@@ -294,7 +294,7 @@ func TestHubOrganization(t *testing.T) {
 		"router", fmt.Sprintf("--child-prefix=%s", hubOrganizationChildPrefix),
 	)
 
-	// validate nexd has started on the discovery node
+	// validate nexd has started on the relay node
 	err = helper.nexdStatus(ctx, node2)
 	require.NoError(err)
 
@@ -420,10 +420,10 @@ func TestChildPrefix(t *testing.T) {
 	// start nexodus on the nodes
 	helper.runNexd(ctx, node1,
 		"--username", username, "--password", password,
-		"relay", "--enable-discovery",
+		"relay",
 	)
 
-	// validate nexd has started on the discovery node
+	// validate nexd has started on the relay node
 	err := helper.nexdStatus(ctx, node1)
 	require.NoError(err)
 
@@ -491,9 +491,9 @@ func TestRelay(t *testing.T) {
 	defer stop()
 
 	// start nexodus on the nodes
-	helper.runNexd(ctx, node1, "--username", username, "--password", password, "relay", "--enable-discovery")
+	helper.runNexd(ctx, node1, "--username", username, "--password", password, "relay")
 
-	// validate nexd has started on the discovery node
+	// validate nexd has started on the relay node
 	err := helper.nexdStatus(ctx, node1)
 	require.NoError(err)
 
@@ -599,9 +599,9 @@ func TestNexctl(t *testing.T) {
 	require.NotEmpty(organizations[0].Description)
 
 	// start nexodus on the nodes
-	helper.runNexd(ctx, node1, "--username", username, "--password", password, "relay", "--enable-discovery")
+	helper.runNexd(ctx, node1, "--username", username, "--password", password, "relay")
 
-	// validate nexd has started on the discovery node
+	// validate nexd has started on the relay node
 	err = helper.nexdStatus(ctx, node1)
 	require.NoError(err)
 
@@ -709,7 +709,7 @@ func TestNexctl(t *testing.T) {
 	// re-join both nodes, flipping the child-prefix to node1 to ensure the child-prefix was released
 	helper.runNexd(ctx, node1, "--username", username, "--password", password, "router", "--child-prefix=100.22.100.0/24")
 
-	// validate nexd has started on the discovery node
+	// validate nexd has started on the relay node
 	err = helper.nexdStatus(ctx, node1)
 	require.NoError(err)
 
@@ -830,7 +830,7 @@ func TestV6Disabled(t *testing.T) {
 	defer stop()
 
 	// start nexodus on the nodes
-	helper.runNexd(ctx, node1, "--username", username, "--password", password, "relay", "--enable-discovery")
+	helper.runNexd(ctx, node1, "--username", username, "--password", password, "relay")
 	err := helper.nexdStatus(ctx, node1)
 	require.NoError(err)
 

--- a/integration-tests/proxy_test.go
+++ b/integration-tests/proxy_test.go
@@ -33,7 +33,7 @@ func TestProxyEgress(t *testing.T) {
 	defer stop()
 
 	// start nexodus on the nodes
-	helper.runNexd(ctx, node1, "--username", username, "--password", password, "relay", "--enable-discovery")
+	helper.runNexd(ctx, node1, "--username", username, "--password", password, "relay")
 	err := helper.nexdStatus(ctx, node1)
 	require.NoError(err)
 
@@ -99,7 +99,7 @@ func TestProxyEgressUDP(t *testing.T) {
 
 	helper.Logf("Starting nexd on node1")
 	// start nexodus on the nodes
-	helper.runNexd(ctx, node1, "--username", username, "--password", password, "relay", "--enable-discovery")
+	helper.runNexd(ctx, node1, "--username", username, "--password", password, "relay")
 	err := helper.nexdStatus(ctx, node1)
 	require.NoError(err)
 
@@ -163,7 +163,7 @@ func TestProxyEgressMultipleRules(t *testing.T) {
 	defer stop()
 
 	// start nexodus on the nodes
-	helper.runNexd(ctx, node1, "--username", username, "--password", password, "relay", "--enable-discovery")
+	helper.runNexd(ctx, node1, "--username", username, "--password", password, "relay")
 	err := helper.nexdStatus(ctx, node1)
 	require.NoError(err)
 
@@ -236,7 +236,7 @@ func TestProxyIngress(t *testing.T) {
 	defer stop()
 
 	// start nexodus on the nodes
-	helper.runNexd(ctx, node1, "--username", username, "--password", password, "relay", "--enable-discovery")
+	helper.runNexd(ctx, node1, "--username", username, "--password", password, "relay")
 	err := helper.nexdStatus(ctx, node1)
 	require.NoError(err)
 
@@ -298,7 +298,7 @@ func TestProxyIngressMultipleRules(t *testing.T) {
 	defer stop()
 
 	// start nexodus on the nodes
-	helper.runNexd(ctx, node1, "--username", username, "--password", password, "relay", "--enable-discovery")
+	helper.runNexd(ctx, node1, "--username", username, "--password", password, "relay")
 	err := helper.nexdStatus(ctx, node1)
 	require.NoError(err)
 
@@ -367,7 +367,7 @@ func TestProxyIngressAndEgress(t *testing.T) {
 	defer stop()
 
 	// start nexodus on the nodes
-	helper.runNexd(ctx, node1, "--username", username, "--password", password, "relay", "--enable-discovery")
+	helper.runNexd(ctx, node1, "--username", username, "--password", password, "relay")
 
 	// validate nexd has started on the discovery node
 	err := helper.nexdStatus(ctx, node1)


### PR DESCRIPTION
Given that we have the stun based discovery in the agent itself, relay based discovery function is now
 redundant.