### PR TITLE
nexd: Detect misplaced arguments

### DIFF
--- a/cmd/nexd/main.go
+++ b/cmd/nexd/main.go
@@ -45,6 +45,10 @@ func nexdRun(cCtx *cli.Context, logger *zap.Logger, mode nexdMode) error {
 		serviceURL = DefaultServiceURL
 	}
 
+	if cCtx.Args().Len() > 1 {
+		return fmt.Errorf("nexd only takes one positional argument, the service URL. Additional arguments ignored: %s", cCtx.Args().Tail())
+	}
+
 	_, err := nexodus.CtlStatus(cCtx)
 	if err == nil {
 		return fmt.Errorf("existing nexd service already running")


### PR DESCRIPTION
Arguments placed after the service URL are treated as additional
positional arguments which are all ignored. Detect this and return
with an error making it clear that the arguments were formed
incorrectly.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
