### PR TITLE
Support running as a daemon on Mac

### DIFF
--- a/contrib/mac/io.nexodus.nexd.plist
+++ b/contrib/mac/io.nexodus.nexd.plist
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>Label</key>
+    <string>io.nexodus.nexd</string>
+
+    <key>ProgramArguments</key>
+    <array>
+      <string>/usr/local/bin/nexd</string>
+      <string>https://try.nexodus.io</string>
+    </array>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>UserName</key>
+    <string>root</string>
+
+    <key>KeepAlive</key>
+    <true/>
+
+    <key>StandardOutPath</key>
+    <string>/var/log/nexd-stdout.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>/var/log/nexd-stderr.log</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+      <key>PATH</key>
+      <string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    </dict>
+  </dict>
+</plist>
+

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -38,10 +38,16 @@ brew tap nexodus-io/nexodus
 brew install nexodus
 ```
 
-Start `nexd` with `sudo` and follow the instructions to register your device.
+To start the `nexd` agent and also have it start automatically on boot, run:
 
 ```sh
-sudo nexd https://try.nexodus.io
+sudo brew services start nexodus
+```
+
+Query the status of `nexd` and follow the instructions to register your device.
+
+```sh
+sudo nexctl nexd status
 ```
 
 ### Other

--- a/docs/user-guide/agent.md
+++ b/docs/user-guide/agent.md
@@ -48,23 +48,16 @@ brew tap nexodus-io/nexodus
 brew install nexodus
 ```
 
-Start the agent with the following command:
+To start the `nexd` agent and also have it start automatically on boot, run:
 
 ```sh
-sudo nexd https://try.nexodus.io
+sudo brew services start nexodus
 ```
 
-It is also possible to run `nexd` as a daemon using `launchd`. To do so, download `io.nexodus.nexd.plist` and place it in the `/Library/LaunchDaemons/` directory. Edit the file if you need to customize the arguments passed to `nexd`.
+To stop the `nexd` agent, run:
 
 ```sh
-curl https://raw.githubusercontent.com/nexodus-io/nexodus/main/contrib/mac/io.nexodus.nexd.plist -o io.nexodus.nexd.plist
-sudo mv io.nexodus.nexd.plist /Library/LaunchDaemons/
-```
-
-Then, start the agent with the following command:
-
-```sh
-sudo launchctl load /Library/LaunchDaemons/io.nexodus.nexd.plist
+sudo brew services stop nexodus
 ```
 
 ### Binary Downloads

--- a/docs/user-guide/agent.md
+++ b/docs/user-guide/agent.md
@@ -27,7 +27,19 @@ Then you should be able to install Nexodus with:
 sudo dnf install nexodus
 ```
 
-#### Mac - Brew
+You can start `nexd` as a systemd service. First, edit `/etc/sysconfig/nexodus` to reflect the URL of the Nexodus service or add any additional command line arguments to `nexd`. Then, start the agent with the following command:
+
+```sh
+sudo systemctl start nexodus
+```
+
+If you would like `nexd` to run automatically on boot, run this command as well:
+
+```sh
+sudo systemctl enable nexodus
+```
+
+### Mac - Brew
 
 For Mac, you can install the Nexodus Agent via [Homebrew](https://brew.sh/).
 
@@ -36,9 +48,15 @@ brew tap nexodus-io/nexodus
 brew install nexodus
 ```
 
-#### Binary Downloads
+Start the agent with the following command:
 
