### PR TITLE
rpm: Fix dependency installation

### DIFF
--- a/contrib/rpm/nexodus.spec.in
+++ b/contrib/rpm/nexodus.spec.in
@@ -34,14 +34,14 @@ URL:            %{gourl}
 Source:         nexodus-##NEXODUS_COMMIT##.tar.gz
 #Source:         %%{gosource}
 
-%description %{common_description}
-
 BuildRequires: systemd-rpm-macros
 BuildRequires: systemd-units
 Requires: wireguard-tools
 Requires(post): systemd-units
 Requires(preun): systemd-units
 Requires(postun): systemd-units
+
+%description %{common_description}
 
 %gopkg
 


### PR DESCRIPTION
When installing nexodus on a new host, nexd failed to start because wireguard-tools didn't get pulled in as a dependency. The reason is because the dependencies were in the wrong section of the spec file. With this change, wireguard-tools will be pulled in automatically as desired.