### PR TITLE
mergify: Remove label requirements for dependabot changes

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -88,6 +88,7 @@ pull_request_rules:
     conditions:
       - -label=has-docs
       - -label=no-docs-required
+      - -author=dependabot[bot]
     actions:
       label:
         add:
@@ -97,6 +98,7 @@ pull_request_rules:
       - or:
         - label=has-docs
         - label=no-docs-required
+        - author=dependabot[bot]
     actions:
       label:
         remove:
@@ -107,6 +109,7 @@ pull_request_rules:
     conditions:
       - -label=has-design
       - -label=no-design-required
+      - -author=dependabot[bot]
     actions:
       label:
         add:
@@ -116,6 +119,7 @@ pull_request_rules:
       - or:
         - label=has-design
         - label=no-design-required
+        - author=dependabot[bot]
     actions:
       label:
         remove:
@@ -126,6 +130,7 @@ pull_request_rules:
     conditions:
       - -label=has-tests
       - -label=no-tests-required
+      - -author=dependabot[bot]
     actions:
       label:
         add:
@@ -135,6 +140,7 @@ pull_request_rules:
       - or:
         - label=has-tests
         - label=no-tests-required
+        - author=dependabot[bot]
     actions:
       label:
         remove:

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -89,6 +89,7 @@ pull_request_rules:
       - -label=has-docs
       - -label=no-docs-required
       - -author=dependabot[bot]
+      - -draft
     actions:
       label:
         add:
@@ -99,6 +100,7 @@ pull_request_rules:
         - label=has-docs
         - label=no-docs-required
         - author=dependabot[bot]
+        - draft
     actions:
       label:
         remove:
@@ -110,6 +112,7 @@ pull_request_rules:
       - -label=has-design
       - -label=no-design-required
       - -author=dependabot[bot]
+      - -draft
     actions:
       label:
         add:
@@ -120,6 +123,7 @@ pull_request_rules:
         - label=has-design
         - label=no-design-required
         - author=dependabot[bot]
+        - draft
     actions:
       label:
         remove:
@@ -131,6 +135,7 @@ pull_request_rules:
       - -label=has-tests
       - -label=no-tests-required
       - -author=dependabot[bot]
+      - -draft
     actions:
       label:
         add:
@@ -141,6 +146,7 @@ pull_request_rules:
         - label=has-tests
         - label=no-tests-required
         - author=dependabot[bot]
+        - draft
     actions:
       label:
         remove:


### PR DESCRIPTION
dependabot PRs do not require the docs/tests/design labels to merge, so exclude those PRs from the rules that apply the labels indicating that required labels are missing.

Do the same change for draft PRs. The label noise isn't necessary on drafts.