### PR TITLE
mergify: Enforce actionlint check

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -22,6 +22,13 @@ pull_request_rules:
       - or:
         - label=has-docs
         - label=no-docs-required
+      # If files are changed in .github/, the actionlint check must pass
+      - or:
+        - and:
+          # regex should match the one in .github/workflows/actionlint.yml
+          - files~=.github/.*$
+          - check-success=actionlint
+        - -files~=.github/.*$
       - or:
         # PRs that include doc changes should also pass the markdown-lint check
         - and:

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches: ["main"]
     paths:
+      # This regex should match the one used for mergify policy in .github/mergify.yml
       - '.github/**'
 
 jobs:


### PR DESCRIPTION
When the github actions config is changed, enforce that the `actionlint` check was successful before automatically merging the PR.