### PR TITLE
deploy: OpenShift Auth for Grafana / Promtail as a DaemonSet

### DIFF
--- a/deploy/nexodus-monitoring/overlays/rosa/grafana-patch.yaml
+++ b/deploy/nexodus-monitoring/overlays/rosa/grafana-patch.yaml
@@ -1,0 +1,73 @@
+apiVersion: integreatly.org/v1alpha1
+kind: Grafana
+metadata:
+  name: nexodus-grafana
+spec:
+  config:
+    log:
+      mode: "console"
+      level: "warn"
+    auth.anonymous:
+      enabled: true
+    auth:
+      disable_login_form: false
+      disable_signout_menu: true
+    auth.basic:
+      enabled: true
+    auth.proxy:
+      enabled: true
+      enable_login_token: true
+      header_property: username
+      header_name: X-Forwarded-User
+    server:
+      root_url: https://nexodus-grafana.apps.open-svc-sts.k1wl.p1.openshiftapps.com
+  containers:
+    - args:
+        - '-provider=openshift'
+        - '-pass-basic-auth=false'
+        - '-https-address=:9091'
+        - '-http-address='
+        - '-email-domain=*'
+        - '-upstream=http://localhost:3000'
+        - '-openshift-sar={"namespace":"nexodus","resource":"pods","verb":"get"}'
+        - '-openshift-delegate-urls={"/": {"resource": "namespaces", "verb": "get"}}'
+        - '-tls-cert=/etc/tls/private/tls.crt'
+        - '-tls-key=/etc/tls/private/tls.key'
+        - '-client-secret-file=/var/run/secrets/kubernetes.io/serviceaccount/token'
+        - '-cookie-secret-file=/etc/proxy/secrets/session_secret'
+        - '-openshift-service-account=grafana-serviceaccount'
+        - '-openshift-ca=/etc/pki/tls/cert.pem'
+        - '-openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt'
+        - '-openshift-ca=/etc/grafana-configmaps/ocp-injected-certs/ca-bundle.crt'
+        - '-skip-auth-regex=^/metrics'
+      image: 'quay.io/openshift/origin-oauth-proxy'
+      name: grafana-proxy
+      ports:
+        - containerPort: 9091
+          name: https
+      resources: {}
+      volumeMounts:
+        - mountPath: /etc/tls/private
+          name: secret-grafana-tls
+          readOnly: false
+        - mountPath: /etc/proxy/secrets
+          name: secret-grafana-proxy
+          readOnly: false
+  secrets:
+    - grafana-tls
+    - grafana-proxy
+  configMaps:
+    - ocp-injected-certs
+  service:
+    ports:
+      - name: https
+        port: 9091
+        protocol: TCP
+        targetPort: https
+    annotations:
+      service.beta.openshift.io/serving-cert-secret-name: grafana-tls
+  client:
+    preferService: true
+  serviceAccount:
+    annotations:
+      serviceaccounts.openshift.io/oauth-redirectreference.primary: '{"kind":"OAuthRedirectReference","apiVersion":"v1","reference":{"kind":"Route","name":"grafana-access"}}'

--- a/deploy/nexodus-monitoring/overlays/rosa/grafana/kustomization.yaml
+++ b/deploy/nexodus-monitoring/overlays/rosa/grafana/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ocp-injected-certs.yaml
+  - role.yaml
+  - rolebinding.yaml
+  - route.yaml
+  - serviceaccount.yaml
+  - secret.yaml

--- a/deploy/nexodus-monitoring/overlays/rosa/grafana/ocp-injected-certs.yaml
+++ b/deploy/nexodus-monitoring/overlays/rosa/grafana/ocp-injected-certs.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    config.openshift.io/inject-trusted-cabundle: "true"
+  name: ocp-injected-certs
+  namespace: nexodus-monitoring

--- a/deploy/nexodus-monitoring/overlays/rosa/grafana/role.yaml
+++ b/deploy/nexodus-monitoring/overlays/rosa/grafana/role.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: grafana-proxy
+  namespace: nexodus-monitoring
+rules:
+  - verbs:
+      - create
+    apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+  - verbs:
+      - create
+    apiGroups:
+      - authorization.k8s.io
+    resources:
+      - subjectaccessreviews

--- a/deploy/nexodus-monitoring/overlays/rosa/grafana/rolebinding.yaml
+++ b/deploy/nexodus-monitoring/overlays/rosa/grafana/rolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: authorization.openshift.io/v1
+kind: RoleBinding
+metadata:
+  namespace: nexodus-monitoring
+  name: grafana-proxy
+roleRef:
+  kind: Role
+  name: grafana-proxy
+subjects:
+  - kind: ServiceAccount
+    name: grafana-serviceaccount
+    namespace: grafana

