### PR TITLE
mergify: Require design and user doc verification

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -17,6 +17,12 @@ pull_request_rules:
       - label!=hold
       - check-success=DCO
       - or:
+        - label=has-design
+        - label=no-design-required
+      - or:
+        - label=has-docs
+        - label=no-docs-required
+      - or:
         # PRs that include doc changes should also pass the markdown-lint check
         - and:
           - check-success=build-workflow-complete

--- a/docs/development/pull-requests.md
+++ b/docs/development/pull-requests.md
@@ -22,6 +22,8 @@ Use the GitHub reviewers field to request reviews from a specific individual. Be
 * CI should be passing.
 * Every person who is on the list of reviewers should be given a chance to weigh in before merging. 24 hours is a good general rule, but if the PR is small and the reviewers are all active, it's fine to merge sooner. If a PR is large, complex, or controversial, waiting longer would make sense. Use your best judgment. Note that a PR will not automatically merge until the review is complete or the review request is removed.
 * The `hold` label must not be present on the PR. Ensure that whoever added the `hold` is OK with removing the label before the PR is merged. There is no timeout on the `hold` label for when someone else should remove it unless the reviewer who placed the hold is unavailable for a significant period.
+* PRs must have either the `has-design` or `no-design-requied` label applied. This is to confirm that a design document has been produced if appropriate.
+* PRs must have either the `has-docs` or `no-docs-required` label applied. This is to confirm that user-facing documentation has been produced if appropriate.
 
 We use [Mergify](https://mergify.io/) to automatically merge PRs that meet the above criteria. See the [Mergify configuration](https://github.com/nexodus-io/nexodus/blob/main/.github/mergify.yml) for more details.
 


### PR DESCRIPTION
Add two more merge rules to be enforced by mergify.

1) Require a label that says user-facing docs are included or to state
   that they are not required.

2) Require a label that says design docs are included (or were
   previously written and merged), or that they are not required.