### PR TITLE
deploy/monitoring: Stack of (speculative) changes required to get monitoring working in ROSA

### DIFF
--- a/deploy/nexodus-client/overlays/dev/kustomization.yaml.sample
+++ b/deploy/nexodus-client/overlays/dev/kustomization.yaml.sample
@@ -15,7 +15,7 @@ commonLabels:
   app.kubernetes.io/component: nexodus-client
   app.kubernetes.io/instance: nexodus-client
   app.kubernetes.io/name: nexodus-client
-patchesJson6902:
+patches:
   - target:
       kind: DaemonSet
       name: nexodus

--- a/deploy/nexodus-client/overlays/sample/kustomization.yaml.sample
+++ b/deploy/nexodus-client/overlays/sample/kustomization.yaml.sample
@@ -15,7 +15,7 @@ commonLabels:
   app.kubernetes.io/component: nexodus-client
   app.kubernetes.io/instance: nexodus-client
   app.kubernetes.io/name: nexodus-client
-patchesJson6902:
+patches:
   - target:
       kind: DaemonSet
       name: nexodus

--- a/deploy/nexodus-monitoring/base/apiproxy-service-monitor.yaml
+++ b/deploy/nexodus-monitoring/base/apiproxy-service-monitor.yaml
@@ -2,6 +2,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: apiproxy
+  namespace: nexodus-monitoring
   labels:
     team: nexodus
 spec:

--- a/deploy/nexodus-monitoring/base/apiserver-service-monitor.yaml
+++ b/deploy/nexodus-monitoring/base/apiserver-service-monitor.yaml
@@ -4,6 +4,7 @@ metadata:
   name: apiserver
   labels:
     team: nexodus
+  namespace: nexodus-monitoring
 spec:
   namespaceSelector:
     matchNames:

--- a/deploy/nexodus-monitoring/base/grafana-dashboard.yaml
+++ b/deploy/nexodus-monitoring/base/grafana-dashboard.yaml
@@ -4,6 +4,7 @@ metadata:
   name: simple-dashboard
   labels:
     app: grafana
+  namespace: nexodus-monitoring
 spec:
   resyncPeriod: 30s
   instanceSelector:

--- a/deploy/nexodus-monitoring/base/grafana-datasource.yaml
+++ b/deploy/nexodus-monitoring/base/grafana-datasource.yaml
@@ -2,6 +2,7 @@ apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDatasource
 metadata:
   name: nexodus-grafanadatasource
+  namespace: nexodus-monitoring
 spec:
   instanceSelector:
     matchLabels:

--- a/deploy/nexodus-monitoring/base/grafana.yaml
+++ b/deploy/nexodus-monitoring/base/grafana.yaml
@@ -2,6 +2,7 @@ apiVersion: grafana.integreatly.org/v1beta1
 kind: Grafana
 metadata:
   name: nexodus-grafana
+  namespace: nexodus-monitoring
   labels:
     dashboards: "nexodus"
 spec:

--- a/deploy/nexodus-monitoring/base/jaeger.yaml
+++ b/deploy/nexodus-monitoring/base/jaeger.yaml
@@ -2,6 +2,7 @@ apiVersion: jaegertracing.io/v1
 kind: Jaeger
 metadata:
   name: jaeger
+  namespace: nexodus-monitoring
 spec:
   ingress:
     enabled: true

--- a/deploy/nexodus-monitoring/base/kustomization.yaml
+++ b/deploy/nexodus-monitoring/base/kustomization.yaml
@@ -1,6 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: nexodus-monitoring
 resources:
   - apiproxy-service-monitor.yaml
   - apiserver-service-monitor.yaml

--- a/deploy/nexodus-monitoring/base/prometheus-service.yaml
+++ b/deploy/nexodus-monitoring/base/prometheus-service.yaml
@@ -1,3 +1,8 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: prometheus
+---
 apiVersion: monitoring.coreos.com/v1
 kind: Prometheus
 metadata:

--- a/deploy/nexodus-monitoring/base/prometheus-service.yaml
+++ b/deploy/nexodus-monitoring/base/prometheus-service.yaml
@@ -16,20 +16,3 @@ spec:
     requests:
       memory: 400Mi
   enableAdminAPI: false
----
-apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
-  name: prometheus
-spec:
-  rules:
-    - host: "prometheus.127.0.0.1.nip.io"
-      http:
-        paths:
-          - pathType: Prefix
-            path: "/"
-            backend:
-              service:
-                name: prometheus-operated
-                port:
-                  number: 9090

