### PR TITLE
rpm: Build centos-stream-9 rpms in the right root

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -139,7 +139,7 @@ jobs:
         include:
           - mock_root: fedora-38-x86_64
             srpm_distro: fc38
-          - mock_root: centos-stream-9-x86_64
+          - mock_root: centos-stream+epel-9-x86_64
             srpm_distro: el9
     steps:
       - uses: actions/checkout@v3
@@ -161,4 +161,5 @@ jobs:
         run: |
           echo "${{ secrets.COPR_CONFIG }}" > ~/.config/copr
           docker run --name copr-cli -v "$(pwd):/nexodus" -v ~/.config:/root/.config quay.io/nexodus/mock:latest \
-              copr-cli build nexodus -r "${{ matrix.mock_root }}" --nowait "/nexodus/dist/rpm/mock/nexodus-0-0.1.$(date +%Y%m%d)git$(git describe --always).${{ matrix.srpm_distro }}.src.rpm"
+              copr-cli build nexodus -r "$(echo ${{ matrix.mock_root }} | cut -f2 -d'+')" --nowait \
+              "/nexodus/dist/rpm/mock/nexodus-0-0.1.$(date +%Y%m%d)git$(git describe --always).${{ matrix.srpm_distro }}.src.rpm"

--- a/contrib/rpm/nexodus.spec.in
+++ b/contrib/rpm/nexodus.spec.in
@@ -84,11 +84,6 @@ for cmd in nexd nexctl ; do
   install -p -D -m 0644 contrib/man/${cmd}.8.gz %{buildroot}%{_mandir}/man8/${cmd}.8.gz
 done
 
-%if %{with check}
-%check
-%gocheck
-%endif
-
 %files
 %license LICENSE
 %doc docs DCO CONTRIBUTING.md README.md


### PR DESCRIPTION
You'd think `centos-stream-9` is the right mock root to build CentOS
Stream 9 packages, but it is not. When you enable a copr repo on CentOS
Stream 9, it enables the `epel-9` repository for that copr project, not
the `centos-stream-9` repo.

When doing this build with mock, `epel-9` is not sufficient. You must
also specify the base distro that `epel-9` is applied on top of, so
there we must specify `centos-stream+epel-9`.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
