### PR TITLE
fix: null pointer panic in linux stun requets

### DIFF
--- a/internal/nexodus/stun_linux.go
+++ b/internal/nexodus/stun_linux.go
@@ -106,6 +106,7 @@ func stunMsgParse(logger *zap.SugaredLogger, msg stun.Message) stunResponse {
 	res.mappedAddr = &stun.MappedAddress{}
 	res.xorAddr = &stun.XORMappedAddress{}
 	res.otherAddr = &stun.OtherAddress{}
+	res.software = &stun.Software{}
 
 	if res.xorAddr.GetFrom(&msg) != nil {
 		res.xorAddr = nil


### PR DESCRIPTION
Was seeing the following panic:

```
panic: runtime error: invalid memory address or nil pointer dereference
        [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x9ebaf3]
        
        goroutine 1 [running]:
        github.com/pion/stun.(*TextAttribute).GetFromAs(...)
        	/go/pkg/mod/github.com/pion/stun@v0.4.0/textattrs.go:127
        github.com/pion/stun.(*Software).GetFrom(...)
        	/go/pkg/mod/github.com/pion/stun@v0.4.0/textattrs.go:79
        github.com/nexodus-io/nexodus/internal/nexodus.stunMsgParse(0x4?, {{0x1, 0x2}, 0x44, {0x13, 0xb8, 0xe7, 0xf5, 0x84, 0xda, ...}, ...})
        	/src/internal/nexodus/stun_linux.go:119 +0x133
        github.com/nexodus-io/nexodus/internal/nexodus.stunRequest(0xc0002df290?, {0xb9c2f5?, 0xb6618a?}, 0xc00009c000?)
        	/src/internal/nexodus/stun_linux.go:61 +0x365
        github.com/nexodus-io/nexodus/internal/nexodus.(*Nexodus).symmetricNatDisco(0xc00009c000)
        	/src/internal/nexodus/nexodus.go:657 +0x4f
```