### PR TITLE
Trim stun server list to prevent an empty string being returned

### DIFF
--- a/internal/stun/stun.go
+++ b/internal/stun/stun.go
@@ -17,9 +17,12 @@ var (
 )
 
 func init() {
-	servers := strings.Split(stunServersTxtFile, "\n")
-	for i := range servers {
-		servers[i] = strings.TrimSpace(servers[i])
+	var servers []string
+	for _, server := range strings.Split(stunServersTxtFile, "\n") {
+		server = strings.TrimSpace(server)
+		if server != "" {
+			servers = append(servers, strings.TrimSpace(server))
+		}
 	}
 	SetServers(servers)
 }

--- a/internal/stun/stun_test.go
+++ b/internal/stun/stun_test.go
@@ -1,0 +1,30 @@
+package stun
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNextStunServer(t *testing.T) {
+	assert := assert.New(t)
+
+	serverCounts := make(map[string]int)
+
+	// Call NextStunServer len(stunServers)*2 times to ensure that we cycle through the servers at least once.
+	for i := 0; i < len(stunServers)*2; i++ {
+		server := NextServer()
+
+		// Assert that a non-empty string is returned
+		assert.NotEmpty(server)
+
+		serverCounts[server]++
+	}
+
+	// Assert that all servers are returned at least once
+	for _, server := range stunServers {
+		count, exists := serverCounts[server]
+		assert.True(exists, "Server was not returned by NextStunServer: %s", server)
+		assert.GreaterOrEqual(count, 1, "Server was returned less than once: %s", server)
+	}
+}


### PR DESCRIPTION
- resolves getting an empty string as a stun server