### PR TITLE
Adds a retry to the initial agent setup API calls

### DIFF
--- a/internal/nexodus/join.go
+++ b/internal/nexodus/join.go
@@ -1,0 +1,50 @@
+package nexodus
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/nexodus-io/nexodus/internal/api/public"
+)
+
+func (ax *Nexodus) createOrUpdateDeviceOperation(userID string, endpoints []public.ModelsEndpoint) (public.ModelsDevice, error) {
+	d, _, err := ax.client.DevicesApi.CreateDevice(context.Background()).Device(public.ModelsAddDevice{
+		UserId:                  userID,
+		OrganizationId:          ax.organization,
+		PublicKey:               ax.wireguardPubKey,
+		TunnelIp:                ax.requestedIP,
+		ChildPrefix:             ax.childPrefix,
+		EndpointLocalAddressIp4: ax.endpointLocalAddress,
+		SymmetricNat:            ax.symmetricNat,
+		Hostname:                ax.hostname,
+		Relay:                   ax.relay,
+		Os:                      ax.os,
+		Endpoints:               endpoints,
+	}).Execute()
+
+	if err != nil {
+		var apiError *public.GenericOpenAPIError
+		if errors.As(err, &apiError) {
+			switch model := apiError.Model().(type) {
+			case public.ModelsConflictsError:
+				d, _, err = ax.client.DevicesApi.UpdateDevice(context.Background(), model.Id).Update(public.ModelsUpdateDevice{
+					ChildPrefix:             ax.childPrefix,
+					EndpointLocalAddressIp4: ax.endpointLocalAddress,
+					SymmetricNat:            ax.symmetricNat,
+					Hostname:                ax.hostname,
+					Endpoints:               endpoints,
+				}).Execute()
+				if err != nil {
+					return public.ModelsDevice{}, fmt.Errorf("error updating device: %w", err)
+				}
+			default:
+				return public.ModelsDevice{}, fmt.Errorf("error creating device: %w", err)
+			}
+		} else {
+			return public.ModelsDevice{}, fmt.Errorf("error creating device: %w", err)
+		}
+	}
+
+	return *d, nil
+}

--- a/internal/nexodus/nexodus_linux.go
+++ b/internal/nexodus/nexodus_linux.go
@@ -22,8 +22,7 @@ func (ax *Nexodus) setupInterfaceOS() error {
 	}
 
 	if ax.TunnelIP == "" || ax.TunnelIpV6 == "" {
-		logger.Infof("Have not received full local node configuration from the service, skipping interface setup")
-		return nil
+		return fmt.Errorf("Have not received local node address configuration from the service, returning for a retry")
 	}
 
 	// create the wireguard ip link interface

--- a/internal/util/retry_operation.go
+++ b/internal/util/retry_operation.go
@@ -1,0 +1,20 @@
+package util
+
+import (
+	"context"
+	"time"
+
+	"github.com/cenkalti/backoff/v4"
+)
+
+// RetryOperation retries the operation with a backoff policy.
+func RetryOperation(ctx context.Context, wait time.Duration, retries int, operation func() error) error {
+	bo := backoff.WithMaxRetries(
+		backoff.NewConstantBackOff(wait),
+		uint64(retries),
+	)
+	bo = backoff.WithContext(bo, ctx)
+	err := backoff.Retry(operation, bo)
+
+	return err
+}

--- a/internal/util/retry_operation_test.go
+++ b/internal/util/retry_operation_test.go
@@ -1,0 +1,89 @@
+package util
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func isMaxRetriesReachedErr(err error) bool {
+	return strings.Contains(err.Error(), "giving up after")
+}
+
+func TestRetryOperation(t *testing.T) {
+	tests := []struct {
+		name           string
+		wait           time.Duration
+		retries        int
+		operation      func() error
+		expectedResult error
+	}{
+		{
+			name:    "Success on first attempt",
+			wait:    10 * time.Millisecond,
+			retries: 3,
+			operation: func() error {
+				return nil
+			},
+			expectedResult: nil,
+		},
+		{
+			name:    "Success after retries",
+			wait:    10 * time.Millisecond,
+			retries: 3,
+			operation: func() error {
+				return errors.New("temporary error")
+			},
+			expectedResult: nil,
+		},
+		{
+			name:    "Context canceled",
+			wait:    50 * time.Millisecond,
+			retries: 3,
+			operation: func() error {
+				return errors.New("temporary error")
+			},
+			expectedResult: context.Canceled,
+		},
+	}
+
+	callCount := 0
+	for _, tt := range tests {
+		callCount = 0 // Reset the callCount before each test
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+			defer cancel()
+
+			if tt.name == "Context canceled" {
+				go func() {
+					time.Sleep(25 * time.Millisecond)
+					cancel()
+				}()
+			}
+
+			// Update the "Success after retries" test case to use the callCount variable
+			if tt.name == "Success after retries" {
+				tt.operation = func() error {
+					if callCount < 2 { // Assuming it will succeed after 2 retries (total 3 attempts)
+						callCount++
+						return errors.New("temporary error")
+					}
+					return nil
+				}
+			}
+
+			err := RetryOperation(ctx, tt.wait, tt.retries, tt.operation)
+			if tt.expectedResult == nil {
+				assert.Nil(t, err)
+			} else if errors.Is(err, context.Canceled) {
+				assert.Equal(t, tt.expectedResult, err)
+			} else {
+				assert.True(t, isMaxRetriesReachedErr(err))
+			}
+		})
+	}
+}

