### PR TITLE
Check if the ChildPrefix is the same as the existing in UpdateDevice

### DIFF
--- a/cmd/nexd/main.go
+++ b/cmd/nexd/main.go
@@ -205,10 +205,6 @@ func main() {
 								if err := nexodus.ValidateCIDR(prefix); err != nil {
 									return fmt.Errorf("Child prefix CIDRs passed in --child-prefix %s is not valid: %w", prefix, err)
 								}
-								if util.IsIPv6Prefix(prefix) {
-									return fmt.Errorf("currently --child-prefix only supports IPv4 prefixes")
-								}
-
 							}
 							return nil
 						},

--- a/integration-tests/integration_test.go
+++ b/integration-tests/integration_test.go
@@ -393,7 +393,7 @@ func TestHubOrganization(t *testing.T) {
 	require.NotContainsf(node2dump, node3IP, "found deleted device node still in wg show wg0 dump tables of a device")
 }
 
-// TestChildPrefix tests requesting a specific address in a newly created organization. This will start nexd three
+// TestChildPrefix tests requesting a specific address in a newly created organization for v4 and v6. This will start nexd three
 // different times. The first makes sure the prefix is created and routes are added. The second is started and then killed.
 // The third start of nexd is to validate the child-prefix was not deleted from the ipam database. TODO: test changing the child-prefix
 func TestChildPrefix(t *testing.T) {
@@ -406,10 +406,12 @@ func TestChildPrefix(t *testing.T) {
 	password := "floofykittens"
 	username, cleanup := helper.createNewUser(ctx, password)
 	defer cleanup()
-	node3LoopbackNet := "172.16.10.101/32"
 	node2LoopbackNet := "172.16.20.102/32"
-	node3ChildPrefix := "172.16.10.0/24"
-	node2ChildPrefix := "172.16.20.0/24"
+	node3LoopbackNet := "172.16.10.101/32"
+	node2LoopbackNetV6 := "200:2::1/64"
+	node3LoopbackNetV6 := "200:3::1/64"
+	node2ChildPrefix := "172.16.20.0/24,200:2::/64"
+	node3ChildPrefix := "172.16.10.0/24,200:3::/64"
 
 	// create the nodes
 	node1, stop := helper.CreateNode(ctx, "node1", []string{defaultNetwork}, enableV6)
@@ -439,17 +441,31 @@ func TestChildPrefix(t *testing.T) {
 		"router", fmt.Sprintf("--child-prefix=%s", node3ChildPrefix),
 	)
 
-	// add loopbacks to the containers that are contained in the node's child prefix
+	// add v4 loopbacks to the containers that are contained in the node's child prefix
 	_, err = helper.containerExec(ctx, node3, []string{"ip", "addr", "add", node3LoopbackNet, "dev", "lo"})
 	require.NoError(err)
 	_, err = helper.containerExec(ctx, node2, []string{"ip", "addr", "add", node2LoopbackNet, "dev", "lo"})
+	require.NoError(err)
+	// add v6 loopbacks to the containers that are contained in the node's child prefix
+	_, err = helper.containerExec(ctx, node3, []string{"ip", "-6", "addr", "add", node3LoopbackNetV6, "dev", "lo"})
+	require.NoError(err)
+	_, err = helper.containerExec(ctx, node2, []string{"ip", "-6", "addr", "add", node2LoopbackNetV6, "dev", "lo"})
 	require.NoError(err)
 
 	// parse the loopback ip from the loopback prefix
 	node3LoopbackIP, _, _ := net.ParseCIDR(node3LoopbackNet)
 	node2LoopbackIP, _, _ := net.ParseCIDR(node2LoopbackNet)
+	// parse the loopback ipv6 from the loopback prefix
+	node3LoopbackIPv6, _, _ := net.ParseCIDR(node3LoopbackNetV6)
+	node2LoopbackIPv6, _, _ := net.ParseCIDR(node2LoopbackNetV6)
 
-	// address will be the same, this is just a readiness check for gather data
+	// readiness check
+	err = helper.nexdStatus(ctx, node2)
+	require.NoError(err)
+	err = helper.nexdStatus(ctx, node3)
+	require.NoError(err)
+
+	// gather the wg0 v4 addresses
 	node3IP, err := getContainerIfaceIP(ctx, inetV4, "wg0", node3)
 	require.NoError(err)
 	node2IP, err := getContainerIfaceIP(ctx, inetV4, "wg0", node2)
@@ -471,7 +487,15 @@ func TestChildPrefix(t *testing.T) {
 	err = ping(ctx, node2, inetV4, node3LoopbackIP.String())
 	require.NoError(err)
 
-	// kill the nexodus process on both nodes
+	helper.Logf("Pinging %s from node3", node2LoopbackIPv6)
+	err = ping(ctx, node3, inetV6, node2LoopbackIPv6.String())
+	require.NoError(err)
+
+	helper.Logf("Pinging %s from node2", node3LoopbackIPv6)
+	err = ping(ctx, node2, inetV6, node3LoopbackIPv6.String())
+	require.NoError(err)
+
+	// kill the nexodus process on all nodes
 	_, err = helper.containerExec(ctx, node1, []string{"killall", "nexd"})
 	require.NoError(err)
 	_, err = helper.containerExec(ctx, node2, []string{"killall", "nexd"})
@@ -501,10 +525,10 @@ func TestChildPrefix(t *testing.T) {
 			"router", fmt.Sprintf("--child-prefix=%s", node3ChildPrefix),
 		)
 
-		// address will be the same, this is just a readiness check for gather data
-		node3IP, err = getContainerIfaceIP(ctx, inetV4, "wg0", node3)
+		// readiness check
+		err = helper.nexdStatus(ctx, node2)
 		require.NoError(err)
-		node2IP, err = getContainerIfaceIP(ctx, inetV4, "wg0", node2)
+		err = helper.nexdStatus(ctx, node3)
 		require.NoError(err)
 		// kill nexd only on the 1st run in the loop
 		if i == 0 {
@@ -532,6 +556,14 @@ func TestChildPrefix(t *testing.T) {
 
 	helper.Logf("Pinging %s from node2", node3LoopbackIP)
 	err = ping(ctx, node2, inetV4, node3LoopbackIP.String())
+	require.NoError(err)
+
+	helper.Logf("Pinging %s from node3", node2LoopbackIPv6)
+	err = ping(ctx, node3, inetV6, node2LoopbackIPv6.String())
+	require.NoError(err)
+
+	helper.Logf("Pinging %s from node2", node3LoopbackIPv6)
+	err = ping(ctx, node2, inetV6, node3LoopbackIPv6.String())
 	require.NoError(err)
 }
 

--- a/internal/handlers/device_test.go
+++ b/internal/handlers/device_test.go
@@ -6,8 +6,10 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"testing"
 
 	"github.com/nexodus-io/nexodus/internal/models"
+	"github.com/stretchr/testify/assert"
 )
 
 func (suite *HandlerTestSuite) TestCreateGetDevice() {
@@ -56,4 +58,45 @@ func (suite *HandlerTestSuite) TestCreateGetDevice() {
 	require.NoError(err)
 
 	assert.Equal(actual, device)
+}
+
+func TestChildPrefixEquals(t *testing.T) {
+	tests := []struct {
+		name         string
+		childPrefixA []string
+		childPrefixB []string
+		expected     bool
+	}{
+		{
+			name:         "identical slices",
+			childPrefixA: []string{"192.168.1.0/24", "2001:db8::/32"},
+			childPrefixB: []string{"192.168.1.0/24", "2001:db8::/32"},
+			expected:     true,
+		},
+		{
+			name:         "different length slices",
+			childPrefixA: []string{"192.168.1.0/24", "2001:db8::/32"},
+			childPrefixB: []string{"192.168.1.0/24"},
+			expected:     false,
+		},
+		{
+			name:         "different CIDR ranges",
+			childPrefixA: []string{"192.168.1.0/24", "2001:db8::/32"},
+			childPrefixB: []string{"192.168.2.0/24", "2001:db8::/32"},
+			expected:     false,
+		},
+		{
+			name:         "same CIDR ranges, different order",
+			childPrefixA: []string{"192.168.1.0/24", "2001:db8::/32"},
+			childPrefixB: []string{"2001:db8::/32", "192.168.1.0/24"},
+			expected:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := childPrefixEquals(tt.childPrefixA, tt.childPrefixB)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
 }

--- a/internal/handlers/user.go
+++ b/internal/handlers/user.go
@@ -311,7 +311,7 @@ func (api *API) DeleteUserFromOrganization(c *gin.Context) {
 			Where("user_id = ?", userID).
 			Where("organization_id = ?", orgID).
 			Delete(&UserOrganization{}); res.Error != nil {
-			c.JSON(http.StatusInternalServerError, models.NewApiInternalError(fmt.Errorf("WTF failed to remove the association from the user_organizations table: %w", res.Error)))
+			c.JSON(http.StatusInternalServerError, models.NewApiInternalError(fmt.Errorf("failed to remove the association from the user_organizations table: %w", res.Error)))
 		}
 		return nil
 	})

--- a/internal/util/ip_utils.go
+++ b/internal/util/ip_utils.go
@@ -84,3 +84,13 @@ func IsDefaultIPv6Route(ip string) bool {
 	ipv6Default := net.ParseIP("::")
 	return ipAddr.Equal(ipv6Default) || (ipNet != nil && ipNet.IP.Equal(ipv6Default) && ipNet.Mask.String() == "<nil>")
 }
+
+// IsDefaultIPRoute wrapper for IsDefaultIPv4Route and IsDefaultIPv6Route
+func IsDefaultIPRoute(ip string) bool {
+	return IsDefaultIPv4Route(ip) || IsDefaultIPv6Route(ip)
+}
+
+// IsValidPrefix checks if the given cidr is valid
+func IsValidPrefix(prefix string) bool {
+	return IsIPv4Prefix(prefix) || IsIPv6Prefix(prefix)
+}

--- a/internal/util/ip_utils.go
+++ b/internal/util/ip_utils.go
@@ -56,3 +56,31 @@ func AppendPrefixMask(ipStr string, maskSize int) (string, error) {
 
 	return ipNet.String(), nil
 }
+
+// IsDefaultIPv4Route checks if the given prefix is the default route for IPv4.
+func IsDefaultIPv4Route(ip string) bool {
+	ipAddr, ipNet, err := net.ParseCIDR(ip)
+	if err != nil {
+		ipAddr = net.ParseIP(ip)
+		if ipAddr == nil {
+			return false
+		}
+	}
+
+	ipv4Default := net.IPv4(0, 0, 0, 0)
+	return ipAddr.Equal(ipv4Default) || (ipNet != nil && ipNet.IP.Equal(ipv4Default) && ipNet.Mask.String() == "0.0.0.0")
+}
+
+// IsDefaultIPv6Route checks if the given prefix is the default route for IPv6.
+func IsDefaultIPv6Route(ip string) bool {
+	ipAddr, ipNet, err := net.ParseCIDR(ip)
+	if err != nil {
+		ipAddr = net.ParseIP(ip)
+		if ipAddr == nil {
+			return false
+		}
+	}
+
+	ipv6Default := net.ParseIP("::")
+	return ipAddr.Equal(ipv6Default) || (ipNet != nil && ipNet.IP.Equal(ipv6Default) && ipNet.Mask.String() == "<nil>")
+}

--- a/internal/util/ip_utils_test.go
+++ b/internal/util/ip_utils_test.go
@@ -2,6 +2,8 @@ package util
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 // TestIsIPv4Address tests the IsIPv4Address function.
@@ -118,6 +120,46 @@ func TestAppendPrefixMask(t *testing.T) {
 			if result != tt.expected {
 				t.Errorf("AppendPrefixMask() got = %v, want = %v", result, tt.expected)
 			}
+		})
+	}
+}
+
+// TestIsIPv4DefaultRoute tests the IsIPv4DefaultRoute function.
+func TestIsDefaultIPv4Route(t *testing.T) {
+	testCases := []struct {
+		input    string
+		expected bool
+	}{
+		{"0.0.0.0", true},
+		{"0.0.0.0/0", true},
+		{"192.168.1.1", false},
+		{"192.168.1.1/24", false},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.input, func(t *testing.T) {
+			result := IsDefaultIPv4Route(tt.input)
+			assert.Equal(t, tt.expected, result, "isDefaultIPv4Route(%q) should be %t", tt.input, tt.expected)
+		})
+	}
+}
+
+// TestIsIPv6DefaultRoute tests the IsIPv6DefaultRoute function.
+func TestIsDefaultIPv6Route(t *testing.T) {
+	testCases := []struct {
+		input    string
+		expected bool
+	}{
+		{"::", true},
+		{"::/0", true},
+		{"2001::1", false},
+		{"2001::1/64", false},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.input, func(t *testing.T) {
+			result := IsDefaultIPv6Route(tt.input)
+			assert.Equal(t, tt.expected, result, "isDefaultIPv6Route(%q) should be %t", tt.input, tt.expected)
 		})
 	}
 }

--- a/internal/util/ip_utils_test.go
+++ b/internal/util/ip_utils_test.go
@@ -134,6 +134,7 @@ func TestIsDefaultIPv4Route(t *testing.T) {
 		{"0.0.0.0/0", true},
 		{"192.168.1.1", false},
 		{"192.168.1.1/24", false},
+		{"invalid-default-route", false},
 	}
 
 	for _, tt := range testCases {
@@ -154,6 +155,7 @@ func TestIsDefaultIPv6Route(t *testing.T) {
 		{"::/0", true},
 		{"2001::1", false},
 		{"2001::1/64", false},
+		{"invalid-default-route", false},
 	}
 
 	for _, tt := range testCases {


### PR DESCRIPTION
- Adds a function and tests to compare the existing vs new prefix request.
- Adds e2e that tests for this condition.
- Tracked in #982
- IPAM errors out of a default route is added as a child prefix
  since that creates an overlap. Its not important to store an
  exit-node prefix in IPAM, so this skips adding a 0.0.0.0 or ::/0
  as a child-prefix.
- Adds ipv6 child prefix support.
