### PR TITLE
Makefile: Fix file permissions for gen-openapi-client

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -244,14 +244,15 @@ gen-openapi-client: internal/api/public/client.go ## Generate the OpenAPI Client
 internal/api/public/client.go: internal/docs/swagger.yaml | dist
 	$(ECHO_PREFIX) printf "  %-12s internal/docs/swagger.yaml\n" "[OPENAPI CLIENT GEN]"
 	$(CMD_PREFIX) rm -f $(shell find internal/api/public | grep .go | grep -v _custom.go)
-	$(CMD_PREFIX) docker run --rm -v $(CURDIR):/src openapitools/openapi-generator-cli:v6.5.0 \
+	$(CMD_PREFIX) docker run --rm -v $(CURDIR):/src --user $(shell id -u):$(shell id -g) \
+		openapitools/openapi-generator-cli:v6.5.0 \
 		generate -i /src/internal/docs/swagger.yaml -g go \
 		--package-name public \
 		-o /src/internal/api/public \
 		-t /src/hack/openapi-templates \
 		--ignore-file-override /src/.openapi-generator-ignore $(PIPE_DEV_NULL)
 	$(ECHO_PREFIX) printf "  %-12s ./...\n" "[GO FMT]"
-	$(CMD_PREFIX) [ -z "$(shell gofmt -l .)" ] || gofmt -w .
+	$(CMD_PREFIX) [ -z "$$(gofmt -l .)" ] || gofmt -w .
 
 internal/api/public/%.go: internal/api/public/client.go
 


### PR DESCRIPTION
I ran into two issues with `make gen-openapi-client`. First, the
generated files would be owned by root, causing errors when trying to
reformat the files later. The fix for this is to add `--user` to the
docker command so it users the same user and group IDs as the user
running `make`.

The file permission errors were confusing, because I would see them
later, not during `gen-openapi-client`.

The Makefile tried to reformat the files within the `gen-openapi-client`
target, but it didn't actually work. make was evaluating
 `$(shell gofmt -l .)` prior to the code being generated, so the check
to see if this was empty was wrong. Instead, we need the command to run
by the underlying shell when make gets to that line of execution.

For me, what this meant was that every time `gen-openapi-client` would
run, it would claim success, but leave unformatted files owned by root
left behind.

This change addresses both file permissions, but also reformatting the
files when we think they are being reformatted.

Closes #933

Signed-off-by: Russell Bryant <rbryant@redhat.com>