--- a/ops/ansible/aws/ansible.cfg
+++ b/ops/ansible/aws/ansible.cfg
@@ -11,7 +11,8 @@ private_key_file = ./nexodus.pem
 timeout = 60
 # reduce the number of SSH connections
 pipelining = true
-
+# increase task batches from the default of 5
+forks=10
 [ssh_connection]
 # how long the SSH keeps an idle connection open in the background
 ssh_args = -o ControlMaster=auto -o ControlPersist=60s

--- a/ops/ansible/aws/deploy-mesh/tasks/main.yml
+++ b/ops/ansible/aws/deploy-mesh/tasks/main.yml
@@ -88,7 +88,7 @@
   become: yes
   shell: |
     echo "Running command: nexd --username {{ nexodus_auth_uid }} --password {{ nexodus_auth_password }} {{ nexodus_url }}" > nexodus-logs.txt
-    nexd \
+    NEXD_LOGLEVEL=debug nexd \
     --username '{{ nexodus_auth_uid }}' \
     --password '{{ nexodus_auth_password }}' \
     {{ nexodus_url }} >> nexodus-logs.txt 2>&1 &
@@ -103,7 +103,7 @@
   become: yes
   shell: |
     echo "Running command: nexd --username {{ nexodus_auth_uid }} --password {{ nexodus_auth_password }} --relay-only {{ nexodus_url }}" > nexodus-logs.txt
-    nexd \
+    NEXD_LOGLEVEL=debug nexd \
     --username '{{ nexodus_auth_uid }}' \
     --password '{{ nexodus_auth_password }}' \
     --relay-only \

--- a/ops/ansible/aws/qa/qa-deploy-mesh/tasks/main.yml
+++ b/ops/ansible/aws/qa/qa-deploy-mesh/tasks/main.yml
@@ -30,7 +30,7 @@
   become: yes
   shell: |
     echo "Running command: nexd --username {{ nexodus_auth_uid }} --password {{ nexodus_auth_password }} {{ nexodus_url }}" > nexodus-logs.txt
-    nexd \
+    NEXD_LOGLEVEL=debug nexd \
     --username '{{ nexodus_auth_uid }}' \
     --password '{{ nexodus_auth_password }}' \
     {{ nexodus_url }} >> nexodus-logs.txt 2>&1 &
@@ -45,7 +45,7 @@
   become: yes
   shell: |
     echo "Running command: nexd --username {{ nexodus_auth_uid }} --password {{ nexodus_auth_password }} --relay-only {{ nexodus_url }}" > nexodus-logs.txt
-    nexd \
+    NEXD_LOGLEVEL=debug nexd \
     --username '{{ nexodus_auth_uid }}' \
     --password '{{ nexodus_auth_password }}' \
     --relay-only \

--- a/ops/ansible/aws/validate-connectivity/tasks/main.yml
+++ b/ops/ansible/aws/validate-connectivity/tasks/main.yml
@@ -24,6 +24,9 @@
   shell: |
     printf "====== Connectivity Results from Node: {{ inventory_hostname }} ======\n" > connectivity-results.txt
     fping -s -g  {{ ip_prefix }}.1 {{ ip_prefix }}.{{ spoke_range_end }} >> connectivity-results.txt 2>&1
+    printf "\n====== WG Dump from Node: {{ inventory_hostname }} ======\n" >> connectivity-results.txt
+    wg show wg0 dump >> connectivity-results.txt 2>&1
+    cat connectivity-results.txt
   ignore_errors: yes
 
 - name: Copy connectivity results back to the runner


### PR DESCRIPTION
- In scale testing we are seeing http timeouts when a large numbers of agents try and connect concurrently. Part of adding some resilience under load is a retry timer for operations prior to entering the reconcile routines.
- If any of these fail after the retries exiting probably makes more sense than an infinite backoff and let systemd manage restarts from there. TBD.
- Playbooks are modified just for testing of this while it is in draft as the relay node scale bug is still outstanding.
- Renamed `device` to `modelsDevice` since it overlaps with the `golang.zx2c4.com/wireguard/device` package.
- Closes #855  and #867 