### PR TITLE
docs: add proxy-in-kube demo 2 content

### DIFF
--- a/docs/user-guide/scenarios/nexd-proxy-in-kube.md
+++ b/docs/user-guide/scenarios/nexd-proxy-in-kube.md
@@ -198,3 +198,211 @@ spec:
         secret:
           secretName: wireguard-keys
 ```
+
+Finally, you can validate that the Service is reachable from another device connected to the same Nexodus organization. You will need the Nexodus IP address associated with the proxy. You can get this by either looking in the `nexd proxy` container log or through the Nexodus Service web UI.
+
+If you check the log, here is what you should see:
+
+```text
+{"level":"info","ts":1684542592.4024842,"caller":"nexodus/wg_peers.go:182","msg":"New local Wireguard interface addresses assigned IPv4 [ 100.100.0.1 ] IPv6 [ 200::1 ]"}
+```
+
+In this case, the Nexodus IP address is `100.100.0.1` or `200::1`.
+
+From another device in the Nexodus organization, you should now be able to reach the nginx Service using these IP addresses.
+
+```console
+## curl http://100.100.0.1
+Hello from nginx-deployment-d76648567-8fmtv
+
+# curl http://100.100.0.1
+Hello from nginx-deployment-d76648567-6ppjm
+
+# curl http://[200::1]
+Hello from nginx-deployment-d76648567-6ppjm
+
+# curl http://[200::1]
+Hello from nginx-deployment-d76648567-8fmtv
+```
+
+## Demo 2 - Kubernetes Service to Reach a Resource Over Nexodus
+
+This demo is similar to the first but in the reverse direction. It may be
+desirable for an application inside Kubernetes to reach a resource that is
+accessible within a Nexodus organization. An example here could be an
+application running in a public cloud that needs to reach a database running in
+a corporate data center.
+
+In this example, the Pod running `nexd proxy` is using a single egress proxy rule like this:
+
+```console
+nexd proxy --egress tcp:80:100.100.0.1:80
+```
+
+```mermaid
+flowchart TD
+ linkStyle default interpolate basis
+ network{Nexodus Network<br/><br/>100.100.0.0/16}-->|tunnel|device1[Remote device running nexd<br/><br/>Nexodus IP: 100.100.0.1<br/><br/>Running a service that listens on TCP port 80]
+ container[Pod running nexd in proxy mode.<br/>Accepts connections from within the cluster and forwards to 100.100.0.1:80]-->|tunnel|network
+
+ subgraph Kubernetes Cluster
+ dest(Source application connecting to port 80 on Service nexd-proxy<br/>)-->|tcp|service1(Kubernetes Service nexd-proxy<br/>)
+ service1-->|tcp|container
+ end
+```
+
+To implement this scenario you will need a Kubernetes cluster and a Nexodus
+Service that allows user/password authentication.
+
+Prior to setting up the Kubernetes portion of this demo, you will need to set up an http server that listens on port 80 within this Nexodus organization. During development of the demo, I ran `nexd` in a container and then ran these additional commands in that container. Note that the rest of demo2 assumes that this Nexodus device has the Nexodus IP of 100.100.0.1.
+
+```console
+echo "Hello from ${HOSTNAME}" > index.html
+pythom -m http.server 80
+```
+
+Now you can proceed with setting up the Kubernetes side of this demo. First, set
+a few variables that we will use for this demo. The username and password will
+be used by `nexd proxy` to authenticate with the Nexodus Service.
+
+```console
+NAMESPACE=nexd-proxy-demo2
+USERNAME=username
+PASSWORD=password
+```
+
+Start by creating a namespace for the demo:
+
+```console
+kubectl create namespace "${NAMESPACE}"
+```
+
+Next, create a Secret that contains the username and password that `nexd proxy`
+will use to authenticate with the Nexodus Service.
+
+```console
+kubectl create secret generic nexodus-credentials \
+    --from-literal=username="${USERNAME}" \
+    --from-literal=password="${PASSWORD}" -n "${NAMESPACE}"
+```
+
+We also need a Secret to hold the wireguard keys used by `nexd`. If you need to
+create the keys, you can use these commands:
+
+```console
+wg genkey | tee private.key | wg pubkey > public.key
+```
+
+Once you have the `private.key` and `public.key` files, you can create a Secret
+for them.
+
+```console
+kubectl create secret generic wireguard-keys \
+    --from-literal=private.key="$(cat private.key)" \
+    --from-literal=public.key="$(cat public.key)" -n "${NAMESPACE}"
+```
+
+Next, create a Deployment for `nexd proxy`. It will run with a single egress proxy rule. Note that if the device running the http server is not `100.100.0.1`, the egress proxy rule will need to be adjusted.
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nexd-proxy
+  namespace: nexd-proxy-demo2
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nexd-proxy
+  template:
+    metadata:
+      labels:
+        app: nexd-proxy
+    spec:
+      containers:
+      - name: nexd-proxy
+        image: quay.io/nexodus/nexd
+        command: ["sh"]
+        args: ["-c", "ln -s /etc/wireguard/private.key /private.key; ln -s /etc/wireguard/public.key /public.key; nexd proxy --egress tcp:80:100.100.0.1:80 https://try.nexodus.io"]
+        env:
+        - name: NEXD_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: nexodus-credentials
+              key: username
+        - name: NEXD_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: nexodus-credentials
+              key: password
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        ports:
+        - containerPort: 80
+        volumeMounts:
+        - name: wireguard-keys
+          mountPath: /etc/wireguard/
+      volumes:
+      - name: wireguard-keys
+        secret:
+          secretName: wireguard-keys
+```
+
+Next, we need a Service that will be used by other applications in the cluster
+that desire to reach the HTTP server we are exposing from the Nexodus
+organization.
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: nexd-proxy
+  namespace: nexd-proxy-demo2
+spec:
+  selector:
+    app: nexd-proxy
+  ports:
+  - name: http
+    port: 80
+    targetPort: 80
+  type: ClusterIP
+```
+
+Finally, we need some sort of application that makes a request to this service.
+Here's a sample deployment that runs `curl` in a loop every second.
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: demo2-client
+  namespace: nexd-proxy-demo2
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: demo2-client
+  template:
+    metadata:
+      labels:
+        app: demo2-client
+    spec:
+      containers:
+      - name: client
+        image: fedora:latest
+        command: ["sh", "-c", "while : ; do curl -s http://nexd-proxy.nexd-proxy-demo2.svc.cluster.local ; sleep 1 ; done"]
+```
+
+Once everything is up and running, the log for the `demo2-client` pod should look something like this, showing whatever data you set up for the http server to return.
+
+```text
+Hello from f88da76f423d
+Hello from f88da76f423d
+Hello from f88da76f423d
+Hello from f88da76f423d
+Hello from f88da76f423d
+...
+```


### PR DESCRIPTION
This covers the 2nd demo scenario originally described in the nexlink
design document. This writeup gives instructions for recreating the
scenario to see it working.

I also added a bit of additional content to the end of the demo 1
section.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
