### PR TITLE
nexctl: Add dynamic proxy rule management

### DIFF
--- a/cmd/nexctl/connectivity.go
+++ b/cmd/nexctl/connectivity.go
@@ -72,7 +72,7 @@ func cmdConnStatus(cCtx *cli.Context) error {
 func callNexdKeepalives() (map[string]nexodus.KeepaliveStatus, error) {
 	var result map[string]nexodus.KeepaliveStatus
 
-	keepaliveJson, err := callNexd("Connectivity")
+	keepaliveJson, err := callNexd("Connectivity", "")
 	if err != nil {
 		return result, fmt.Errorf("Failed to get nexd connectivity status: %w\n", err)
 	}

--- a/cmd/nexd/main.go
+++ b/cmd/nexd/main.go
@@ -98,11 +98,6 @@ func nexdRun(cCtx *cli.Context, logger *zap.Logger, mode nexdMode) error {
 
 	wg := &sync.WaitGroup{}
 
-	err = nex.LoadProxyRules()
-	if err != nil {
-		logger.Fatal(fmt.Sprintf("Failed to load the stored proxy rules: %v", err))
-	}
-
 	for _, egressRule := range cCtx.StringSlice("egress") {
 		_, err := nex.UserspaceProxyAdd(ctx, wg, egressRule, nexodus.ProxyTypeEgress, false)
 		if err != nil {
@@ -115,6 +110,11 @@ func nexdRun(cCtx *cli.Context, logger *zap.Logger, mode nexdMode) error {
 			logger.Fatal(fmt.Sprintf("Failed to add ingress proxy rule (%s): %v", ingressRule, err))
 		}
 	}
+	err = nex.LoadProxyRules()
+	if err != nil {
+		logger.Fatal(fmt.Sprintf("Failed to load the stored proxy rules: %v", err))
+	}
+
 	if err := nex.Start(ctx, wg); err != nil {
 		logger.Fatal(err.Error())
 	}

--- a/cmd/nexd/main.go
+++ b/cmd/nexd/main.go
@@ -97,14 +97,20 @@ func nexdRun(cCtx *cli.Context, logger *zap.Logger, mode nexdMode) error {
 	}
 
 	wg := &sync.WaitGroup{}
+
+	err = nex.LoadProxyRules()
+	if err != nil {
+		logger.Fatal(fmt.Sprintf("Failed to load the stored proxy rules: %v", err))
+	}
+
 	for _, egressRule := range cCtx.StringSlice("egress") {
-		err := nex.UserspaceProxyAdd(ctx, wg, egressRule, nexodus.ProxyTypeEgress, false)
+		_, err := nex.UserspaceProxyAdd(ctx, wg, egressRule, nexodus.ProxyTypeEgress, false)
 		if err != nil {
 			logger.Fatal(fmt.Sprintf("Failed to add egress proxy rule (%s): %v", egressRule, err))
 		}
 	}
 	for _, ingressRule := range cCtx.StringSlice("ingress") {
-		err := nex.UserspaceProxyAdd(ctx, wg, ingressRule, nexodus.ProxyTypeIngress, false)
+		_, err := nex.UserspaceProxyAdd(ctx, wg, ingressRule, nexodus.ProxyTypeIngress, false)
 		if err != nil {
 			logger.Fatal(fmt.Sprintf("Failed to add ingress proxy rule (%s): %v", ingressRule, err))
 		}

--- a/cmd/nexd/main.go
+++ b/cmd/nexd/main.go
@@ -98,13 +98,13 @@ func nexdRun(cCtx *cli.Context, logger *zap.Logger, mode nexdMode) error {
 
 	wg := &sync.WaitGroup{}
 	for _, egressRule := range cCtx.StringSlice("egress") {
-		err := nex.UserspaceProxyAdd(ctx, wg, egressRule, nexodus.ProxyTypeEgress)
+		err := nex.UserspaceProxyAdd(ctx, wg, egressRule, nexodus.ProxyTypeEgress, false)
 		if err != nil {
 			logger.Fatal(fmt.Sprintf("Failed to add egress proxy rule (%s): %v", egressRule, err))
 		}
 	}
 	for _, ingressRule := range cCtx.StringSlice("ingress") {
-		err := nex.UserspaceProxyAdd(ctx, wg, ingressRule, nexodus.ProxyTypeIngress)
+		err := nex.UserspaceProxyAdd(ctx, wg, ingressRule, nexodus.ProxyTypeIngress, false)
 		if err != nil {
 			logger.Fatal(fmt.Sprintf("Failed to add ingress proxy rule (%s): %v", ingressRule, err))
 		}
@@ -112,6 +112,8 @@ func nexdRun(cCtx *cli.Context, logger *zap.Logger, mode nexdMode) error {
 	if err := nex.Start(ctx, wg); err != nil {
 		logger.Fatal(err.Error())
 	}
+	<-ctx.Done()
+	nex.Stop()
 	wg.Wait()
 
 	return nil

--- a/docs/development/design/userspace-mode.md
+++ b/docs/development/design/userspace-mode.md
@@ -76,13 +76,13 @@ sudo nexodus proxy --egress tcp:5432:100.100.0.2:5432
 The `--ingress` and `--engress` flags will be the first configuration methods implemented. A future enhancement would be to allow configuration at runtime using `nexctl`. For example, to remove a ingress proxy rule:
 
 ```sh
-sudo nexctl nexd proxy remove ingress tcp:443:127.0.0.1:8080
+sudo nexctl nexd proxy remove --ingress tcp:443:127.0.0.1:8080
 ```
 
 or to add a new egress proxy rule:
 
 ```sh
-sudo nexctl nexd proxy add egress tcp:5432:100.100.0.2:5432
+sudo nexctl nexd proxy add --egress tcp:5432:100.100.0.2:5432
 ```
 
 ## Alternatives Considered

--- a/docs/user-guide/nexd-proxy.md
+++ b/docs/user-guide/nexd-proxy.md
@@ -80,6 +80,28 @@ flowchart TD
 
 Since UDP is a connectionless protocol, `nexd proxy` must maintain its own state for each UDP flow to ensure that return traffic is forwarded appropriately. These flows time out after 60 seconds of inactivity.
 
+### Managing Rules with Nexctl
+
+In addition to configuring rules as command line flags, `nexctl` can be used to dynamically add or remove proxy rules. Rules that are added dynamically are persisted across `nexd proxy` restarts.
+
+To add a rule:
+
+```console
+nexctl nexd proxy add --ingress tcp:443:10.0.10.34:8443
+```
+
+To remove a rule:
+
+```console
+nexctl nexd proxy remove --ingress tcp:$43:10.0.10.34:8443
+```
+
+To list currently active rules:
+
+```console
+nexctl nexd proxy list
+```
+
 ## Demo Using Containers
 
 This section provides instructions on running an end-to-end demonstration of using `nexd proxy` on both ends of a connection. We will run two containers: one running an http server, and another that would like to reach that http server. `nexd` in each container will negotiate an encrypted tunnel directly between each other. The connection will go over this tunnel.

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/itchyny/gojq v0.12.12
 	github.com/libp2p/go-reuseport v0.3.0
 	github.com/metal-stack/go-ipam v1.11.6
+	github.com/natefinch/atomic v1.0.1
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/pion/stun v0.4.0
 	github.com/sirupsen/logrus v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -460,6 +460,8 @@ github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7P
 github.com/mrunalp/fileutils v0.5.0/go.mod h1:M1WthSahJixYnrXQl/DFQuteStB1weuxD2QJNHXfbSQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
+github.com/natefinch/atomic v1.0.1 h1:ZPYKxkqQOx3KZ+RsbnP/YsgvxWQPGxjC0oBt2AhwV0A=
+github.com/natefinch/atomic v1.0.1/go.mod h1:N/D/ELrljoqDyT3rZrsUmtsuzvHkeB/wWjHV22AZRbM=
 github.com/nexodus-io/wireguard-go v0.0.0-20230407202523-3eab17a590b0 h1:IUJgXVKUDOgzigLGpkl+6WxcgL2TnzpOhbdaDyCgvBg=
 github.com/nexodus-io/wireguard-go v0.0.0-20230407202523-3eab17a590b0/go.mod h1:tqur9LnfstdR9ep2LaJT4lFUl0EjlHtge+gAjmsHUG4=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=

--- a/internal/nexodus/ctlserver.go
+++ b/internal/nexodus/ctlserver.go
@@ -42,3 +42,52 @@ func (ac *NexdCtl) GetTunnelIPv6(_ string, result *string) error {
 	*result = ac.ax.TunnelIpV6
 	return nil
 }
+
+func (ac *NexdCtl) ProxyList(_ string, result *string) error {
+	*result = ""
+	ac.ax.proxyLock.RLock()
+	defer ac.ax.proxyLock.RUnlock()
+	for _, proxy := range ac.ax.ingressProxies {
+		*result += fmt.Sprintf("%s\n", proxy)
+	}
+	for _, proxy := range ac.ax.egressProxies {
+		*result += fmt.Sprintf("%s\n", proxy)
+	}
+	return nil
+}
+
+func (ac *NexdCtl) ProxyAddIngress(rule string, result *string) error {
+	err := ac.ax.UserspaceProxyAdd(ac.ax.nexCtx, ac.ax.nexWg, rule, ProxyTypeIngress, true)
+	if err != nil {
+		return err
+	}
+	*result = fmt.Sprintf("Added ingress proxy rule: %s\n", rule)
+	return nil
+}
+
+func (ac *NexdCtl) ProxyAddEgress(rule string, result *string) error {
+	err := ac.ax.UserspaceProxyAdd(ac.ax.nexCtx, ac.ax.nexWg, rule, ProxyTypeEgress, true)
+	if err != nil {
+		return err
+	}
+	*result = fmt.Sprintf("Added egress proxy rule: %s\n", rule)
+	return nil
+}
+
+func (ac *NexdCtl) ProxyRemoveIngress(rule string, result *string) error {
+	err := ac.ax.UserspaceProxyRemove(rule, ProxyTypeIngress)
+	if err != nil {
+		return err
+	}
+	*result = fmt.Sprintf("Removed ingress proxy rule: %s\n", rule)
+	return nil
+}
+
+func (ac *NexdCtl) ProxyRemoveEgress(rule string, result *string) error {
+	err := ac.ax.UserspaceProxyRemove(rule, ProxyTypeEgress)
+	if err != nil {
+		return err
+	}
+	*result = fmt.Sprintf("Removed egress proxy rule: %s\n", rule)
+	return nil
+}

--- a/internal/nexodus/ctlserver.go
+++ b/internal/nexodus/ctlserver.go
@@ -57,7 +57,12 @@ func (ac *NexdCtl) ProxyList(_ string, result *string) error {
 }
 
 func (ac *NexdCtl) ProxyAddIngress(rule string, result *string) error {
-	err := ac.ax.UserspaceProxyAdd(ac.ax.nexCtx, ac.ax.nexWg, rule, ProxyTypeIngress, true)
+	proxy, err := ac.ax.UserspaceProxyAdd(ac.ax.nexCtx, ac.ax.nexWg, rule, ProxyTypeIngress, true)
+	if err != nil {
+		return err
+	}
+	proxy.stored = true
+	err = ac.ax.StoreProxyRules()
 	if err != nil {
 		return err
 	}
@@ -66,7 +71,12 @@ func (ac *NexdCtl) ProxyAddIngress(rule string, result *string) error {
 }
 
 func (ac *NexdCtl) ProxyAddEgress(rule string, result *string) error {
-	err := ac.ax.UserspaceProxyAdd(ac.ax.nexCtx, ac.ax.nexWg, rule, ProxyTypeEgress, true)
+	proxy, err := ac.ax.UserspaceProxyAdd(ac.ax.nexCtx, ac.ax.nexWg, rule, ProxyTypeEgress, true)
+	if err != nil {
+		return err
+	}
+	proxy.stored = true
+	err = ac.ax.StoreProxyRules()
 	if err != nil {
 		return err
 	}
@@ -75,18 +85,30 @@ func (ac *NexdCtl) ProxyAddEgress(rule string, result *string) error {
 }
 
 func (ac *NexdCtl) ProxyRemoveIngress(rule string, result *string) error {
-	err := ac.ax.UserspaceProxyRemove(rule, ProxyTypeIngress)
+	proxy, err := ac.ax.UserspaceProxyRemove(rule, ProxyTypeIngress)
 	if err != nil {
 		return err
+	}
+	if proxy.stored {
+		err = ac.ax.StoreProxyRules()
+		if err != nil {
+			return err
+		}
 	}
 	*result = fmt.Sprintf("Removed ingress proxy rule: %s\n", rule)
 	return nil
 }
 
 func (ac *NexdCtl) ProxyRemoveEgress(rule string, result *string) error {
-	err := ac.ax.UserspaceProxyRemove(rule, ProxyTypeEgress)
+	proxy, err := ac.ax.UserspaceProxyRemove(rule, ProxyTypeEgress)
 	if err != nil {
 		return err
+	}
+	if proxy.stored {
+		err = ac.ax.StoreProxyRules()
+		if err != nil {
+			return err
+		}
 	}
 	*result = fmt.Sprintf("Removed egress proxy rule: %s\n", rule)
 	return nil


### PR DESCRIPTION
commit b50e8aeae81d15824ac51c1bd95812b42d77877c
Author: Russell Bryant <russell.bryant@gmail.com>
Date:   Thu Apr 20 20:09:01 2023 -0400

    nexctl: Add dynamic proxy rule management
    
    Add the following commands to `nexctl` for dynamic proxy rule
    management in `nexd`.
    
    - `nexctl nexd proxy list`
    - `nexctl nexd proxy add`
    - `nexctl nexd proxy remove`
    
    Each `add` or `remove` can contain multiple ingress and egress rules
    to add or remove at the same time.
    
    Add an e2e test that exercises all of these commands.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>

commit 5c7a50c3bf4f7e0e767f2d0276bfbda53a216d3e
Author: Hiram Chirino <hiram@hiramchirino.com>
Date:   Sat Apr 29 13:21:49 2023 -0500

    feat: store dynamically added proxy routes between restarts
    
    Signed-off-by: Hiram Chirino <hiram@hiramchirino.com>

commit bd8498de6b5d15f4ccd8276b5d45f56d7651fc6e
Author: Hiram Chirino <hiram@hiramchirino.com>
Date:   Sat Apr 29 15:59:44 2023 -0500

    Avoid failing to startup due to a adding a static startup route that duplicates a previously added dynamic route.
    
    Signed-off-by: Hiram Chirino <hiram@hiramchirino.com>

commit 315b76aa4380530118c4b0fe943894c4cc3b4003
Author: Russell Bryant <russell.bryant@gmail.com>
Date:   Sun Apr 30 09:22:28 2023 -0400

    docs: Cover managing proxy rules with nexctl
    
    Show how to list, add, or remove proxy rules using `nexctl`.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>

Closes #705 
