### PR TITLE
nexd: Move peer setup msg to debug

### DIFF
--- a/internal/nexodus/wg_deploy.go
+++ b/internal/nexodus/wg_deploy.go
@@ -42,6 +42,6 @@ func (ax *Nexodus) DeployWireguardConfig(newPeers []public.ModelsDevice, firstTi
 		}
 	}
 
-	ax.logger.Infof("Peer setup complete")
+	ax.logger.Debug("Peer setup complete")
 	return nil
 }


### PR DESCRIPTION
Recent commits moved other peering setup details to be debug messages,
so this one stands out as not helpful on its own with the debug
counterparts.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
