### PR TITLE
hack: Add tmux to nexd container

### DIFF
--- a/Containerfile.nexd
+++ b/Containerfile.nexd
@@ -42,6 +42,7 @@ RUN dnf update -qy && \
     nftables \
     hostname \
     netcat \
+    tmux \
     && \
     dnf clean all -y &&\
     rm -rf /var/cache/yum

--- a/Makefile
+++ b/Makefile
@@ -466,7 +466,7 @@ image-apiserver:
 
 .PHONY: image-nexd ## Build the nexodus agent image
 image-nexd: dist/.image-nexd
-dist/.image-nexd: $(NEXD_DEPS) $(NEXCTL_DEPS) Containerfile.nexd | dist
+dist/.image-nexd: $(NEXD_DEPS) $(NEXCTL_DEPS) Containerfile.nexd hack/update-ca.sh | dist
 	$(CMD_PREFIX) docker build -f Containerfile.nexd -t quay.io/nexodus/nexd:$(TAG) .
 	$(CMD_PREFIX) docker tag quay.io/nexodus/nexd:$(TAG) quay.io/nexodus/nexd:latest
 	$(CMD_PREFIX) touch $@

--- a/hack/update-ca.sh
+++ b/hack/update-ca.sh
@@ -14,12 +14,28 @@ if [ -f /.certs/rootCA.pem ]; then
   fi
 fi
 
-if [ -z "$1" ]; then
-  echo "To connect this container to the nexodus network, try running:"
-  echo
-  echo "   /bin/nexd --username admin --password floofykittens https://try.nexodus.127.0.0.1.nip.io"
-  echo
-  exec /bin/bash
-else
+if [ -n "$1" ]; then
   exec "$@"
 fi
+
+cat << EOF > ~/.bash_history
+nexd https://try.nexodus.io
+nexd https://qa.nexodus.io
+nexd --username admin --password floofykittens https://try.nexodus.127.0.0.1.nip.io
+EOF
+
+cat << EOF > ~/.motd
+
+To connect this container to the nexodus network, try running:
+
+    nexd --username admin --password floofykittens https://try.nexodus.127.0.0.1.nip.io
+
+Commands for using a dev service, qa.nexodus.io, or try.nexodus.io are in bash history.
+
+Try pressing the up arrow.
+
+EOF
+
+tmux new-session -s nexd-session -d
+tmux send-keys "cat ~/.motd" "C-m"
+exec tmux attach-session -t nexd-session


### PR DESCRIPTION
This change includes a couple of updates to `make run-nexd-container`.

First, the commands for running `nexd` against a dev instance, qa, or
prod, are now in the bash history. You can hit the up arrow to choose
which one you want to execute.

Start up with tmux. You can use it the exact same way as before, but it
also makes it easy to add new splits or windows if desired. I frequently
want this because I'm launching nexd, and then I want to run additional
commands either to run a client or server or some kind to test
connectivity.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
