### PR TITLE
Add linting for GitHub actions workflows

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,23 @@
+name: Lint GitHub Actions workflows
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - '.github/**'
+  pull_request:
+    branches: ["main"]
+    paths:
+      - '.github/**'
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Download actionlint
+        id: get_actionlint
+        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+        shell: bash
+      - name: Check workflow files
+        run: PATH=".:$PATH" make action-lint
+        shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
             echo "Detected uncommitted changes after build.  See status below:"
             git diff
             echo "========================================================"
-            echo "  run `make generate` and commit the changes"
+            echo "  run 'make generate' and commit the changes"
             echo "========================================================"
             exit 1
           fi
@@ -94,7 +94,7 @@ jobs:
         uses: ./.github/actions/setup-go-env
 
       - name: Login to GHCR
-        run: echo "${{ github.token }}" | docker login https://ghcr.io -u ${GITHUB_ACTOR} --password-stdin
+        run: echo "${{ github.token }}" | docker login https://ghcr.io -u "${GITHUB_ACTOR}" --password-stdin
 
       - name: Check Kube Manifests
         run: |
@@ -366,7 +366,7 @@ jobs:
         id: build-rpm
         run: |
           make rpm
-          echo "artifact-name=$(pwd)/dist/rpm/mock/nexodus-*.x86_64.rpm" >> $GITHUB_OUTPUT
+          echo "artifact-name=$(pwd)/dist/rpm/mock/nexodus-*.x86_64.rpm" >> "$GITHUB_OUTPUT"
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -139,7 +139,6 @@ jobs:
           outputs: type=docker,dest=/tmp/${{ matrix.name }}.tar
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          target: ${{ matrix.target }}
 
       - name: Upload ${{ matrix.name }} artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -85,34 +85,34 @@ jobs:
       - name: Calculate Short SHA
         id: gitsha
         run: |
-          echo "short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+          echo "short=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Set up Kustomize
         run: |
-          mkdir -p $HOME/.local/bin
-          pushd $HOME/.local/bin
+          mkdir -p "$HOME/.local/bin"
+          pushd "$HOME/.local/bin"
           curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash -s 4.5.7
           popd
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Update QA Images
         run: |
           pushd ./deploy/nexodus/overlays/released
-          kustomize edit set image quay.io/nexodus/apiserver:${GITHUB_SHA}
-          kustomize edit set image quay.io/nexodus/frontend:${GITHUB_SHA}
-          kustomize edit set image quay.io/nexodus/go-ipam:${GITHUB_SHA}
-          kustomize edit set image quay.io/nexodus/envsubst:${GITHUB_SHA}
+          kustomize edit set image "quay.io/nexodus/apiserver:${GITHUB_SHA}"
+          kustomize edit set image "quay.io/nexodus/frontend:${GITHUB_SHA}"
+          kustomize edit set image "quay.io/nexodus/go-ipam:${GITHUB_SHA}"
+          kustomize edit set image "quay.io/nexodus/envsubst:${GITHUB_SHA}"
           yq -i kustomization.yaml
           popd
 
       - name: Check for changes
         run: |
-          git diff --quiet || echo "COMMIT_CHANGES=1" >> $GITHUB_ENV
+          git diff --quiet || echo "COMMIT_CHANGES=1" >> "$GITHUB_ENV"
 
       - name: Check for new commits in main
         run: |
           git fetch origin
-          if [ "$(git log HEAD..origin/main --oneline | wc -l)" != "0" ]; then echo "COMMIT_CHANGES=0"; fi >> $GITHUB_ENV
+          if [ "$(git log HEAD..origin/main --oneline | wc -l)" != "0" ]; then echo "COMMIT_CHANGES=0"; fi >> "$GITHUB_ENV"
 
       - name: Commit Changes
         id: commit
@@ -153,8 +153,8 @@ jobs:
       - id: go-cache-paths
         shell: bash
         run: |
-          echo "go-build=$(go env GOCACHE)" >> $GITHUB_OUTPUT
-          echo "go-mod=$(go env GOMODCACHE)" >> $GITHUB_OUTPUT
+          echo "go-build=$(go env GOCACHE)" >> "$GITHUB_OUTPUT"
+          echo "go-mod=$(go env GOMODCACHE)" >> "$GITHUB_OUTPUT"
 
       - name: Go Build Cache
         uses: actions/cache@v3
