### PR TITLE
nexd: Reduce error logs

### DIFF
--- a/internal/nexodus/nexodus.go
+++ b/internal/nexodus/nexodus.go
@@ -457,7 +457,14 @@ func (ax *Nexodus) reconcileDevices(ctx context.Context, options []client.Option
 	if err = ax.Reconcile(false); err == nil {
 		return
 	}
-	// TODO: Add smarter reconciliation logic
+
+	var dnsErr *net.DNSError
+	if errors.As(err, &dnsErr) && dnsErr.Temporary() {
+		// Temporary dns resolution failure is normal, just debug log it
+		ax.logger.Debugf("%v", err)
+		return
+	}
+
 	ax.logger.Errorf("Failed to reconcile state with the nexodus API server: %v", err)
 
 	// if the token grant becomes invalid expires refresh or exit depending on the onboard method


### PR DESCRIPTION
- nexd: Reduce nesting in reconcileDevices()
- nexd: Make temporary dns failures a debug log instead of error


commit b27133ab9bfbef5cb2ade557beb45cfbea363e90
Author: Russell Bryant <russell.bryant@gmail.com>
Date:   Thu Apr 27 22:02:38 2023 -0400

    nexd: Reduce nesting in reconcileDevices()
    
    Reduce the nesting a few levels in this method to make the flow easier
    to follow.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>

commit d4b9c2773653426367727f803991fe7a6a06c144
Author: Russell Bryant <russell.bryant@gmail.com>
Date:   Thu Apr 27 22:12:54 2023 -0400

    nexd: Make temporary dns failures a debug log instead of error
    
    When nexd has a temporary failure to resolve DNS for the api server,
    just log it to debug instead of error. This is a normal, expected
    condition to hit periodically. In my case, I run `nexd` on my laptop,
    and I get this message a lot in my logs when moving aronud, suspending
    and resuming, and connecting to different networks.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>
