### PR TITLE
ci: Remove more steps from publish-rpms

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -146,31 +146,15 @@ jobs:
       - name: Setup Go
         uses: ./.github/actions/setup-go-env
 
-      - id: go-cache-paths
-        shell: bash
-        run: |
-          echo "go-build=$(go env GOCACHE)" >> "$GITHUB_OUTPUT"
-          echo "go-mod=$(go env GOMODCACHE)" >> "$GITHUB_OUTPUT"
-
-      - name: Go Build Cache
-        uses: actions/cache@v3
-        with:
-          path: ${{ steps.go-cache-paths.outputs.go-build }}
-          key: ${{ runner.os }}-go-build-${{ hashFiles('**/go.sum') }}
-
-      - name: Go Mod Cache
-        uses: actions/cache@v3
-        with:
-          path: ${{ steps.go-cache-paths.outputs.go-mod }}
-          key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
-
       - name: Install make
         run: |
           sudo apt -y install make
+
       - name: Build srpm
         run: |
           MOCK_ROOT="${{ matrix.mock_root }}" make srpm
           find dist
+
       - name: Submit srpm to copr
         run: |
           echo "${{ secrets.COPR_CONFIG }}" > ~/.config/copr


### PR DESCRIPTION
Now that this job is using our custom go setup action, there's more that
can be removed since it's already taken care of.

Signed-off-by: Russell Bryant <russell.bryant@gmail.com>