@@ -178,5 +178,5 @@ jobs:
       - name: Submit srpm to copr
         run: |
           echo "${{ secrets.COPR_CONFIG }}" > ~/.config/copr
-          docker run --name copr-cli -v $(pwd):/nexodus -v ~/.config:/root/.config quay.io/nexodus/mock:latest \
-              copr-cli build nexodus -r ${{ matrix.mock_root }} --nowait /nexodus/dist/rpm/mock/nexodus-0-0.1.$(date +%Y%m%d)git$(git describe --always).${{ matrix.srpm_distro }}.src.rpm
+          docker run --name copr-cli -v "$(pwd):/nexodus" -v ~/.config:/root/.config quay.io/nexodus/mock:latest \
+              copr-cli build nexodus -r "${{ matrix.mock_root }}" --nowait "/nexodus/dist/rpm/mock/nexodus-0-0.1.$(date +%Y%m%d)git$(git describe --always).${{ matrix.srpm_distro }}.src.rpm"

--- a/.github/workflows/qa-dev.yml
+++ b/.github/workflows/qa-dev.yml
@@ -45,9 +45,9 @@ jobs:
         id: check_pr
         run: |
           if [[ "${{ github.event.inputs.pr_or_branch }}" =~ ^[0-9]+$ ]]; then
-            echo "is_pr=true" >> $GITHUB_OUTPUT
+            echo "is_pr=true" >> "$GITHUB_OUTPUT"
           else
-            echo "is_pr=false" >> $GITHUB_OUTPUT
+            echo "is_pr=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Fetch and checkout PR

--- a/.github/workflows/qa-scale.yml
+++ b/.github/workflows/qa-scale.yml
@@ -45,9 +45,9 @@ jobs:
         id: check_pr
         run: |
           if [[ "${{ github.event.inputs.pr_or_branch }}" =~ ^[0-9]+$ ]]; then
-            echo "is_pr=true" >> $GITHUB_OUTPUT
+            echo "is_pr=true" >> "$GITHUB_OUTPUT"
           else
-            echo "is_pr=false" >> $GITHUB_OUTPUT
+            echo "is_pr=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Fetch and checkout PR
@@ -86,7 +86,7 @@ jobs:
             -u qa \
             -p "${{ secrets.QA_USER_PASSWORD }}" \
             https://auth.qa.nexodus.io)
-          echo "USER=$output" >> $GITHUB_OUTPUT
+          echo "USER=$output" >> "$GITHUB_OUTPUT"
 
       - name: User results from Keycloak
         run: echo "User is ${{ steps.kc-user.outputs.USER }}"


### PR DESCRIPTION
- Makefile: Add action-lint target
- actions: Remove unused line in actions workflow
- ci: Fix shellcheck wranings
- ci: Add workflow to lint github action workflow config

Closes #909 

commit 3e1fccb124b5f5d2982fdfa0d3b4d41a3290aefa
Author: Russell Bryant <russell.bryant@gmail.com>
Date:   Mon Apr 24 22:19:46 2023 -0400

    Makefile: Add action-lint target
    
    This target runs the `actionlint` tool to lint our github action
    workflows. Find more about `actionlint` here:
    
    https://github.com/rhysd/actionlint
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>

commit f7bc42744a5d38a375a7b53fdf0e5801624e2823
Author: Russell Bryant <russell.bryant@gmail.com>
Date:   Mon Apr 24 22:15:09 2023 -0400

    actions: Remove unused line in actions workflow
    
    actionlint pointed out that nothing sets `target`, so this line can
    just be removed as it's never set to anything.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>

commit 25ec5bf44ca1df30a9d9ccdd0de46d070522d10f
Author: Russell Bryant <russell.bryant@gmail.com>
Date:   Tue Apr 25 10:31:59 2023 -0400

    ci: Fix shellcheck wranings
    
    actionlint runs shellcheck on shell code embedded in github action
    workflows. This patch fixes all issues identified by shellcheck. Most
    of it was about using quotes to ensure there is not unintended word
    splitting after evaluating a variable or expression.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>

commit 91544839ea64a18efc82cb7f4432c13069c0a8b7
Author: Russell Bryant <russell.bryant@gmail.com>
Date:   Mon Apr 24 22:21:58 2023 -0400

    ci: Add workflow to lint github action workflow config
    
    This uses the `actionlint` tool that can be found here:
    
    https://github.com/rhysd/actionlint
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>
