### PR TITLE
Add license checking for Go dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -112,6 +112,17 @@ jobs:
       - name: OPA Lint and Tests
         run: make opa-lint
 
+  go-licenses:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Go
+        uses: ./.github/actions/setup-go-env
+
+      - name: Check Go Licenses
+        run: |
+          make go-licenses
+
   build-images:
     runs-on: ubuntu-latest
     strategy:
@@ -349,7 +360,7 @@ jobs:
             ${{ steps.build-rpm.outputs.artifact-name }}
 
   build-workflow-complete:
-    needs: ["build-packages", "build-rpm", "go-unit", "e2e", "k8s-lint", "opa-lint", "ui-lint"]
+    needs: ["build-packages", "build-rpm", "go-unit", "e2e", "k8s-lint", "opa-lint", "ui-lint", "go-licenses"]
     runs-on: ubuntu-latest
     steps:
       - name: Build Complete

--- a/Makefile
+++ b/Makefile
@@ -221,6 +221,21 @@ dist/.action-lint: $(find -type f .github) | dist
 	$(CMD_PREFIX) actionlint -color
 	$(CMD_PREFIX) touch $@
 
+# https://github.com/google/go-licenses
+# For license IDs: https://github.com/google/licenseclassifier/blob/main/license_type.go
+DISALLOWED_LICENSE_TYPES:=forbidden,restricted,unknown
+.PHONY: go-licenses
+go-licenses: dist/.go-licenses ## Validate licenses of Go dependencies
+dist/.go-licenses: $(NEX_ALL_GO) | dist
+	$(ECHO_PREFIX) printf "  %-12s ./...\n" "[GO LICENSES]"
+	$(CMD_PREFIX) if ! which go-licenses $(PIPE_DEV_NULL) ; then \
+		echo "Please install go-licenses." ; \
+		echo "go install github.com/google/go-licenses@latest" ; \
+		exit 1 ; \
+	fi
+	$(CMD_PREFIX) go-licenses check --include_tests --disallowed_types=$(DISALLOWED_LICENSE_TYPES) ./...
+	$(CMD_PREFIX) touch $@
+
 .PHONY: gen-docs
 gen-docs: $(SWAGGER_YAML) ## Generate API docs
 .PHONY: openapi-lint

--- a/hack/install-tools.sh
+++ b/hack/install-tools.sh
@@ -24,3 +24,7 @@ if [ -z "$(which kustomize)" ] || [ "$1" = "--force" ]; then
   echo installing kustomize
   go install sigs.k8s.io/kustomize/kustomize/v5@latest
 fi
+if [ -z "$(which go-licenses)" ] || [ "$1" = "--force" ]; then
+  echo installing go-licenses
+  go install github.com/google/go-licenses@latest
+fi


### PR DESCRIPTION
Add a Makefile target and a CI job that checks the licenses of Go
dependencies. If a license is enountered that is either unknown or is
of a more restrictive type than we'd like to allow, this will result
in an error. An example would be if someone accidentally introduced an
AGPL licensed dependency, this would catch it.

More details on the checker: https://github.com/google/go-licenses

To see what is categorized in the types we disallow, "forbidden" or
"restrictive", see:
https://github.com/google/licenseclassifier/blob/main/license_type.go

Signed-off-by: Russell Bryant <rbryant@redhat.com>
