### PR TITLE
apiserver: implement ext_autz grpc endpoint

### DIFF
--- a/deploy/nexodus/base/apiproxy/files/envoy.yaml
+++ b/deploy/nexodus/base/apiproxy/files/envoy.yaml
@@ -79,6 +79,26 @@ static_resources:
                       address: frontend
                       port_value: 3000
 
+    - name: ext-authz
+      type: STRICT_DNS
+      dns_lookup_family: V4_ONLY
+      lb_policy: ROUND_ROBIN
+      connect_timeout: 1s
+      typed_extension_protocol_options:
+        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+          "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+          explicit_http_config:
+            http2_protocol_options: {}
+      load_assignment:
+        cluster_name: ext-authz
+        endpoints:
+          - lb_endpoints:
+              - endpoint:
+                  address:
+                    socket_address:
+                      address: apiserver
+                      port_value: 5080
+
     # upstream server: ratelimiter
     # used to access the rate limiting service.
     - name: ratelimiter
@@ -198,6 +218,18 @@ static_resources:
                     typed_config:
                       "@type": type.googleapis.com/envoy.extensions.filters.http.cors.v3.Cors
 
+                  - name: envoy.filters.http.ext_authz
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz
+                      grpc_service:
+                        envoy_grpc:
+                          cluster_name: ext-authz
+                        timeout: 2s
+                      transport_api_version: V3
+                      failure_mode_allow: false
+                      status_on_error:
+                        code: 503
+
                   # For JWT verification
                   - name: envoy.filters.http.jwt_authn
                     typed_config:
@@ -255,6 +287,10 @@ static_resources:
                         - name: default
                           match:
                             prefix: /
+                          typed_per_filter_config:
+                            envoy.filters.http.ext_authz:
+                              "@type": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute
+                              disabled: true
                           route:
                             timeout: 10s
                             cluster: frontend

--- a/deploy/nexodus/base/apiserver/deployment.yaml
+++ b/deploy/nexodus/base/apiserver/deployment.yaml
@@ -145,5 +145,9 @@ spec:
             limits:
               cpu: 100m
               memory: 200Mi
-
+          ports:
+            - containerPort: 8080
+              name: web
+            - containerPort: 5080
+              name: ext-authz
       restartPolicy: Always

--- a/deploy/nexodus/base/apiserver/service.yaml
+++ b/deploy/nexodus/base/apiserver/service.yaml
@@ -12,3 +12,6 @@ spec:
     - name: web
       port: 8080
       targetPort: 8080
+    - name: ext-authz
+      port: 5080
+      targetPort: 5080

--- a/docs/development/design/rate-limiting.md
+++ b/docs/development/design/rate-limiting.md
@@ -21,9 +21,8 @@ Using an Envoy proxy has the following benefits:
 * Some K8s platforms are moving to envoy as the Ingress gateway so in the future we may be able to move this functionality into the ingress gateway (avoiding a proxy hop).
 * Aligned with service mesh deployment models.
 
