### PR TITLE
rpm: Add centos-stream-9 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -328,6 +328,13 @@ jobs:
   build-rpm:
     needs: [ go-lint-linux, generate ]
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - mock_root: fedora-38-x86_64
+            srpm_distro: fc38
+          - mock_root: centos-stream-9-x86_64
+            srpm_distroy: el9
     steps:
       - uses: actions/checkout@v3
 
@@ -338,7 +345,7 @@ jobs:
       - name: Build rpm
         id: build-rpm
         run: |
-          make rpm
+          MOCK_ROOT=${{ matrix.mock_root}} SRPM_DISTRO=${{ matrix.srpm_distro }} make rpm
           echo "artifact-name=$(pwd)/dist/rpm/mock/nexodus-*.x86_64.rpm" >> "$GITHUB_OUTPUT"
 
       - name: Upload Artifact

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -139,6 +139,8 @@ jobs:
         include:
           - mock_root: fedora-38-x86_64
             srpm_distro: fc38
+          - mock_root: centos-stream-9-x86_64
+            srpm_distro: el9
     steps:
       - uses: actions/checkout@v3
 

--- a/Makefile
+++ b/Makefile
@@ -662,6 +662,8 @@ srpm: dist/rpm manpages ## Build a source RPM
 	mv vendor dist/rpm/nexodus-${NEXODUS_RELEASE}/.
 	mkdir -p dist/rpm/nexodus-${NEXODUS_RELEASE}/contrib/man
 	cp -r contrib/man/* dist/rpm/nexodus-${NEXODUS_RELEASE}/contrib/man/.
+	NEXODUS_BUILD_PROFILE=prod $(MAKE) ldflags.txt
+	mv ldflags.txt dist/rpm/nexodus-${NEXODUS_RELEASE}/.
 	cd dist/rpm && tar czf nexodus-${NEXODUS_RELEASE}.tar.gz nexodus-${NEXODUS_RELEASE} && rm -rf nexodus-${NEXODUS_RELEASE}
 	cp contrib/rpm/nexodus.spec.in contrib/rpm/nexodus.spec
 	sed -i -e "s/##NEXODUS_COMMIT##/${NEXODUS_RELEASE}/" contrib/rpm/nexodus.spec
@@ -681,6 +683,9 @@ rpm: srpm ## Build an RPM
 .PHONY: version
 version: ## Print the version string
 	$(CMD_PREFIX) echo "${NEXODUS_VERSION}-${NEXODUS_RELEASE}"
+
+ldflags.txt:
+	@echo "$(NEXODUS_LDFLAGS) " > ldflags.txt
 
 ##@ Documentation
 

--- a/contrib/rpm/nexodus.spec.in
+++ b/contrib/rpm/nexodus.spec.in
@@ -44,6 +44,7 @@ Source:         nexodus-##NEXODUS_COMMIT##.tar.gz
 
 BuildRequires: systemd-rpm-macros
 BuildRequires: systemd-units
+BuildRequires: make
 Requires(post): systemd-units
 Requires(preun): systemd-units
 Requires(postun): systemd-units
@@ -70,7 +71,7 @@ Requires(postun): systemd-units
 %endif
 
 for cmd in cmd/nexd cmd/nexctl ; do
-  %gobuild -o %{gobuilddir}/bin/$(basename $cmd) %{goipath}/$cmd
+  LDFLAGS="$(cat ldflags.txt)" %gobuild -o %{gobuilddir}/bin/$(basename $cmd) %{goipath}/$cmd
 done
 
 %install

--- a/contrib/rpm/nexodus.spec.in
+++ b/contrib/rpm/nexodus.spec.in
@@ -14,8 +14,12 @@
 # building more go packages for i686. If your package is not a leaf package,
 # you'll need to coordinate the removal of the package's dependents first.
 # ---
-# REMOVE BEFORE SUBMITTING THIS FOR REVIEWmock
+# REMOVE BEFORE SUBMITTING THIS FOR REVIEW
+%if 0%{?fedora}
 %gometa -f
+%else
+%gometa
+%endif
 
 %global common_description %{expand:
 A prototype of connectivity as a service.}
@@ -25,7 +29,11 @@ A prototype of connectivity as a service.}
 
 Name:           nexodus
 Version:        0
+%if 0%{?fedora}
 Release:        %autorelease -p
+%else
+Release:        ##NEXODUS_AUTORELEASE##
+%endif
 Summary:        A prototype of connectivity as a service
 
 License:        Apache-2.0
@@ -53,7 +61,14 @@ Requires(postun): systemd-units
 #%go_generate_buildrequires
 
 %build
-find .
+%if 0%{?fedora}
+# has Go 1.20 already
+%else
+  curl -L https://go.dev/dl/go1.20.4.linux-amd64.tar.gz -o go1.20.4.linux-amd64.tar.gz
+  tar -C .. -xzf go1.20.4.linux-amd64.tar.gz
+  export PATH=/$(pwd)/../go/bin:$PATH
+%endif
+
 for cmd in cmd/nexd cmd/nexctl ; do
   %gobuild -o %{gobuilddir}/bin/$(basename $cmd) %{goipath}/$cmd
 done
@@ -111,4 +126,6 @@ done
 %endif
 
 %changelog
+%if 0%{?fedora}
 %autochangelog
+%endif

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -4,11 +4,12 @@ This guide will walk you through getting your first devices connected via Nexodu
 
 ## Install and Start the Nexodus Agent
 
-### Fedora
+### Fedora, CentOS Stream
 
-!!! note "Minimum Release Version"
+Supported versions:
 
-    Fedora 38 is the minimum release version supported by this copr repository.
+- Fedora 38
+- CentOS Stream 9
 
 ```sh
 # Enable the COPR repository and install the nexodus package

--- a/docs/user-guide/agent.md
+++ b/docs/user-guide/agent.md
@@ -6,11 +6,12 @@ The following sections contain general instructions to deploy the Nexodus agent 
 
 ### Installing the Agent
 
-#### Fedora - RPM
+#### Fedora, CentOS Stream - RPM
 
-!!! note "Minimum Release Version"
+Supported versions:
 
-    Fedora 38 is the minimum release version supported by this copr repository.
+- Fedora 38
+- CentOS Stream 9
 
 A Fedora [Copr repository](https://copr.fedorainfracloud.org/coprs/russellb/nexodus/) is updated with new rpms after each new commit to the `main` branch that passes CI. The rpm will include `nexctl`, `nexd`, and integration with systemd.
 


### PR DESCRIPTION
commit 3c9c14d5407d1d642aecd76e618e9d0a0cb31d0a
Author: Russell Bryant <russell.bryant@gmail.com>
Date:   Tue May 2 13:32:51 2023 -0400

    rpm: Add centos-stream-9 support
    
    Add support for building rpms for centos-stream-9-x86_64. Turn on
    automatic builds in copr for this distro, as well.
    
    Centos Stream 9 doesn't include Go 1.20 or some of the rpm golang macros
    available in Fedora.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>

commit ce56d1eac1906536ef18e00fd85e56da052a1f26
Author: Russell Bryant <russell.bryant@gmail.com>
Date:   Thu May 4 07:40:24 2023 -0400

    docs: Note support of CentOS Stream 9
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>

commit b71b7a996e6fffa6092836a72bf80e0382c46391
Author: Russell Bryant <russell.bryant@gmail.com>
Date:   Thu May 4 07:46:44 2023 -0400

    ci: Test building centos-stream-9 rpm in CI
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>

commit 00cc3372f928afb9f70a7f39fed44b281b3d1216
Author: Russell Bryant <russell.bryant@gmail.com>
Date:   Fri May 5 08:49:51 2023 -0400

    rpm: Use ldflags from the Makefile
    
    We use ldflags to speicfy a default service URL and a version number in
    binaries. These flags were not applied in the rpm build. This change
    fixes that.
    
    Closes #576
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>

Closes #576 