### PR TITLE
systemd: Fix autostart on boot

### DIFF
--- a/contrib/rpm/nexodus.service
+++ b/contrib/rpm/nexodus.service
@@ -10,3 +10,6 @@ RestartSec=1
 User=root
 EnvironmentFile=/etc/sysconfig/nexodus
 ExecStart=/usr/bin/nexd ${NEXD_ARGS}
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
The systemd service unit configuration was missing the Install section, which is required for doing `systemctl enable nexodus` to have it automatically started on boot.