--- a/deploy/nexodus-monitoring/overlays/rosa/grafana/route.yaml
+++ b/deploy/nexodus-monitoring/overlays/rosa/grafana/route.yaml
@@ -1,0 +1,18 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: grafana-access
+  namespace: nexodus-monitoring
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: grafana-tls
+spec:
+  host: nexodus-grafana.apps.open-svc-sts.k1wl.p1.openshiftapps.com
+  port:
+    targetPort: https
+  tls:
+    termination: reencrypt
+  to:
+    kind: Service
+    name: grafana-service
+    weight: 100
+  wildcardPolicy: None

--- a/deploy/nexodus-monitoring/overlays/rosa/grafana/secret.yaml
+++ b/deploy/nexodus-monitoring/overlays/rosa/grafana/secret.yaml
@@ -1,0 +1,14 @@
+kind: SealedSecret
+apiVersion: bitnami.com/v1alpha1
+metadata:
+  name: grafana-proxy
+  namespace: nexodus-monitoring
+  creationTimestamp:
+spec:
+  template:
+    metadata:
+      name: grafana-proxy
+      namespace: nexodus-monitoring
+      creationTimestamp:
+  encryptedData:
+    session_secret: AgBmruwMh4wJ9g14BWb/oYeIAJcVoniyigFxKFgDXF/A7BCXiu1bsXP3rIuuEJ0GoDHEBB2ooIJYWgPVIivgMrfElQMRil45z4+HyTokgH5mqzMXTjGTX1fwU2OvpQOJc7cGsXsd3Pg97k78E7q1n0fqqi7iIMTIWUWYTSwY/bJJKRSMFLPYkPWhwZ8FP44Voo4uoDdcIFXhVR3bcEe4+4FQPHecI8//wt2SAQ+WLBTz5Z33ZA4W+QiHMXW49gM9OqrrNIIRu9uJWFlzosJCfL/nugLFqFqqqJsCuMip1la3PXgrdXNGhVUb1ps0kXpoUgC1xieVX9hM3YOZdoNeFdzp3vHoPXsSF9RXKIyGGQoo9TW+Wd7UyVpnHUeKVH1mItNE/+DMj3YIoxlBmk68jFb4JnF0tnKYwS9/Y8O/1S8U+H9B7EefUDpEjYPvnofvvDNb15Mvlk8Az/bfTDgGgtja9iFaNpM6fZQuEus+ofDSLTJSdj/Yhk3na8UewoxLAMGz/AfwbmjPhw9Dk96spJ9tlueVUsh+h7vNqyCz0BX9qKf/jcFawkXb8+rymLh/3a/MPNUH0TAvb2GPQX5hg7aBBf9qzIGPWfryTak6JCqYduybvfzyuFe6MTX7oTXigPe/kuN1II74VubCphkkpbwz2i5qd0Ac49Z95UNLAF5iCnf+jowS1ojXzA3y/UKarzGGEe35K8K/zWS7KKGwAf10RkKrNWnIq+HHRJTLDJaLWiY=

--- a/deploy/nexodus-monitoring/overlays/rosa/grafana/serviceaccount.yaml
+++ b/deploy/nexodus-monitoring/overlays/rosa/grafana/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: grafana-serviceaccount
+  namespace: nexodus-monitoring

--- a/deploy/nexodus-monitoring/overlays/rosa/kustomization.yaml
+++ b/deploy/nexodus-monitoring/overlays/rosa/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base
+  - ./grafana
   - apiproxy-service-monitor.yaml
   - apiserver-service-monitor.yaml
   - prometheus-rbac.yaml
@@ -18,10 +19,18 @@ patches:
       group: integreatly.org
       version: v1alpha1
       kind: Grafana
+    path: grafana-patch.yaml
+  - target:
+      group: integreatly.org
+      version: v1alpha1
+      kind: Grafana
     patch: |-
-      - op: replace
-        path: /spec/ingress/hostname
-        value: nexodus-grafana.apps.open-svc-sts.k1wl.p1.openshiftapps.com
-      - op: replace
-        path: /spec/config/server/root_url
-        value: https://nexodus-grafana.apps.open-svc-sts.k1wl.p1.openshiftapps.com
+      - op: remove
+        path: /spec/config/security
+  - target:
+      group: integreatly.org
+      version: v1alpha1
+      kind: Grafana
+    patch: |-
+      - op: remove
+        path: /spec/ingress

