### PR TITLE
docs: Update quickstart with docker instructions

### DIFF
--- a/Containerfile.nexd
+++ b/Containerfile.nexd
@@ -53,3 +53,5 @@ COPY --chmod=755 --from=build /src/dist/nexctl /bin/nexctl
 COPY --chmod=755 --from=build /go/bin/mkcert /bin/mkcert
 COPY --chmod=755 --from=build /src/udping /bin/udping
 COPY --chmod=755 --from=build /src/udpong /bin/udpong
+
+CMD /update-ca.sh prod

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -50,6 +50,21 @@ Query the status of `nexd` and follow the instructions to register your device.
 sudo nexctl nexd status
 ```
 
+### Docker or Podman
+
+For testing purposes, you can run the Nexodus Agent in a container. The following command will start a container and launch a shell inside it.
+
+```sh
+docker run --rm -it --cap-add SYS_MODULE --cap-add NET_ADMIN --cap-add NET_RAW \
+    --sysctl net.ipv6.conf.all.disable_ipv6=0 quay.io/nexodus/nexd
+```
+
+Once the container is running, start `nexd` and follow the instructions to register your device.
+
+```sh
+nexd https://try.nexodus.io
+```
+
 ### Other
 
 Download the latest release package for your OS and architecture. Each release includes a `nexd` binary and a `nexctl` binary.

--- a/hack/update-ca.sh
+++ b/hack/update-ca.sh
@@ -14,17 +14,34 @@ if [ -f /.certs/rootCA.pem ]; then
   fi
 fi
 
-if [ -n "$1" ]; then
+if [ -n "$1" ] && [ "$1" != "prod" ]; then
   exec "$@"
 fi
 
-cat << EOF > ~/.bash_history
+if [ "$1" = "prod" ]; then
+  cat << EOF > ~/.bash_history
+nexd https://qa.nexodus.io
+nexd https://try.nexodus.io
+EOF
+
+  cat << EOF > ~/.motd
+
+To connect this container to the nexodus network, try running:
+
+    nexd https://try.nexodus.io
+
+Press the up arrow to get this command from bash history.
+
+EOF
+
+else
+  cat << EOF > ~/.bash_history
 nexd https://try.nexodus.io
 nexd https://qa.nexodus.io
 nexd --username admin --password floofykittens https://try.nexodus.127.0.0.1.nip.io
 EOF
 
-cat << EOF > ~/.motd
+  cat << EOF > ~/.motd
 
 To connect this container to the nexodus network, try running:
 
@@ -32,9 +49,10 @@ To connect this container to the nexodus network, try running:
 
 Commands for using a dev service, qa.nexodus.io, or try.nexodus.io are in bash history.
 
-Try pressing the up arrow.
+Press the up arrow to find these commands.
 
 EOF
+fi
 
 tmux new-session -s nexd-session -d
 tmux send-keys "cat ~/.motd" "C-m"


### PR DESCRIPTION
For quick testing and demo purposes, provide instructions for
launching a nexd container that can be quickly connected to our demo
service.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
