### PR TITLE
rpm: Drop f37 support

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -137,8 +137,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - mock_root: fedora-37-x86_64
-            srpm_distro: fc37
           - mock_root: fedora-38-x86_64
             srpm_distro: fc38
     steps:

--- a/Makefile
+++ b/Makefile
@@ -601,7 +601,9 @@ cacerts: ## Install the Self-Signed CA Certificate
 dist/rpm:
 	$(CMD_PREFIX) mkdir -p dist/rpm
 
-MOCK_ROOTS:=fedora-37-x86_64 fedora-38-x86_64
+#Uncomment once f39 is on copr
+#MOCK_ROOTS:=fedora-38-x86_64 fedora-39-x86_64
+MOCK_ROOTS:=fedora-38-x86_64
 MOCK_DEPS:=golang systemd-rpm-macros systemd-units
 
 .PHONY: image-mock
@@ -621,8 +623,8 @@ image-mock: ## Build and publish updated mock images to quay.io used for buildin
 		docker push quay.io/nexodus/mock:$$MOCK_ROOT ; \
 	done
 
-MOCK_ROOT?=fedora-37-x86_64
-SRPM_DISTRO?=fc37
+MOCK_ROOT?=fedora-38-x86_64
+SRPM_DISTRO?=fc38
 
 .PHONY: srpm
 srpm: dist/rpm manpages ## Build a source RPM

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -6,6 +6,10 @@ This guide will walk you through getting your first devices connected via Nexodu
 
 ### Fedora
 
+!!! note "Minimum Release Version"
+
+    Fedora 38 is the minimum release version supported by this copr repository.
+
 ```sh
 # Enable the COPR repository and install the nexodus package
 sudo dnf copr enable russellb/nexodus

--- a/docs/user-guide/agent.md
+++ b/docs/user-guide/agent.md
@@ -8,6 +8,10 @@ The following sections contain general instructions to deploy the Nexodus agent 
 
 #### Fedora - RPM
 
+!!! note "Minimum Release Version"
+
+    Fedora 38 is the minimum release version supported by this copr repository.
+
 A Fedora [Copr repository](https://copr.fedorainfracloud.org/coprs/russellb/nexodus/) is updated with new rpms after each new commit to the `main` branch that passes CI. The rpm will include `nexctl`, `nexd`, and integration with systemd.
 
 You can add this repository to your Fedora host with the following command:


### PR DESCRIPTION
Fedora 38 is now GA and includes Go 1.20. Update to f38 as our minimum
version so that we can require Go 1.20.

Closes #916

Signed-off-by: Russell Bryant <rbryant@redhat.com>
