### PR TITLE
Address proxy test reliability

### DIFF
--- a/integration-tests/proxy_test.go
+++ b/integration-tests/proxy_test.go
@@ -663,6 +663,11 @@ func TestProxyInvalidConfig(t *testing.T) {
 		"--egress", "tcp:8080"))
 	require.Error(err)
 
+	// destination host can not be blank
+	_, err = helper.containerExec(ctx, node1, append(baseArgs,
+		"--egress", "tcp:8080::80"))
+	require.Error(err)
+
 	// Note: no validation is done on the destination address, because it can be a hostname or an IP address
 }
 

--- a/integration-tests/proxy_test.go
+++ b/integration-tests/proxy_test.go
@@ -16,7 +16,7 @@ import (
 
 // TestProxyEgress tests that nexd proxy can be used with a single egress rule
 func TestProxyEgress(t *testing.T) {
-	//t.Parallel()
+	t.Parallel()
 	helper := NewHelper(t)
 	require := helper.require
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
@@ -81,7 +81,7 @@ func TestProxyEgress(t *testing.T) {
 
 // TestProxyEgressUDP tests that nexd proxy can be used with a single UDP egress rule
 func TestProxyEgressUDP(t *testing.T) {
-	//t.Parallel()
+	t.Parallel()
 	helper := NewHelper(t)
 	require := helper.require
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
@@ -165,7 +165,7 @@ func TestProxyEgressUDP(t *testing.T) {
 
 // TestProxyEgress tests that nexd proxy can be used with multiple egress rules
 func TestProxyEgressMultipleRules(t *testing.T) {
-	//t.Parallel()
+	t.Parallel()
 	helper := NewHelper(t)
 	require := helper.require
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
@@ -249,7 +249,7 @@ func TestProxyEgressMultipleRules(t *testing.T) {
 
 // TestProxyIngress tests that nexd proxy with a single ingress rule
 func TestProxyIngress(t *testing.T) {
-	//t.Parallel()
+	t.Parallel()
 	helper := NewHelper(t)
 	require := helper.require
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
@@ -311,7 +311,7 @@ func TestProxyIngress(t *testing.T) {
 
 // TestProxyIngressUDP tests that nexd proxy can be used with a single UDP ingress rule
 func TestProxyIngressUDP(t *testing.T) {
-	//t.Parallel()
+	t.Parallel()
 	helper := NewHelper(t)
 	require := helper.require
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
@@ -392,7 +392,7 @@ func TestProxyIngressUDP(t *testing.T) {
 
 // TestProxyIngress tests that nexd proxy with multiple ingress rules
 func TestProxyIngressMultipleRules(t *testing.T) {
-	//t.Parallel()
+	t.Parallel()
 	helper := NewHelper(t)
 	require := helper.require
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
@@ -473,7 +473,7 @@ func TestProxyIngressMultipleRules(t *testing.T) {
 
 // TestProxyIngressAndEgress tests that a proxy can be used to both ingress and egress traffic
 func TestProxyIngressAndEgress(t *testing.T) {
-	//t.Parallel()
+	t.Parallel()
 	helper := NewHelper(t)
 	require := helper.require
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
@@ -563,7 +563,7 @@ func TestProxyIngressAndEgress(t *testing.T) {
 
 // Test invalid proxy configuration
 func TestProxyInvalidConfig(t *testing.T) {
-	//t.Parallel()
+	t.Parallel()
 	var err error
 	helper := NewHelper(t)
 	require := helper.require
@@ -672,7 +672,7 @@ func TestProxyInvalidConfig(t *testing.T) {
 }
 
 func TestProxyNexctl(t *testing.T) {
-	//t.Parallel()
+	t.Parallel()
 	helper := NewHelper(t)
 	require := helper.require
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)

--- a/internal/nexodus/userspace_proxy.go
+++ b/internal/nexodus/userspace_proxy.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/natefinch/atomic"
 	"io"
 	"net"
 	"os"
@@ -15,6 +14,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/natefinch/atomic"
 
 	"github.com/nexodus-io/nexodus/internal/util"
 	"go.uber.org/zap"
@@ -131,6 +132,10 @@ func proxyFromRule(rule string, ruleType ProxyType) (*UsProxy, error) {
 	destHost, destPortStr, err := net.SplitHostPort(destHostPort)
 	if err != nil {
 		return nil, fmt.Errorf("Invalid destination host:port (%s): %w", destHostPort, err)
+	}
+
+	if destHost == "" {
+		return nil, fmt.Errorf("Invalid destination host:port (%s): host cannot be empty", destHostPort)
 	}
 
 	destPort, err := parsePort(destPortStr)


### PR DESCRIPTION
- nexd: Reject proxy rules with a blank dest host
- e2e: Update nexdStatus() check to include tunnel IPs
- e2e: Run proxy tests in parallel again


commit bd241e2827326427129a6c35330d20b73e0aa59f
Author: Russell Bryant <russell.bryant@gmail.com>
Date:   Tue May 2 15:19:05 2023 -0400

    nexd: Reject proxy rules with a blank dest host
    
    Proxy rules with a blank destination host should be considered invalid.
    Add a check for this and a test case.
    
    I have observed a failure in e2e tests where proxy rules were configured
    this way as a result of an earlier error. The original error would have
    been easier to spot if the rule had been outright rejected.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>

commit a86ebc9e9ef6531a204cb99bf3e8e4e6643eea67
Author: Russell Bryant <russell.bryant@gmail.com>
Date:   Tue May 2 15:27:56 2023 -0400

    e2e: Update nexdStatus() check to include tunnel IPs
    
    Update the method that checks for nexd to report its status as READY to
    also validate that it can return its tunnel IPs. I am seeing cases in
    e2e tests where attempts to get this IP sometimes come back blank
    because the request was issued too soon.
    
    This really should not be necessary. If we had a better state machine
    for nexd, we could know that nexd is running and the data plane is up.
    Right now, READY just means nexd has successfully connected with the
    control plane. Attempts to get data plane info may happen too soon. This
    is a hack to make sure nexd has had enough time to get its own local
    config.
    
    Related: https://github.com/nexodus-io/nexodus/pull/886
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>

commit f0ba0c106453ff802d6e541ee817a81510fc612c
Author: Russell Bryant <russell.bryant@gmail.com>
Date:   Tue May 2 16:04:29 2023 -0400

    e2e: Run proxy tests in parallel again
    
    Previous commits addressed the failures I was able to reproduce. I'm now
    able to run them in parallel reliably locally.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>
