### PR TITLE
e2e: Fix major flaw in TestProxyInvalidConfig

### DIFF
--- a/integration-tests/proxy_test.go
+++ b/integration-tests/proxy_test.go
@@ -576,7 +576,7 @@ func TestProxyInvalidConfig(t *testing.T) {
 	node1, stop := helper.CreateNode(ctx, "node1", []string{defaultNetwork}, enableV6)
 	defer stop()
 
-	baseArgs := []string{"--username", username, "--password", password, "proxy"}
+	baseArgs := []string{"nexd", "--username", username, "--password", password, "proxy"}
 	proxyArgs := [][]string{
 		// duplicate tcp ingress port
 		{"--ingress", "tcp:8080:127.0.0.1:80", "--ingress", "tcp:8080:127.0.0.2:81"},
@@ -616,7 +616,11 @@ func TestProxyInvalidConfig(t *testing.T) {
 
 	for _, args := range proxyArgs {
 		out, err := helper.containerExec(ctx, node1, append(baseArgs, args...))
-		helper.Logf("nexd output: %s", out)
+		if err == nil {
+			// This test will fail. Print the output just in case there's a hint in there
+			// about what went wrong.
+			helper.Logf("nexd output: %s", out)
+		}
 		require.Error(err)
 	}
 }


### PR DESCRIPTION
It turns out this test was never actually testing what it was supposed
to. The intent was to start `nexd` with invalid proxy rules and verify
that it exited with an error. The problem is that a very critical
argument was left out ... `nexd`. What was happening in every test case
was that it tried to run a command called `--username`. Of course, this
fails. Every so often, containerExec() would not return an error, but
since I added debug output, I was able to spot the error message that
clued me in to what went wrong.

```
    proxy_test.go:619: nexd output: �OCI runtime exec failed: exec
failed: unable to start container process: exec: "--username":
executable file not found in $PATH: unknown
 ```

Big oops.

This change fixes it so the test actually runs `nexd`. It also stops
printing the debug output every time and only dumps it if the command
unexpectedly returns success.

Closes #960

Signed-off-by: Russell Bryant <rbryant@redhat.com>
