### PR TITLE
nexctl: Move connections command under nexd

### DIFF
--- a/cmd/nexctl/local_unix.go
+++ b/cmd/nexctl/local_unix.go
@@ -50,6 +50,11 @@ func init() {
 				},
 			},
 			{
+				Name:   "connections",
+				Usage:  "Run a test of the nexd peer connectivity (host firewalls may block the ICMP probes)",
+				Action: cmdConnStatus,
+			},
+			{
 				Name:  "get",
 				Usage: "Get a value from the local nexd instance",
 				Subcommands: []*cli.Command{

--- a/cmd/nexctl/main.go
+++ b/cmd/nexctl/main.go
@@ -77,11 +77,6 @@ func main() {
 				},
 			},
 			{
-				Name:   "connections",
-				Usage:  "Run a test of the nexd peer connectivity (host firewalls may block the ICMP probes)",
-				Action: cmdConnStatus,
-			},
-			{
 				Name:  "organization",
 				Usage: "Commands relating to organizations",
 				Subcommands: []*cli.Command{

--- a/integration-tests/proxy_test.go
+++ b/integration-tests/proxy_test.go
@@ -764,7 +764,7 @@ func TestProxyNexctlConnections(t *testing.T) {
 	err = helper.nexdStatus(ctx, node2)
 	require.NoError(err)
 
-	out, err := helper.containerExec(ctx, node1, []string{"nexctl", "connections"})
+	out, err := helper.containerExec(ctx, node1, []string{"nexctl", "nexd", "connections"})
 	require.NoError(err)
 	require.False(strings.Contains(out, "Unreachable"))
 	require.True(strings.Contains(out, "Reachable"))

--- a/ops/ansible/aws/validate-connectivity/tasks/main.yml
+++ b/ops/ansible/aws/validate-connectivity/tasks/main.yml
@@ -29,8 +29,8 @@
   become: yes
   shell: |
     printf "====== Connectivity Results from Node: {{ inventory_hostname }} ======\n" > connectivity-results.txt
-    nexctl connections
-    nexctl connections >> connectivity-results.txt 2>&1
+    nexctl nexd connections
+    nexctl nexd connections >> connectivity-results.txt 2>&1
     printf "\n====== WG Dump from Node: {{ inventory_hostname }} ======\n" >> connectivity-results.txt
     wg show wg0 dump >> connectivity-results.txt 2>&1
     cat connectivity-results.txt


### PR DESCRIPTION
Rename `nexctl connections` to `nexctl nexd connections`.

Everything else that interacts with `nexd` is under that subcommand.
Other subcommands relate to resources in the Nexodus API.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
