### PR TITLE
ci: Use go 1.20 in publish-rpms

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -143,10 +143,8 @@ jobs:
       - uses: actions/checkout@v3
 
       # Needed for building binaries to generate manpages
-      - name: Set up Go
-        uses: actions/setup-go@v4
-        with:
-          go-version: "1.19"
+      - name: Setup Go
+        uses: ./.github/actions/setup-go-env
 
       - id: go-cache-paths
         shell: bash


### PR DESCRIPTION
Use the common Go env setup for the publish-rpms job. It was still
using Go 1.19, so rpm builds were broken.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
