### PR TITLE
.github: Remove context from docker-build-push action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -133,7 +133,6 @@ jobs:
       - name: Build and export ${{ matrix.name }}
         uses: docker/build-push-action@v4
         with:
-          context: .
           file: ./Containerfile.${{ matrix.name }}
           tags: ${{ matrix.tags }}
           outputs: type=docker,dest=/tmp/${{ matrix.name }}.tar

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -63,7 +63,6 @@ jobs:
       - name: Build and push ${{ matrix.name }}
         uses: docker/build-push-action@v4
         with:
-          context: .
           platforms: linux/amd64,linux/arm64
           push: true
           file: ./Containerfile.${{ matrix.name }}


### PR DESCRIPTION
See if this is the issue for our image builds taking a while.
Apparently context: . means that `.git` will get pulled in which is not
deterministic. That can cause the cache not to be hit.

Updates: #1038 