### PR TITLE
Use nexctl to validate connectivity in qa

### DIFF
--- a/.github/workflows/qa-dev.yml
+++ b/.github/workflows/qa-dev.yml
@@ -66,10 +66,12 @@ jobs:
       - name: Build
         run: |
           make dist/nexd-linux-amd64
+          make dist/nexctl-linux-amd64
 
-      - name:  Copy Agent Binary to S3
+      - name:  Copy Binaries to S3
         run: |
           aws s3 cp ./dist/nexd-linux-amd64 s3://nexodus-io/ec2-e2e/
+          aws s3 cp ./dist/nexctl-linux-amd64 s3://nexodus-io/ec2-e2e/
           aws s3 cp ./hack/e2e-scripts/init-pr-e2e.sh s3://nexodus-io/ec2-e2e/
 
       - uses: actions/setup-python@v4
@@ -133,11 +135,11 @@ jobs:
         run: |
           set -e
           cat ./ops/ansible/aws/connectivity-results.txt
-          if grep -q '0 unreachable' ./ops/ansible/aws/connectivity-results.txt; then
-            echo "Connectivity results contain '0 unreachable' nodes"
-          else
-            echo "Connectivity results do not contain '0 unreachable' nodes, check the connectivity results for details, failing this job"
+          if grep -iq 'Unreachable' ./ops/ansible/aws/connectivity-results.txt; then
+            echo "Connectivity results contain 'Unreachable' nodes, check the connectivity results for details. Failing the job"
             exit 1
+          else
+            echo "Connectivity results do not contain any 'Unreachable' nodes"
           fi
 
       - name: Gather api-server Server Logs

--- a/.github/workflows/qa-scale.yml
+++ b/.github/workflows/qa-scale.yml
@@ -66,10 +66,12 @@ jobs:
       - name: Build
         run: |
           make dist/nexd-linux-amd64
+          make dist/nexctl-linux-amd64
 
-      - name:  Copy Agent Binary to S3
+      - name:  Copy Binaries to S3
         run: |
           aws s3 cp ./dist/nexd-linux-amd64 s3://nexodus-io/ec2-e2e/qa/
+          aws s3 cp ./dist/nexctl-linux-amd64 s3://nexodus-io/ec2-e2e/qa/
 
       - name:  Build Keycloak Tool
         run: |
@@ -140,11 +142,11 @@ jobs:
         run: |
           set -e
           cat ./ops/ansible/aws/connectivity-results.txt
-          if grep -q '0 unreachable' ./ops/ansible/aws/connectivity-results.txt; then
-            echo "Connectivity results contain '0 unreachable' nodes"
-          else
-            echo "Connectivity results do not contain '0 unreachable' nodes, check the connectivity results for details, failing this job"
+          if grep -iq 'Unreachable' ./ops/ansible/aws/connectivity-results.txt; then
+            echo "Connectivity results contain 'Unreachable' nodes, check the connectivity results for details. Failing the job"
             exit 1
+          else
+            echo "Connectivity results do not contain any 'Unreachable' nodes"
           fi
 
       - name: Terminate EC2 Instances

--- a/ops/ansible/aws/validate-connectivity/tasks/main.yml
+++ b/ops/ansible/aws/validate-connectivity/tasks/main.yml
@@ -15,15 +15,22 @@
 - set_fact:
     ip_prefix={{ ip_prefix.stdout }}
 
+- name: Download the Nexodus Agent Binary
+  shell: |
+    sudo curl {{ nexctl_binary }} --output /usr/local/bin/nexctl
+    sudo chmod +x /usr/local/bin/nexctl
+
 - name: Debug
   debug:
     msg: "Running connectivity test on spoke node: {{ inventory_hostname }}"
 
+# Run connections twice, once to stdout and one piped to a file. Partially to verify any false positives as the timers are currently very short on the probes
 - name: Verify Connectivity from a spoke node to all spokes
   become: yes
   shell: |
     printf "====== Connectivity Results from Node: {{ inventory_hostname }} ======\n" > connectivity-results.txt
-    fping -s -g  {{ ip_prefix }}.1 {{ ip_prefix }}.{{ spoke_range_end }} >> connectivity-results.txt 2>&1
+    nexctl connections
+    nexctl connections >> connectivity-results.txt 2>&1
     printf "\n====== WG Dump from Node: {{ inventory_hostname }} ======\n" >> connectivity-results.txt
     wg show wg0 dump >> connectivity-results.txt 2>&1
     cat connectivity-results.txt


### PR DESCRIPTION
- On bulk simultaneous joins, IPAM is skipping some addresses for a tbd reason. Using `nexctl connections` probes peers so makes more sense to use and validate in the process.