### PR TITLE
nexd: drop the requirement to install the wireguard tools.

### DIFF
--- a/Containerfile.dev
+++ b/Containerfile.dev
@@ -10,7 +10,6 @@ RUN apt-get update -qy && \
     ca-certificates \
     iputils-ping \
     iproute2 \
-    wireguard-tools \
     iptables \
     net-tools \
     traceroute \

--- a/Containerfile.nexd
+++ b/Containerfile.nexd
@@ -39,7 +39,6 @@ RUN dnf update -qy && \
     iproute \
     psmisc \
     procps-ng \
-    wireguard-tools \
     nftables \
     hostname \
     netcat \

--- a/Containerfile.test
+++ b/Containerfile.test
@@ -16,7 +16,6 @@ RUN CGO_ENABLED=0 go build \
 FROM alpine:3.16 as alpine
 RUN apk add --no-cache \
     iputils \
-    wireguard-tools \
     nftables \
     psmisc \
     ca-certificates
@@ -33,7 +32,6 @@ RUN dnf update -qy && \
     iproute \
     psmisc \
     procps-ng \
-    wireguard-tools \
     nftables \
     hostname \
     && \
@@ -50,7 +48,6 @@ RUN apt-get update -qy && \
     ca-certificates \
     iputils-ping \
     iproute2 \
-    wireguard-tools \
     nftables \
     net-tools \
     traceroute \

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -2,10 +2,10 @@
 
 The following table lists the names and email addresses of project maintainers.
 
-| Name | Email |
-| ---- | ----- |
-| Anil Vishnoi | `avishnoi@redhat.com` |
-| Brent Salisbury | `bsalisbu@redhat.com` |
-| Dave Tucker | `dave@dtucker.co.uk` |
-| Hiram Chirino | `hiram@hiramchirino.com` |
-| Russell Bryant | `russell.bryant@gmail.com` |
+| Name            | Email                        |
+|-----------------|------------------------------|
+| Anil Vishnoi    | `<avishnoi@redhat.com>`      |
+| Brent Salisbury | `<bsalisbu@redhat.com>`      |
+| Dave Tucker     | `<dave@dtucker.co.uk>`       |
+| Hiram Chirino   | `<hiram@hiramchirino.com>`   |
+| Russell Bryant  | `<russell.bryant@gmail.com>` |

--- a/contrib/rpm/nexodus.spec.in
+++ b/contrib/rpm/nexodus.spec.in
@@ -36,7 +36,6 @@ Source:         nexodus-##NEXODUS_COMMIT##.tar.gz
 
 BuildRequires: systemd-rpm-macros
 BuildRequires: systemd-units
-Requires: wireguard-tools
 Requires(post): systemd-units
 Requires(preun): systemd-units
 Requires(postun): systemd-units

--- a/docs/user-guide/scenarios/kubernetes-edge.md
+++ b/docs/user-guide/scenarios/kubernetes-edge.md
@@ -132,7 +132,7 @@ Request ID: 5648b07d658223aa8f488d9833cac06d
     ```sh
     sudo dnf install https://www.elrepo.org/elrepo-release-8.el8.elrepo.noarch.rpm
     sudo dnf install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
-    sudo dnf install kmod-wireguard wireguard-tools -y
+    sudo dnf install kmod-wireguard -y
     ```
 
 * MicroShift doesn't allow you to deploy a simple pod (e.g curl pod) in the default namespace.

--- a/internal/cucumber/sql.go
+++ b/internal/cucumber/sql.go
@@ -63,7 +63,7 @@ func (s *TestScenario) iRunSQLGivesResults(sql string, expected *godog.Table) er
 	if err != nil {
 		return err
 	}
-	defer util.IgnoreError(rows.Close())
+	defer util.IgnoreError(rows.Close)
 
 	var actualTable [][]string
 	cols, err := rows.Columns()

--- a/internal/nexodus/nexodus.go
+++ b/internal/nexodus/nexodus.go
@@ -30,7 +30,6 @@ import (
 
 const (
 	pollInterval       = 5 * time.Second
-	wgBinary           = "wg"
 	wgGoBinary         = "wireguard-go"
 	nexdWgGoBinary     = "nexd-wireguard-go"
 	wgWinBinary        = "wireguard.exe"

--- a/internal/nexodus/utils_linux.go
+++ b/internal/nexodus/utils_linux.go
@@ -190,10 +190,6 @@ func defaultTunnelDevOS() string {
 
 // binaryChecks validate the required binaries are available
 func binaryChecks() error {
-	// all OSs require the wg binary
-	if !IsCommandAvailable(wgBinary) {
-		return fmt.Errorf("%s command not found, is wireguard installed?", wgBinary)
-	}
 	return nil
 }
 

--- a/internal/util/Ignore_error.go
+++ b/internal/util/Ignore_error.go
@@ -1,5 +1,8 @@
 package util
 
-// IgnoreError is a noop.  It is used to eat errors.  Example `defer util.IgnoreError(file.Close())`
-func IgnoreError(err error) {
+type fnWithErrorResult func() error
+
+// IgnoreError call the passed fn and ignore the errors it returns.  Example `defer util.IgnoreError(file.Close)`
+func IgnoreError(fn fnWithErrorResult) {
+	_ = fn()
 }


### PR DESCRIPTION
The wg cli tool was being used to configure the WG interface.  We now do it with the wgctl go module.