### PR TITLE
ci: Fix publish-rpm job

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -154,7 +154,7 @@ jobs:
 
       - name: Build srpm
         run: |
-          MOCK_ROOT="${{ matrix.mock_root }}" make srpm
+          MOCK_ROOT="${{ matrix.mock_root }}" SRPM_DISTRO="${{ matrix.srpm_distro }}" make srpm
           find dist
 
       - name: Submit srpm to copr


### PR DESCRIPTION
Publishing rpms to our rpm repo was broken for Centos Stream 9 because
of accidentally not setting this variable when building the srpm.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
