### PR TITLE
fix: test container log output had 8 bytes of binary junk before the …

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.20
 
 require (
 	github.com/Nerzal/gocloak/v13 v13.3.0
+	github.com/ahmetb/dlog v0.0.0-20170105205344-4fb5f8204f26
 	github.com/briandowns/spinner v1.23.0
 	github.com/bufbuild/connect-go v1.7.0
 	github.com/cockroachdb/cockroach-go/v2 v2.3.3
@@ -61,6 +62,7 @@ require (
 	github.com/Microsoft/go-winio v0.6.0 // indirect
 	github.com/OneOfOne/xxhash v1.2.8 // indirect
 	github.com/agnivade/levenshtein v1.1.1 // indirect
+	github.com/ahmetalpbalkan/dlog v0.0.0-20170105205344-4fb5f8204f26 // indirect
 	github.com/benbjohnson/clock v1.3.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bytedance/gopkg v0.0.0-20221122125632-68358b8ecec6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -48,6 +48,10 @@ github.com/OneOfOne/xxhash v1.2.8 h1:31czK/TI9sNkxIKfaUfGlU47BAxQ0ztGgd9vPyqimf8
 github.com/OneOfOne/xxhash v1.2.8/go.mod h1:eZbhyaAYD41SGSSsnmcpxVoRiQ/MPUTjUdIIOT9Um7Q=
 github.com/agnivade/levenshtein v1.1.1 h1:QY8M92nrzkmr798gCo3kmMyqXFzdQVpxLlGPRBij0P8=
 github.com/agnivade/levenshtein v1.1.1/go.mod h1:veldBMzWxcCG2ZvUTKD2kJNRdCk5hVbJomOvKkmgYbo=
+github.com/ahmetalpbalkan/dlog v0.0.0-20170105205344-4fb5f8204f26 h1:pzStYMLAXM7CNQjS/Wn+zK9MUxDhSUNfVvnHsyQyjs0=
+github.com/ahmetalpbalkan/dlog v0.0.0-20170105205344-4fb5f8204f26/go.mod h1:ilK+u7u1HoqaDk0mjhh27QJB7PyWMreGffEvOCoEKiY=
+github.com/ahmetb/dlog v0.0.0-20170105205344-4fb5f8204f26 h1:3YVZUqkoev4mL+aCwVOSWV4M7pN+NURHL38Z2zq5JKA=
+github.com/ahmetb/dlog v0.0.0-20170105205344-4fb5f8204f26/go.mod h1:ymXt5bw5uSNu4jveerFxE0vNYxF8ncqbptntMaFMg3k=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=

--- a/integration-tests/helper_test.go
+++ b/integration-tests/helper_test.go
@@ -3,6 +3,7 @@ package integration_tests
 import (
 	"context"
 	"fmt"
+	"github.com/ahmetb/dlog"
 	"io"
 	"os/exec"
 	"path/filepath"
@@ -178,14 +179,16 @@ func (helper *Helper) containerExec(ctx context.Context, container testcontainer
 	if cmd[0] != "wg" && cmd[0] != "cat" {
 		helper.logf("Running command on %s: %s", nodeName, strings.Join(cmd, " "))
 	}
-	code, outputRaw, err := container.Exec(
+	code, reader, err := container.Exec(
 		ctx,
 		cmd,
 	)
 	if err != nil {
 		return "", err
 	}
-	output, err := io.ReadAll(outputRaw)
+
+	reader = dlog.NewReader(reader)
+	output, err := io.ReadAll(reader)
 	if err != nil {
 		return "", err
 	}

--- a/integration-tests/proxy_test.go
+++ b/integration-tests/proxy_test.go
@@ -683,7 +683,7 @@ func TestProxyNexctl(t *testing.T) {
 		  "ingress": [
 			"tcp:4242:127.0.0.1:8080"
 		  ]
-		}`, out[8:])
+		}`, out)
 
 	// Rules are present now
 	out, err = helper.containerExec(ctx, node1, []string{"nexctl", "nexd", "proxy", "list"})
@@ -727,7 +727,7 @@ func TestProxyNexctl(t *testing.T) {
 		{
 		  "egress": null,
 		  "ingress": null
-		}`, out[8:])
+		}`, out)
 
 	// Connectivity should now fail again
 	_, err = helper.containerExec(ctx, node1, []string{"curl", "http://127.0.0.1"})

--- a/integration-tests/util_test.go
+++ b/integration-tests/util_test.go
@@ -11,7 +11,6 @@ import (
 	"net"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -166,7 +165,7 @@ func getTunnelIP(ctx context.Context, helper *Helper, family ipFamily, ctr testc
 		args = append(args, "--ipv6")
 	}
 	tunnelIP, err := helper.containerExec(ctx, ctr, args)
-	return clearString(tunnelIP), err
+	return strings.TrimSpace(tunnelIP), err
 }
 
 func ping(ctx context.Context, ctr testcontainers.Container, family ipFamily, address string) error {
@@ -298,10 +297,4 @@ func getOauth2Token(ctx context.Context, userid, password string) (*oauth2.Token
 		RefreshToken: jwt.RefreshToken,
 		Expiry:       time.Now().Add(time.Duration(jwt.ExpiresIn) * time.Second),
 	}, nil
-}
-
-var nonAlphanumericRegex = regexp.MustCompile(`[^a-zA-Z0-9\.\[\]: ]+`)
-
-func clearString(str string) string {
-	return nonAlphanumericRegex.ReplaceAllString(str, "")
 }


### PR DESCRIPTION
…output.

We now strip it out to simplify looking at test results.