### PR TITLE
Add logging for symmetric nat discovery

### DIFF
--- a/internal/nexodus/nexodus.go
+++ b/internal/nexodus/nexodus.go
@@ -574,7 +574,6 @@ func (ax *Nexodus) reconcileStun(deviceID string) error {
 			}
 		}
 	}
-	ax.logger.Debugf("reflexive binding is %s", reflexiveIP)
 
 	return nil
 }
@@ -658,11 +657,11 @@ func (ax *Nexodus) symmetricNatDisco() error {
 	// discover the server reflexive address per ICE RFC8445
 	stunServer1 := NextStunServer()
 	stunServer2 := NextStunServer()
-	stunAddr, err := stunRequest(ax.logger, stunServer1, ax.listenPort)
+	stunAddr1, err := stunRequest(ax.logger, stunServer1, ax.listenPort)
 	if err != nil {
 		return err
 	} else {
-		ax.nodeReflexiveAddressIPv4 = stunAddr
+		ax.nodeReflexiveAddressIPv4 = stunAddr1
 	}
 
 	isSymmetric := false
@@ -670,7 +669,19 @@ func (ax *Nexodus) symmetricNatDisco() error {
 	if err != nil {
 		return err
 	} else {
-		isSymmetric = stunAddr.String() != stunAddr2.String()
+		isSymmetric = stunAddr1.String() != stunAddr2.String()
+	}
+
+	if stunAddr1.Addr().String() != "" {
+		ax.logger.Debugf("first NAT discovery STUN request returned: %s", stunAddr1.String())
+	} else {
+		ax.logger.Debugf("first NAT discovery STUN request returned an empty value")
+	}
+
+	if stunAddr2.Addr().String() != "" {
+		ax.logger.Debugf("second NAT discovery STUN request returned: %s", stunAddr2.String())
+	} else {
+		ax.logger.Debugf("second NAT discovery STUN request returned an empty value")
 	}
 
 	if isSymmetric {

--- a/internal/nexodus/stun_darwin.go
+++ b/internal/nexodus/stun_darwin.go
@@ -58,7 +58,7 @@ func stunRequest(logger *zap.SugaredLogger, stunServer string, srcPort int) (net
 	if err != nil {
 		return netip.AddrPort{}, fmt.Errorf("failed to parse a valid address:port binding from the stun response: %w", err)
 	}
-	logger.Debugf("STUN: your public facing ip:port binding is: %s", xorBinding.String())
+	logger.Debugf("reflexive binding is: %s", xorBinding.String())
 
 	return xorBinding, nil
 }

--- a/internal/nexodus/stun_linux.go
+++ b/internal/nexodus/stun_linux.go
@@ -163,12 +163,11 @@ func stunListen(logger *zap.SugaredLogger, conn *ipv4.PacketConn) (messages chan
 	go func() {
 		for {
 			buf := make([]byte, 1500)
-			n, _, addr, err := conn.ReadFrom(buf)
+			n, _, _, err := conn.ReadFrom(buf)
 			if err != nil {
 				close(messages)
 				return
 			}
-			logger.Debugf("response from %v: (%v bytes)", addr, n)
 			// cut UDP header, cut postfix
 			buf = buf[8:n]
 

--- a/internal/nexodus/stun_windows.go
+++ b/internal/nexodus/stun_windows.go
@@ -58,7 +58,7 @@ func stunRequest(logger *zap.SugaredLogger, stunServer string, srcPort int) (net
 	if err != nil {
 		return netip.AddrPort{}, fmt.Errorf("failed to parse a valid address:port binding from the stun response: %w", err)
 	}
-	logger.Debugf("STUN: your public facing ip:port binding is: %s", xorBinding.String())
+	logger.Debugf("reflexive binding is: %s", xorBinding.String())
 
 	return xorBinding, nil
 }


### PR DESCRIPTION
- The symmetric disocvery logs are only on the initial statrtup. As we add a reconciler we may want to dial the successful log back but in the meantime this will help with debugging. Lets get stable with STUNs before we roll to symmetric checking in a reconcile.
- Removed a duplicate log printing the NAT binding results and made the debug msg the same across all three OSs.