### PR TITLE
deploy: Use RollingUpdate for Nexodus components

### DIFF
--- a/deploy/nexodus/base/apiproxy/deployment.yaml
+++ b/deploy/nexodus/base/apiproxy/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   replicas: 1
   strategy:
-    type: Recreate
+    type: RollingUpdate
   template:
     spec:
       initContainers:

--- a/deploy/nexodus/base/apiserver/deployment.yaml
+++ b/deploy/nexodus/base/apiserver/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   replicas: 1
   strategy:
-    type: Recreate
+    type: RollingUpdate
   template:
     spec:
       containers:

--- a/deploy/nexodus/base/frontend/deployment.yaml
+++ b/deploy/nexodus/base/frontend/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   replicas: 1
   strategy:
-    type: Recreate
+    type: RollingUpdate
   template:
     spec:
       containers:


### PR DESCRIPTION
Keycloak has to use Recreate, or the realm import won't work.
go-ipam is unknown, but we don't redeploy very often at all so it won't hurt.