### PR TITLE
mergify: Notify submitters of conflicts

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -34,3 +34,20 @@ pull_request_rules:
     actions:
       merge:
         method: merge
+
+  - name: Warn on conflicts
+    conditions:
+      - conflict
+    actions:
+      comment:
+        message: "@{{author}}, this pull request is now in conflict and requires a rebase."
+      label:
+        add:
+          - needs-rebase
+  - name: remove conflict label if not needed
+    conditions:
+      - -conflict
+    actions:
+      label:
+        remove:
+          - needs-rebase


### PR DESCRIPTION
Automatically add and remove the `needs-rebase` label on PRs based on conflicts with the base branch. When adding the label, mergify will also post a comment notifying the author that a rebase is required.