### PR TITLE
mergify: Add tests checklist item via label enforcement

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -22,6 +22,9 @@ pull_request_rules:
       - or:
         - label=has-docs
         - label=no-docs-required
+      - or:
+        - label=has-tests
+        - label=no-tests-required
       # If files are changed in .github/, the actionlint check must pass
       - or:
         - and:
@@ -102,3 +105,22 @@ pull_request_rules:
       label:
         remove:
           - missing-design-label
+
+  # Give a hint via label when no tests label has been applied
+  - name: Label when tests label is missing
+    conditions:
+      - -label=has-tests
+      - -label=no-tests-required
+    actions:
+      label:
+        add:
+          - missing-tests-label
+  - name: Remove label when tests label is present
+    conditions:
+      - or:
+        - label=has-tests
+        - label=no-tests-required
+    actions:
+      label:
+        remove:
+          - missing-tests-label

--- a/docs/development/pull-requests.md
+++ b/docs/development/pull-requests.md
@@ -24,6 +24,7 @@ Use the GitHub reviewers field to request reviews from a specific individual. Be
 * The `hold` label must not be present on the PR. Ensure that whoever added the `hold` is OK with removing the label before the PR is merged. There is no timeout on the `hold` label for when someone else should remove it unless the reviewer who placed the hold is unavailable for a significant period.
 * PRs must have either the `has-design` or `no-design-requied` label applied. This is to confirm that a design document has been produced if appropriate.
 * PRs must have either the `has-docs` or `no-docs-required` label applied. This is to confirm that user-facing documentation has been produced if appropriate.
+* PRs must have either the `has-tests` or `no-tests-required` label applied. This is to confirm that tests have been produced if appropriate.
 
 We use [Mergify](https://mergify.io/) to automatically merge PRs that meet the above criteria. See the [Mergify configuration](https://github.com/nexodus-io/nexodus/blob/main/.github/mergify.yml) for more details.
 


### PR DESCRIPTION
Ensure test coverage is either present or not required by using label
enforcement in the same way as is done for user docs and design docs.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
