### PR TITLE
convert the apiserver and frontend services to be headless 

### DIFF
--- a/deploy/nexodus/base/apiproxy/files/envoy.yaml
+++ b/deploy/nexodus/base/apiproxy/files/envoy.yaml
@@ -49,6 +49,7 @@ static_resources:
     - name: apiserver
       connect_timeout: 5s
       type: STRICT_DNS
+      dns_refresh_rate: 1s
       dns_lookup_family: V4_ONLY
       lb_policy: ROUND_ROBIN
       load_assignment:
@@ -65,6 +66,7 @@ static_resources:
     - name: frontend
       connect_timeout: 5s
       type: STRICT_DNS
+      dns_refresh_rate: 1s
       dns_lookup_family: V4_ONLY
       lb_policy: ROUND_ROBIN
       load_assignment:

--- a/deploy/nexodus/base/apiserver/service.yaml
+++ b/deploy/nexodus/base/apiserver/service.yaml
@@ -3,6 +3,7 @@ kind: Service
 metadata:
   name: apiserver
 spec:
+  clusterIP: None
   selector:
     app.kubernetes.io/component: apiserver
     app.kubernetes.io/instance: apiserver

--- a/deploy/nexodus/base/frontend/service.yaml
+++ b/deploy/nexodus/base/frontend/service.yaml
@@ -3,6 +3,7 @@ kind: Service
 metadata:
   name: frontend
 spec:
+  clusterIP: None
   selector:
     app.kubernetes.io/component: frontend
     app.kubernetes.io/instance: frontend


### PR DESCRIPTION
and poll DNS every 1s for service membership changes.

Hopefully, this helps avoid Envoy returning 503 responses when we deploy updates.