### PR TITLE
fix: use the nexd-wireguard-go binary if it can be found on the path.

### DIFF
--- a/internal/nexodus/nexodus.go
+++ b/internal/nexodus/nexodus.go
@@ -31,6 +31,7 @@ const (
 	pollInterval       = 5 * time.Second
 	wgBinary           = "wg"
 	wgGoBinary         = "wireguard-go"
+	nexdWgGoBinary     = "nexd-wireguard-go"
 	wgWinBinary        = "wireguard.exe"
 	WgLinuxConfPath    = "/etc/wireguard/"
 	WgDarwinConfPath   = "/usr/local/etc/wireguard/"

--- a/internal/nexodus/nexodus_darwin.go
+++ b/internal/nexodus/nexodus_darwin.go
@@ -4,6 +4,7 @@ package nexodus
 
 import (
 	"fmt"
+	"os/exec"
 	"strconv"
 
 	"go.uber.org/zap"
@@ -20,7 +21,13 @@ func (ax *Nexodus) setupInterfaceOS() error {
 		deleteDarwinIface(logger, dev)
 	}
 
-	_, err := RunCommand("wireguard-go", dev)
+	// prefer nexd-wireguard-go over wireguard-go since it supports port reuse.
+	wgBinary := wgGoBinary
+	if path, err := exec.LookPath(nexdWgGoBinary); err == nil {
+		wgBinary = path
+	}
+
+	_, err := RunCommand(wgBinary, dev)
 	if err != nil {
 		logger.Errorf("failed to create the %s interface: %v\n", dev, err)
 		return fmt.Errorf("%w", interfaceErr)

--- a/internal/nexodus/utils_darwin.go
+++ b/internal/nexodus/utils_darwin.go
@@ -75,10 +75,10 @@ func defaultTunnelDevOS() string {
 // binaryChecks validate the required binaries are available
 func binaryChecks() error {
 	// Darwin wireguard-go userspace binary
-	if !IsCommandAvailable(wgGoBinary) {
-		return fmt.Errorf("%s command not found, is wireguard installed?", wgGoBinary)
+	if IsCommandAvailable(nexdWgGoBinary) || IsCommandAvailable(wgGoBinary) {
+		return nil
 	}
-	return nil
+	return fmt.Errorf("%s command not found, is wireguard installed?", wgGoBinary)
 }
 
 // prepOS perform OS specific OS changes


### PR DESCRIPTION
The nexd-wireguard-go is known to allow port reuse so that nexd can discover it's external endpoint address using STUN requests.