-Download the latest release package for your OS and architecture. Each release includes a `nexd` binary and a `nexctl` binary.
+```sh
+sudo nexd https://try.nexodus.io
+```
+
+### Binary Downloads
+
+You can download the latest release package for your OS and architecture. Each release includes a `nexd` binary and a `nexctl` binary.
 
 - [Linux x86-64](https://nexodus-io.s3.amazonaws.com/qa/nexodus-linux-amd64.tar.gz)
 - [Linux arm64](https://nexodus-io.s3.amazonaws.com/qa/nexodus-linux-arm64.tar.gz)
@@ -55,53 +73,10 @@ cd nexodus-linux-amd64
 sudo install -m 755 nexd nexctl /usr/local/bin
 ```
 
-#### Custom RPM Build
-
-You can also build a custom rpm from the git repository. You must have `mock` installed to build the package.
+Proceed by starting `nexd` manually:
 
 ```sh
-make rpm
-```
-
-After running this command, the resulting rpm can be found in `./dist/rpm/mock/`.
-
-To install the rpm, you may use `dnf`.
-
-```sh
-sudo dnf install ./dist/rpm/mock/nexodus-0-0.1.20230216git068fedd.fc37.src.rpm
-```
-
-#### Systemd
-
-If you did not install `nexd` via the rpm, you can still use the systemd integration if you would like. The following commands will put the files in the right place.
-
-```sh
-sudo cp contrib/rpm/nexodus.service /usr/lib/systemd/service/nexodus.service
-sudo cp contrib/rpm/nexodus.sysconfig /etc/sysconfig/nexodus
-sudo systemctl daemon-reload
-```
-
-#### Starting the Agent
-
-> **Note**
-> In a self-signed dev environment, each agent machine needs to have the [imported cert](../deployment/nexodus-service.md#https) and the [host entry](../deployment/nexodus-service.md#add-required-dns-entries) detailed above.
-
-You may start `nexd` directly. You must include the URL to the Nexodus service as an argument.
-
-```sh
-sudo nexd https://try.nexodus.127.0.0.1.nip.io
-```
-
-Alternatively, you can start `nexd` as a systemd service. First, edit `/etc/sysconfig/nexodus` to reflect the URL of the Nexodus service. Then, start the agent with the following command:
-
-```sh
-sudo systemctl start nexodus
-```
-
-If you would like `nexd` to run automatically on boot, run this command as well:
-
-```sh
-sudo systemctl enable nexodus
+sudo nexd https://try.nexodus.io
 ```
 
 ### Interactive Enrollment

--- a/docs/user-guide/agent.md
+++ b/docs/user-guide/agent.md
@@ -54,6 +54,19 @@ Start the agent with the following command:
 sudo nexd https://try.nexodus.io
 ```
 
+It is also possible to run `nexd` as a daemon using `launchd`. To do so, download `io.nexodus.nexd.plist` and place it in the `/Library/LaunchDaemons/` directory. Edit the file if you need to customize the arguments passed to `nexd`.
+
+```sh
+curl https://raw.githubusercontent.com/nexodus-io/nexodus/main/contrib/mac/io.nexodus.nexd.plist -o io.nexodus.nexd.plist
+sudo mv io.nexodus.nexd.plist /Library/LaunchDaemons/
+```
+
+Then, start the agent with the following command:
+
+```sh
+sudo launchctl load /Library/LaunchDaemons/io.nexodus.nexd.plist
+```
+
 ### Binary Downloads
 
 You can download the latest release package for your OS and architecture. Each release includes a `nexd` binary and a `nexctl` binary.
@@ -81,7 +94,7 @@ sudo nexd https://try.nexodus.io
 
 ### Interactive Enrollment
 
-If the agent is able to successfully reach the Service API, it will provide a one-time code to provide to the service web UI to complete enrollment of this node into a Nexodus organization. If you ran `nexd` manually, you will see a message like the following in your terminal:
+If the agent can successfully reach the Service API, it will provide a one-time code to provide to the service web UI to complete enrollment of this node into a Nexodus organization. If you ran `nexd` manually, you will see a message like the following in your terminal:
 
 ```sh
 Your device must be registered with Nexodus.
@@ -90,7 +103,7 @@ Please open the following URL in your browser to sign in:
 https://auth.try.nexodus.127.0.0.1.nip.io/realms/nexodus/device?user_code=LTCV-OFFS
 ```
 
-If the agent was started using systemd, you will find the same thing in the service logs. You can also retrieve this status information using `nexctl`.
+If the agent was started using systemd on Linux or launchd on Mac, you will find the same thing in the service logs. You can also retrieve this status information using `nexctl`.
 
 ```sh
 $ sudo nexctl nexd status


### PR DESCRIPTION
- mac: Add plist file to run nexd as a daemon
- docs: Reorganize agent install instructions
- docs: Document running nexd with launchd on mac


commit 9f7cc98eaebf7c31943cf35df68f660eca199307
Author: Russell Bryant <russell.bryant@gmail.com>
Date:   Fri Apr 28 22:27:35 2023 -0400

    mac: Add plist file to run nexd as a daemon
    
    Add the file needed to run `nexd` as a daemon under launchd on mac.
    
    Signed-off-by: Russell Bryant <russell.bryant@gmail.com>

commit 069191308227d8559d83d0f87bd756a594c9634c
Author: Russell Bryant <russell.bryant@gmail.com>
Date:   Sat Apr 29 19:41:15 2023 -0400

    docs: Reorganize agent install instructions
    
    Reorganize the agent install docs to include install+run instructions
    together instead of split across 2 sections.
    
    Signed-off-by: Russell Bryant <russell.bryant@gmail.com>

commit 46dcc86db22c3ac24cbc42100dd7766a6794b696
Author: Russell Bryant <russell.bryant@gmail.com>
Date:   Sat Apr 29 19:59:17 2023 -0400

    docs: Document running nexd with launchd on mac
    
    These instructions describe how to set this up manually. Once it is
    merged and present in the `prod` tag, I will update `homebrew-nexodus`
    to set this up automatically and adjust the documentation accordingly.
    
    Signed-off-by: Russell Bryant <russell.bryant@gmail.com>