--- a/deploy/nexodus-monitoring/base/prometheus-service.yaml
+++ b/deploy/nexodus-monitoring/base/prometheus-service.yaml
@@ -2,11 +2,13 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: prometheus
+  namespace: nexodus-monitoring
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: Prometheus
 metadata:
   name: prometheus
+  namespace: nexodus-monitoring
 spec:
   serviceAccountName: prometheus
   serviceMonitorSelector:

--- a/deploy/nexodus-monitoring/overlays/dev/kustomization.yaml
+++ b/deploy/nexodus-monitoring/overlays/dev/kustomization.yaml
@@ -3,4 +3,5 @@ kind: Kustomization
 namespace: nexodus-monitoring
 resources:
   - prometheus-rbac.yaml
+  - prometheus-ingress.yaml
   - ../../base

--- a/deploy/nexodus-monitoring/overlays/dev/kustomization.yaml
+++ b/deploy/nexodus-monitoring/overlays/dev/kustomization.yaml
@@ -1,6 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: nexodus-monitoring
 resources:
   - prometheus-rbac.yaml
   - prometheus-ingress.yaml

--- a/deploy/nexodus-monitoring/overlays/dev/prometheus-rbac.yaml
+++ b/deploy/nexodus-monitoring/overlays/dev/prometheus-rbac.yaml
@@ -1,8 +1,3 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: prometheus
----
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/deploy/nexodus-monitoring/overlays/dev/prometheus-rbac.yaml
+++ b/deploy/nexodus-monitoring/overlays/dev/prometheus-rbac.yaml
@@ -2,6 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: prometheus
+  namespace: nexodus-monitoring
 rules:
   - apiGroups: [""]
     resources:

--- a/deploy/nexodus-monitoring/overlays/dev/promtheus-ingress.yaml
+++ b/deploy/nexodus-monitoring/overlays/dev/promtheus-ingress.yaml
@@ -1,0 +1,16 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: prometheus
+spec:
+  rules:
+    - host: "prometheus.127.0.0.1.nip.io"
+      http:
+        paths:
+          - pathType: Prefix
+            path: "/"
+            backend:
+              service:
+                name: prometheus-operated
+                port:
+                  number: 9090

--- a/deploy/nexodus-monitoring/overlays/dev/promtheus-ingress.yaml
+++ b/deploy/nexodus-monitoring/overlays/dev/promtheus-ingress.yaml
@@ -2,6 +2,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: prometheus
+  namespace: nexodus-monitoring
 spec:
   rules:
     - host: "prometheus.127.0.0.1.nip.io"

--- a/deploy/nexodus-monitoring/overlays/rosa/apiproxy-service-monitor.yaml
+++ b/deploy/nexodus-monitoring/overlays/rosa/apiproxy-service-monitor.yaml
@@ -2,6 +2,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: qa-apiproxy
+  namespace: nexodus-monitoring
   labels:
     team: nexodus
 spec:

--- a/deploy/nexodus-monitoring/overlays/rosa/apiserver-service-monitor.yaml
+++ b/deploy/nexodus-monitoring/overlays/rosa/apiserver-service-monitor.yaml
@@ -2,6 +2,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: qa-apiserver
+  namespace: nexodus-monitoring
   labels:
     team: nexodus
 spec:

--- a/deploy/nexodus-monitoring/overlays/rosa/kustomization.yaml
+++ b/deploy/nexodus-monitoring/overlays/rosa/kustomization.yaml
@@ -5,4 +5,10 @@ resources:
   - ../../base
   - apiproxy-service-monitor.yaml
   - apiserver-service-monitor.yaml
-# TODO: Add patches to override the URLs in ROSA
+patchesJson6902:
+  - target:
+      kind: Jaeger
+      name: jaeger
+    patch: |-
+      - op: remove
+        path: /spec/ingress/hosts

--- a/deploy/nexodus-monitoring/overlays/rosa/kustomization.yaml
+++ b/deploy/nexodus-monitoring/overlays/rosa/kustomization.yaml
@@ -5,7 +5,7 @@ resources:
   - apiproxy-service-monitor.yaml
   - apiserver-service-monitor.yaml
   - prometheus-rbac.yaml
-patchesJson6902:
+patches:
   - target:
       kind: Jaeger
       name: jaeger