--- a/deploy/nexodus-monitoring/overlays/rosa/monitoringstack.yaml
+++ b/deploy/nexodus-monitoring/overlays/rosa/monitoringstack.yaml
@@ -7,4 +7,4 @@ spec:
   retention: 2d
   resourceSelector:
     matchLabels:
-      app.kubernetes.io/part-of: nexodus
+      team: nexodus

--- a/deploy/nexodus/components/promtail/kustomization.yaml
+++ b/deploy/nexodus/components/promtail/kustomization.yaml
@@ -8,4 +8,4 @@ resources:
   - promtail-serviceaccount.yaml
   - promtail-role.yaml
   - promtail-rolebinding.yaml
-  - promtail-deployment.yaml
+  - promtail-daemonset.yaml

--- a/deploy/nexodus/components/promtail/promtail-daemonset.yaml
+++ b/deploy/nexodus/components/promtail/promtail-daemonset.yaml
@@ -26,7 +26,7 @@ spec:
           args:
             - -config.file=/etc/promtail/promtail.yaml
           env:
-            - name: "HOSTNAME" # needed when using kubernetes_sd_configs
+            - name: "HOSTNAME"  # needed when using kubernetes_sd_configs
               valueFrom:
                 fieldRef:
                   fieldPath: "spec.nodeName"

--- a/deploy/nexodus/components/promtail/promtail-daemonset.yaml
+++ b/deploy/nexodus/components/promtail/promtail-daemonset.yaml
@@ -1,5 +1,5 @@
 apiVersion: apps/v1
-kind: Deployment
+kind: DaemonSet
 metadata:
   name: promtail
   labels:
@@ -7,9 +7,6 @@ metadata:
     app.kubernetes.io/instance: promtail
     app.kubernetes.io/name: promtail
 spec:
-  replicas: 2
-  strategy:
-    type: Recreate
   selector:
     matchLabels:
       app.kubernetes.io/component: promtail
@@ -23,22 +20,13 @@ spec:
         app.kubernetes.io/name: promtail
     spec:
       serviceAccountName: promtail-serviceaccount
-      topologySpreadConstraints:
-        - maxSkew: 1
-          topologyKey: kubernetes.io/hostname
-          whenUnsatisfiable: DoNotSchedule
-          labelSelector:
-            matchLabels:
-              app.kubernetes.io/component: promtail
-              app.kubernetes.io/instance: promtail
-              app.kubernetes.io/name: promtail
       containers:
         - name: promtail-container
           image: docker.io/grafana/promtail:2.8.2
           args:
             - -config.file=/etc/promtail/promtail.yaml
           env:
-            - name: "HOSTNAME"  # needed when using kubernetes_sd_configs
+            - name: "HOSTNAME" # needed when using kubernetes_sd_configs
               valueFrom:
                 fieldRef:
                   fieldPath: "spec.nodeName"

--- a/deploy/nexodus/overlays/prod/kustomization.yaml
+++ b/deploy/nexodus/overlays/prod/kustomization.yaml
@@ -98,9 +98,11 @@ patches:
       kind: Ingress
       name: frontend
   - target:
-      kind: Deployment
-      name: promtail
+      group: rbac.authorization.k8s.io
+      version: v1
+      kind: Role
+      name: promtail-role
     patch: |-
-      - op: replace
-        path: /spec/replicas
-        value: 7
+      - op: add
+        path: /rules/1
+        value: {"apiGroups":["security.openshift.io"],"resources":["securitycontextconstraints"],"resourceNames":["hostmount-anyuid"],"verbs":["use"]}

--- a/deploy/nexodus/overlays/qa/kustomization.yaml
+++ b/deploy/nexodus/overlays/qa/kustomization.yaml
@@ -97,9 +97,11 @@ patches:
       kind: Ingress
       name: frontend
   - target:
-      kind: Deployment
-      name: promtail
+      group: rbac.authorization.k8s.io
+      version: v1
+      kind: Role
+      name: promtail-role
     patch: |-
-      - op: replace
-        path: /spec/replicas
-        value: 7
+      - op: add
+        path: /rules/1
+        value: {"apiGroups":["security.openshift.io"],"resources":["securitycontextconstraints"],"resourceNames":["hostmount-anyuid"],"verbs":["use"]}


### PR DESCRIPTION
- Run Promtail as a DaemonSet and attempt to add correct incantations to get it started on OpenShift.
- Authenticate access to Grafana using OpenShift

Fixes: #1024 