### PR TITLE
ci: Don't run build workflow on mergify config changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,7 @@ on:
       - '**/*.md'
       - '**/*.gitignore'
       - '.vscode/**'
+      - '.github/mergify.yml'
   pull_request:
     branches: ["main"]
     # Must stay in sync with the paths in .github/workflows/docs.yml and .github/mergify.yml
@@ -14,6 +15,7 @@ on:
       - '**/*.md'
       - '**/*.gitignore'
       - '.vscode/**'
+      - '.github/mergify.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
If the only thing in a PR is a mergify config change or a config change with associate docs, don't run the build workflow.