--- a/deploy/nexodus-monitoring/overlays/rosa/kustomization.yaml
+++ b/deploy/nexodus-monitoring/overlays/rosa/kustomization.yaml
@@ -1,10 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: nexodus-monitoring
 resources:
   - ../../base
   - apiproxy-service-monitor.yaml
   - apiserver-service-monitor.yaml
+  - prometheus-rbac.yaml
 patchesJson6902:
   - target:
       kind: Jaeger

--- a/deploy/nexodus-monitoring/overlays/rosa/prometheus-rbac.yaml
+++ b/deploy/nexodus-monitoring/overlays/rosa/prometheus-rbac.yaml
@@ -4,9 +4,9 @@ metadata:
   name: prometheus-nexodus
   namespace: nexodus
 subjects:
-- kind: ServiceAccount
-  name: prometheus
-  namespace: nexodus-monitoring
+  - kind: ServiceAccount
+    name: prometheus
+    namespace: nexodus-monitoring
 roleRef:
   kind: ClusterRole
   name: prometheus-monitoring
@@ -18,9 +18,9 @@ metadata:
   name: prometheus-nexodus-qa
   namespace: nexodus-qa
 subjects:
-- kind: ServiceAccount
-  name: prometheus
-  namespace: nexodus-monitoring
+  - kind: ServiceAccount
+    name: prometheus
+    namespace: nexodus-monitoring
 roleRef:
   kind: ClusterRole
   name: prometheus-monitoring

--- a/deploy/nexodus-monitoring/overlays/rosa/prometheus-rbac.yaml
+++ b/deploy/nexodus-monitoring/overlays/rosa/prometheus-rbac.yaml
@@ -1,0 +1,27 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: prometheus-nexodus
+  namespace: nexodus
+subjects:
+- kind: ServiceAccount
+  name: prometheus
+  namespace: nexodus-monitoring
+roleRef:
+  kind: ClusterRole
+  name: prometheus-monitoring
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: prometheus-nexodus-qa
+  namespace: nexodus-qa
+subjects:
+- kind: ServiceAccount
+  name: prometheus
+  namespace: nexodus-monitoring
+roleRef:
+  kind: ClusterRole
+  name: prometheus-monitoring
+  apiGroup: rbac.authorization.k8s.io

--- a/deploy/nexodus/overlays/dev/kustomization.yaml
+++ b/deploy/nexodus/overlays/dev/kustomization.yaml
@@ -12,7 +12,7 @@ configMapGenerator:
     literals:
       - NEXAPI_FFLAG_MULTI_ORGANIZATION=true
     name: apiserver
-patchesJson6902:
+patches:
   - target:
       kind: Ingress
       name: apiproxy

--- a/deploy/nexodus/overlays/prod/kustomization.yaml
+++ b/deploy/nexodus/overlays/prod/kustomization.yaml
@@ -31,7 +31,7 @@ configMapGenerator:
       - NEXAPI_REDIRECT_URL=https://try.nexodus.io/#/login
       - NEXAPI_ORIGINS=https://try.nexodus.io
 
-patchesJson6902:
+patches:
   - patch: |-
       - op: replace
         path: /spec/rules/0/host

--- a/deploy/nexodus/overlays/qa/kustomization.yaml
+++ b/deploy/nexodus/overlays/qa/kustomization.yaml
@@ -30,7 +30,7 @@ configMapGenerator:
       - NEXAPI_REDIRECT_URL=https://qa.nexodus.io/#/login
       - NEXAPI_ORIGINS=https://qa.nexodus.io
     name: apiserver
-patchesJson6902:
+patches:
   - patch: |-
       - op: replace
         path: /spec/rules/0/host

--- a/deploy/nexodus/overlays/released/kustomization.yaml
+++ b/deploy/nexodus/overlays/released/kustomization.yaml
@@ -8,7 +8,7 @@ resources:
 # - ../../components/monitoring
 components:
   - ../../components/limitador
-# patchesJson6902:
+# patches:
 #   - patch: |-
 #       - op: replace
 #         path: /data/NEXAPI_TRACE_ENDPOINT_OTLP


### PR DESCRIPTION
This PR:

1. Splits out the prometheus RBAC config for dev and rosa
1. Removes Ingresses in ROSA (for now) since somehow Grafana is made available through an openshiftapps.com route
1. Fixes a deprecation warning from kustomize