### PR TITLE
nexd: Avoid duplicates in the newPeers list

### DIFF
--- a/internal/nexodus/nexodus.go
+++ b/internal/nexodus/nexodus.go
@@ -580,8 +580,7 @@ func (ax *Nexodus) Reconcile(firstTime bool) error {
 			if !ok {
 				ax.deviceCache[p.Id] = p
 				newPeers = append(newPeers, p)
-			}
-			if !reflect.DeepEqual(existing, p) {
+			} else if !reflect.DeepEqual(existing, p) {
 				ax.deviceCache[p.Id] = p
 				newPeers = append(newPeers, p)
 			}


### PR DESCRIPTION
The Reconcile logic had a flaw where the same peer could be appended to
the `newPeers` list twice. I haven't observed a direct failure as a
result, but I spotted it because of some suspicious debug output while
debugging a different issue.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
