### PR TITLE
docs: Fix doc title copied from template

### DIFF
--- a/docs/development/design/TEMPLATE.md
+++ b/docs/development/design/TEMPLATE.md
@@ -1,4 +1,4 @@
-# Enhancement Title
+# TEMPLATE - Enhancement Title
 
 > [Issue #NNN](https://github.com/nexodus-io/nexodus/issues/NNN)
 

--- a/docs/development/design/project-name.md
+++ b/docs/development/design/project-name.md
@@ -1,4 +1,4 @@
-# Enhancement Title
+# Project Name
 
 > [Issue #428](https://github.com/nexodus-io/nexodus/issues/428)
 


### PR DESCRIPTION
Fix the document title for the design doc about the project name. It
was still the title copied from the template.

Also update the template to include the word "TEMPLATE" so it's a
little easier to find in the list of docs on the docs site.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