-The login handlers for the frontend will need to set the `AccessToken` http only Cookie.  
-API requests from devices will pass the AccessToken as a bearer token in the `Authentication` header.  
-This will allow the Envoy proxy to have easy access to the AccessToken for requests being sent to the apiserver.  
+Web based UI interactions will store the user OAuth token in a Redis backed session.  Envoy use the [External Authorization Filter](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/security/ext_authz_filter#arch-overview-ext-authz) to set `Authentication` header to `AccessToken` obtained form the OAuth login.   This will allow the Envoy proxy to have easy access to the AccessToken for all API requests being sent to the apiserver.  
+
 The JWT AccessToken will then be validated in Envoy and it's claims passed to limitador to enforce per-user rate limits.  
 Envoy can then send 429 responses for any requests that have been rate limited.  
 Since a valid AccessToken is needed, we will be able to identify the tenant generating the source of the traffic even if client trying to create multiple sessions or changing source IPs.

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/coreos/go-oidc/v3 v3.6.0
 	github.com/cucumber/godog v0.12.6
 	github.com/docker/docker v23.0.5+incompatible
+	github.com/envoyproxy/go-control-plane v0.11.0
 	github.com/fatih/color v1.15.0
 	github.com/gin-contrib/cors v1.4.0
 	github.com/gin-contrib/zap v0.1.0
@@ -69,6 +70,7 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bytedance/sonic v1.9.1 // indirect
 	github.com/chenzhuoyu/base64x v0.0.0-20221115062448-fe3a3abad311 // indirect
+	github.com/cncf/xds/go v0.0.0-20230310173818-32f1caf87195 // indirect
 	github.com/containerd/containerd v1.6.19 // indirect
 	github.com/cpuguy83/dockercfg v0.3.1 // indirect
 	github.com/cucumber/gherkin-go/v19 v19.0.3 // indirect
@@ -76,6 +78,7 @@ require (
 	github.com/docker/distribution v2.8.2+incompatible // indirect
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
+	github.com/envoyproxy/protoc-gen-validate v0.10.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.2 // indirect
 	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/go-logr/logr v1.2.4 // indirect
@@ -199,7 +202,7 @@ require (
 	golang.org/x/sync v0.1.0 // indirect
 	golang.org/x/text v0.9.0 // indirect
 	golang.org/x/tools v0.7.0 // indirect
-	google.golang.org/genproto v0.0.0-20230306155012-7f2fa6fef1f4 // indirect
+	google.golang.org/genproto v0.0.0-20230306155012-7f2fa6fef1f4
 	google.golang.org/grpc v1.55.0
 	google.golang.org/protobuf v1.30.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -105,6 +105,8 @@ github.com/cncf/xds/go v0.0.0-20210312221358-fbca930ec8ed/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20210805033703-aa0b78936158/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
+github.com/cncf/xds/go v0.0.0-20230310173818-32f1caf87195 h1:58f1tJ1ra+zFINPlwLWvQsR9CzAKt2e+EWV2yX9oXQ4=
+github.com/cncf/xds/go v0.0.0-20230310173818-32f1caf87195/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cockroachdb/cockroach-go/v2 v2.3.3 h1:fNmtG6XhoA1DhdDCIu66YyGSsNb1szj4CaAsbDxRmy4=
 github.com/cockroachdb/cockroach-go/v2 v2.3.3/go.mod h1:1wNJ45eSXW9AnOc3skntW9ZUZz6gxrQK3cOj3rK+BC8=
 github.com/containerd/console v1.0.3/go.mod h1:7LqA/THxQ86k76b8c/EMSiaJ3h1eZkMkXar0TQ1gf3U=
@@ -162,7 +164,11 @@ github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1m
 github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210512163311-63b5d3c536b0/go.mod h1:hliV/p42l8fGbc6Y9bQ70uLwIvmJyVE5k4iMKlh8wCQ=
 github.com/envoyproxy/go-control-plane v0.9.10-0.20210907150352-cf90f659a021/go.mod h1:AFq3mo9L8Lqqiid3OhADV3RfLJnjiw63cSpi+fDTRC0=
+github.com/envoyproxy/go-control-plane v0.11.0 h1:jtLewhRR2vMRNnq2ZZUoCjUlgut+Y0+sDDWPOfwOi1o=
+github.com/envoyproxy/go-control-plane v0.11.0/go.mod h1:VnHyVMpzcLvCFt9yUz1UnCwHLhwx1WguiVDV7pTG/tI=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
+github.com/envoyproxy/protoc-gen-validate v0.10.0 h1:oIfnZFdC0YhpNNEX+SuIqko4cqqVZeN9IGTrhZje83Y=
+github.com/envoyproxy/protoc-gen-validate v0.10.0/go.mod h1:DRjgyB0I43LtJapqN6NiRwroiAU2PaFuvk/vjgh61ss=
 github.com/fatih/color v1.15.0 h1:kOqh6YHBtK8aywxGerMG2Eq3H6Qgoqeo13Bk2Mv/nBs=
 github.com/fatih/color v1.15.0/go.mod h1:0h5ZqXfHYED7Bhv2ZJamyIOUej9KtShiJESRwBDUSsw=
 github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8vw=

--- a/hack/ext-authz-client/main.go
+++ b/hack/ext-authz-client/main.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	auth "github.com/envoyproxy/go-control-plane/envoy/service/auth/v3"
+	"github.com/nexodus-io/nexodus/internal/util"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"os"
+)
+
+func check(server string) error {
+	var opts []grpc.DialOption
+	opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.Dial(server, opts...)
+	if err != nil {
+		return err
+	}
+	defer util.IgnoreError(conn.Close)
+	c := auth.NewAuthorizationClient(conn)
+
+	response, err := c.Check(context.Background(), &auth.CheckRequest{})
+	if err != nil {
+		return err
+	}
+	fmt.Printf("%+v\n", response)
+	return nil
+}
+
+func main() {
+	server := "localhost:5080"
+	if len(os.Args) > 1 {
+		server = os.Args[1]
+	}
+	err := check(server)
+	if err != nil {
+		panic(err)
+	}
+}

--- a/internal/handlers/api.go
+++ b/internal/handlers/api.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"context"
+	"github.com/go-session/session/v3"
 	"github.com/nexodus-io/nexodus/internal/signalbus"
 	"github.com/redis/go-redis/v9"
 
@@ -26,19 +27,31 @@ func init() {
 }
 
 type API struct {
-	logger        *zap.SugaredLogger
-	db            *gorm.DB
-	ipam          ipam.IPAM
-	defaultZoneID uuid.UUID
-	fflags        *fflags.FFlags
-	transaction   database.TransactionFunc
-	dialect       database.Dialect
-	store         storage.Store
-	signalBus     signalbus.SignalBus
-	redis         *redis.Client
+	logger         *zap.SugaredLogger
+	db             *gorm.DB
+	ipam           ipam.IPAM
+	defaultZoneID  uuid.UUID
+	fflags         *fflags.FFlags
+	transaction    database.TransactionFunc
+	dialect        database.Dialect
+	store          storage.Store
+	signalBus      signalbus.SignalBus
+	redis          *redis.Client
+	sessionManager *session.Manager
 }
 
-func NewAPI(parent context.Context, logger *zap.SugaredLogger, db *gorm.DB, ipam ipam.IPAM, fflags *fflags.FFlags, store storage.Store, signalBus signalbus.SignalBus, redis *redis.Client) (*API, error) {
+func NewAPI(
+	parent context.Context,
+	logger *zap.SugaredLogger,
+	db *gorm.DB,
+	ipam ipam.IPAM,
+	fflags *fflags.FFlags,
+	store storage.Store,
+	signalBus signalbus.SignalBus,
+	redis *redis.Client,
+	sessionManager *session.Manager,
+) (*API, error) {
+
 	ctx, span := tracer.Start(parent, "NewAPI")
 	defer span.End()
 
@@ -48,16 +61,17 @@ func NewAPI(parent context.Context, logger *zap.SugaredLogger, db *gorm.DB, ipam
 	}
 
 	api := &API{
-		logger:        logger,
-		db:            db,
-		ipam:          ipam,
-		defaultZoneID: uuid.Nil,
-		fflags:        fflags,
-		transaction:   transactionFunc,
-		dialect:       dialect,
-		store:         store,
-		signalBus:     signalBus,
-		redis:         redis,
+		logger:         logger,
+		db:             db,
+		ipam:           ipam,
+		defaultZoneID:  uuid.Nil,
+		fflags:         fflags,
+		transaction:    transactionFunc,
+		dialect:        dialect,
+		store:          store,
+		signalBus:      signalBus,
+		redis:          redis,
+		sessionManager: sessionManager,
 	}
 
 	if err := api.populateStore(ctx); err != nil {

--- a/internal/handlers/envoy_authz.go
+++ b/internal/handlers/envoy_authz.go
@@ -1,0 +1,78 @@
+package handlers
+
+import (
+	"context"
+	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	auth "github.com/envoyproxy/go-control-plane/envoy/service/auth/v3"
+	"github.com/nexodus-io/nexodus/pkg/oidcagent"
+	"google.golang.org/genproto/googleapis/rpc/status"
+	"google.golang.org/grpc/codes"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+)
+
+const SESSION_ID_COOKIE_NAME = "sid"
+
+// Check implements Envoy Authorization service. Proto file:
+// https://github.com/envoyproxy/envoy/blob/main/api/envoy/service/auth/v3/external_auth.proto
+//
+// We use this to convert the browser cookie to a JWT in the authorization header.  This can then be
+// used by envoy to rate limit requests.
+func (api *API) Check(ctx context.Context, checkReq *auth.CheckRequest) (*auth.CheckResponse, error) {
+
+	okResponse := &auth.CheckResponse{
+		Status: &status.Status{Code: int32(codes.OK)},
+		HttpResponse: &auth.CheckResponse_OkResponse{
+			OkResponse: &auth.OkHttpResponse{},
+		},
+	}
+
+	if checkReq.Attributes.Request.Http.Headers["authorization"] != "" {
+		return okResponse, nil
+	}
+
+	// Can use a cookie to get the authorization header?
+	req := &http.Request{
+		URL:    &url.URL{},
+		Header: map[string][]string{},
+	}
+	for k, v := range checkReq.Attributes.Request.Http.Headers {
+		if k == "cookie" {
+			k = "Cookie"
+		}
+		req.Header[k] = []string{v}
+	}
+	resp := &httptest.ResponseRecorder{}
+
+	session, err := api.sessionManager.Start(ctx, resp, req)
+	if err != nil {
+		return okResponse, nil
+	}
+
+	tokenRaw, ok := session.Get(oidcagent.TokenKey)
+	if !ok {
+		return okResponse, nil
+	}
+	token, err := oidcagent.JsonStringToToken(tokenRaw.(string))
+	if err != nil {
+		return okResponse, nil
+	}
+
+	// add the access token header to the upstream requests..
+	return &auth.CheckResponse{
+		Status: &status.Status{Code: int32(codes.OK)},
+		HttpResponse: &auth.CheckResponse_OkResponse{
+			OkResponse: &auth.OkHttpResponse{
+				Headers: []*core.HeaderValueOption{
+					{
+						Header: &core.HeaderValue{
+							Key:   "authorization",
+							Value: "Bearer " + token.AccessToken,
+						},
+					},
+				},
+			},
+		},
+	}, nil
+}

--- a/internal/handlers/handlers_test.go
+++ b/internal/handlers/handlers_test.go
@@ -71,7 +71,7 @@ func (suite *HandlerTestSuite) SetupSuite() {
 	})
 	fflags := fflags.NewFFlags(suite.logger)
 	store := inmem.New()
-	suite.api, err = NewAPI(context.Background(), suite.logger, db, ipamClient, fflags, store, signalbus.NewSignalBus(), redisClient)
+	suite.api, err = NewAPI(context.Background(), suite.logger, db, ipamClient, fflags, store, signalbus.NewSignalBus(), redisClient, nil)
 	if err != nil {
 		suite.T().Fatal(err)
 	}

--- a/internal/routers/middleware.go
+++ b/internal/routers/middleware.go
@@ -3,9 +3,6 @@ package routers
 import (
 	"context"
 	_ "embed"
-	"github.com/go-session/redis/v3"
-	"github.com/go-session/session/v3"
-	"github.com/nexodus-io/nexodus/pkg/ginsession"
 	"io"
 	"net/http"
 	"strings"
@@ -55,18 +52,8 @@ func ValidateJWT(ctx context.Context, o APIRouterOptions, jwksURI string) (func(
 			return
 		}
 
-		authz := c.Request.Header.Get("Authorization")
-		if authz == "" {
-
-			accessToken, err := c.Cookie("AccessToken")
-			if err != nil {
-				c.AbortWithStatus(http.StatusUnauthorized)
-				return
-			}
-			authz = "Bearer " + accessToken
-		}
-
-		parts := strings.Split(authz, " ")
+		authHeader := c.Request.Header.Get("Authorization")
+		parts := strings.Split(authHeader, " ")
 		if len(parts) != 2 {
 			c.AbortWithStatus(http.StatusUnauthorized)
 			return
@@ -188,13 +175,4 @@ func getURLAsText(ctx context.Context, jwksURL string) (string, error) {
 
 	keySet := string(body)
 	return keySet, nil
-}
-
-func RedisSessionMiddleware(o APIRouterOptions) gin.HandlerFunc {
-	return ginsession.New(
-		session.SetCookieName("sid"),
-		session.SetStore(redis.NewRedisStore(&redis.Options{
-			Addr: o.RedisServer,
-			DB:   o.RedisDB,
-		})))
 }

--- a/pkg/oidcagent/handlers.go
+++ b/pkg/oidcagent/handlers.go
@@ -213,13 +213,6 @@ func (o *OidcAgent) LoginEnd(c *gin.Context) {
 			return
 		}
 		logger.With("session_id", session.SessionID()).Debug("user is logged in")
-
-		expiresIn := 0
-		if !oauth2Token.Expiry.IsZero() {
-			expiresIn = int(time.Until(oauth2Token.Expiry).Seconds())
-		}
-		c.SetCookie("AccessToken", oauth2Token.AccessToken, expiresIn, "/", "", true, true)
-
 		loggedIn = true
 	} else {
 		logger.Debug("checking if user is logged in")
@@ -252,7 +245,7 @@ func (o *OidcAgent) UserInfo(c *gin.Context) {
 		c.AbortWithStatus(http.StatusUnauthorized)
 		return
 	}
-	token, err := jsonStringToToken(tokenRaw.(string))
+	token, err := JsonStringToToken(tokenRaw.(string))
 	if err != nil {
 		c.AbortWithStatus(http.StatusInternalServerError)
 		return
@@ -340,7 +333,7 @@ func (o *OidcAgent) Refresh(c *gin.Context) {
 		c.AbortWithStatus(http.StatusUnauthorized)
 		return
 	}
-	token, err := jsonStringToToken(tokenRaw.(string))
+	token, err := JsonStringToToken(tokenRaw.(string))
 	if err != nil {
 		c.AbortWithStatus(http.StatusInternalServerError)
 		return
@@ -362,13 +355,6 @@ func (o *OidcAgent) Refresh(c *gin.Context) {
 		c.AbortWithStatus(http.StatusInternalServerError)
 		return
 	}
-
-	expiresIn := 0
-	if !token.Expiry.IsZero() {
-		expiresIn = int(time.Until(token.Expiry).Seconds())
-	}
-	c.SetCookie("AccessToken", token.AccessToken, expiresIn, "/", "", true, true)
-
 	c.Status(http.StatusNoContent)
 }
 
@@ -415,7 +401,7 @@ func (o *OidcAgent) CodeFlowProxy(c *gin.Context) {
 		c.AbortWithStatus(http.StatusUnauthorized)
 		return
 	}
-	token, err := jsonStringToToken(tokenRaw.(string))
+	token, err := JsonStringToToken(tokenRaw.(string))
 	if err != nil {
 		c.AbortWithStatus(http.StatusInternalServerError)
 		return
@@ -482,7 +468,7 @@ func tokenToJSONString(t *oauth2.Token) (string, error) {
 	return string(b), nil
 }
 
-func jsonStringToToken(s string) (*oauth2.Token, error) {
+func JsonStringToToken(s string) (*oauth2.Token, error) {
 	var t oauth2.Token
 	if err := json.Unmarshal([]byte(s), &t); err != nil {
 		return nil, err


### PR DESCRIPTION
We were stuffing the AccessToken in a browser cookie. With this change we get the AccessToken from the redis session.  This lowers the amount of data placed into browser cookies to just being the Redis session id.

This will also give us a place to implement per device API token in the future.