### PR TITLE
nexd: Avoid segfault in error handling

### DIFF
--- a/internal/nexodus/nexodus.go
+++ b/internal/nexodus/nexodus.go
@@ -569,7 +569,11 @@ func (ax *Nexodus) reconcileStun(deviceID string) error {
 func (ax *Nexodus) Reconcile(firstTime bool) error {
 	peerListing, resp, err := ax.informer.Execute()
 	if err != nil {
-		return fmt.Errorf("error: %w header: %v", err, resp.Header)
+		if resp != nil {
+			return fmt.Errorf("error: %w header: %v", err, resp.Header)
+		} else {
+			return fmt.Errorf("error: %w", err)
+		}
 	}
 	var newPeers []public.ModelsDevice
 	if firstTime {


### PR DESCRIPTION
I just hit a seg fault on this fmt.Errorf() line because resp was nil.
Update the code to only include the header if resp is not nil.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
