### PR TITLE
nexd: Set a more generous ResponseHeaderTimeout

### DIFF
--- a/internal/client/apiclient.go
+++ b/internal/client/apiclient.go
@@ -38,7 +38,7 @@ func NewAPIClient(ctx context.Context, addr string, authcb func(string), options
 		Transport: &http.Transport{
 			DialContext:           dialer.DialContext,
 			TLSHandshakeTimeout:   10 * time.Second,
-			ResponseHeaderTimeout: 10 * time.Second,
+			ResponseHeaderTimeout: 30 * time.Second,
 			ExpectContinueTimeout: 5 * time.Second,
 			TLSClientConfig:       opts.tlsConfig,
 		},


### PR DESCRIPTION
The previous apiclient config had an equal timeout for both the TLS
handshake and to start receive response headers. I've seen the following
log message on my laptop using try.nexodus.io:

```
May 03 13:22:49 t14s nexd[16578]:
{"level":"error","ts":1683134569.6455014,"caller":"nexodus/nexodus.go:458","msg":"Failed
to reconcile state with the nexodus API server: Get
\"https://api.try.nexodus.io/api/organizations/b272fb0d-3bb0-4f56-8519-d853c9efc854/devices?watch=true\":
net/http: timeout awaiting response headers"}
```

It's possible this is the result of a performance issue on the
api-server side, but it could also be something caused by my home
network. Bumping this back, but still not letting it hang forever seems
like a reasonable thing to try.

30 seconds is a bit arbitrary. It does seem safer to set more generous
timeouts on the client side. We're not as worried about DoS attacks.
We're more concerned with making sure `nexd` stops and retries within
reasonable time periods.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
