### PR TITLE
nexd: Merge two device registration logs

### DIFF
--- a/internal/nexodus/nexodus.go
+++ b/internal/nexodus/nexodus.go
@@ -342,7 +342,6 @@ func (ax *Nexodus) Start(ctx context.Context, wg *sync.WaitGroup) error {
 	if len(organizations) != 1 {
 		return fmt.Errorf("user being in > 1 organization is not yet supported")
 	}
-	ax.logger.Infof("Device belongs in organization: %s (%s)", organizations[0].Name, organizations[0].Id)
 	ax.organization = organizations[0].Id
 
 	informerCtx, informerCancel := context.WithCancel(ctx)
@@ -424,7 +423,8 @@ func (ax *Nexodus) Start(ctx context.Context, wg *sync.WaitGroup) error {
 	}
 
 	ax.logger.Debug(fmt.Sprintf("Device: %+v", modelsDevice))
-	ax.logger.Infof("Successfully registered device with UUID: %+v", modelsDevice.Id)
+	ax.logger.Infof("Successfully registered device with UUID: [ %+v ] into organization: [ %s (%s) ]",
+		modelsDevice.Id, organizations[0].Name, organizations[0].Id)
 
 	// a relay node requires ip forwarding and nftable rules, OS type has already been checked
 	if ax.relay {


### PR DESCRIPTION
Previously, nexd produced a log message that said "Device belongs in
organization: ..." prior to creating the device. I found this a little
bit confusing, so I combined the logs into one that says "registered
device into organization".

Here is the specific new log message from my dev environment:

    {"level":"info","ts":1683742835.132936,"caller":"nexodus/nexodus.go:426","msg":"Successfully
	registered device with UUID: [ f7dc75ae-3d35-4541-b690-812a6a21c3a5 ]
	into organization: [ admin (351e9543-fddb-4234-ad53-af9da8ba837c) ]"}

Signed-off-by: Russell Bryant <rbryant@redhat.com>
