### PR TITLE
Create Security Policy document

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,9 @@
+# Security Policy
+
+## Supported Versions
+
+The Nexodus project maintains no release branches. We run our services off of the `main` branch, so that is the only supported version.
+
+## Reporting a Vulnerability
+
+Vulnerabilities may be reported privately via [GitHub](https://github.com/nexodus-io/nexodus/security/advisories). For more information about privately reporting security issues via GitHub, see the [GitHub Documentation](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability).


### PR DESCRIPTION
GitHub advised creating this file with a security policy that includes what versions are supported and how vulnerabilities are reported. This came from the community guidelines checklist.