### PR TITLE
Add the ability to get wg information from the interface via nexctl

### DIFF
--- a/cmd/nexctl/local_unix.go
+++ b/cmd/nexctl/local_unix.go
@@ -50,11 +50,6 @@ func init() {
 				},
 			},
 			{
-				Name:   "connections",
-				Usage:  "Run a test of the nexd peer connectivity (host firewalls may block the ICMP probes)",
-				Action: cmdConnStatus,
-			},
-			{
 				Name:  "get",
 				Usage: "Get a value from the local nexd instance",
 				Subcommands: []*cli.Command{
@@ -147,6 +142,25 @@ func init() {
 						Action: func(cCtx *cli.Context) error {
 							return proxyAddRemove(cCtx, false)
 						},
+					},
+				},
+			},
+			{
+				Name:  "peers",
+				Usage: "Commands for interacting nexd exit node configuration",
+				Subcommands: []*cli.Command{
+					{
+						Name:  "list",
+						Usage: "list the nexd peers for this device",
+						Action: func(cCtx *cli.Context) error {
+							encodeOut := cCtx.String("output")
+							return cmdListPeers(cCtx, encodeOut)
+						},
+					},
+					{
+						Name:   "ping",
+						Usage:  "run a test to check the nexd peer connectivity (host firewalls may block the ICMP probes)",
+						Action: cmdConnStatus,
 					},
 				},
 			},

--- a/cmd/nexctl/peers.go
+++ b/cmd/nexctl/peers.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"strconv"
+	"time"
+
+	"encoding/json"
+	"github.com/urfave/cli/v2"
+)
+
+type WgListPeers struct {
+	PublicKey       string
+	PreSharedKey    string
+	Endpoint        string
+	AllowedIPs      []string
+	LatestHandshake string
+	Tx              int64
+	Rx              int64
+}
+
+func cmdListPeers(cCtx *cli.Context, encodeOut string) error {
+	var err error
+	var peers []WgListPeers
+	if err = checkVersion(); err != nil {
+		return err
+	}
+
+	result, err := callNexd("ListPeers", "")
+	if err != nil {
+		return fmt.Errorf("Failed to list peers: %w\n", err)
+	}
+
+	err = json.Unmarshal([]byte(result), &peers)
+	if err != nil {
+		return fmt.Errorf("Failed to marshall peer results: %w\n", err)
+	}
+
+	if encodeOut == encodeColumn || encodeOut == encodeNoHeader {
+		w := newTabWriter()
+		fs := "%s\t%s\t%s\t%s\t%s\t%s\n"
+		if encodeOut != encodeNoHeader {
+			fmt.Fprintf(w, fs, "PUBLIC KEY", "ENDPOINT", "ALLOWED IPS", "LATEST HANDSHAKE", "TRANSMITTED", "RECEIVED")
+		}
+
+		for _, peer := range peers {
+			tx := strconv.FormatInt(peer.Tx, 10)
+			rx := strconv.FormatInt(peer.Rx, 10)
+			handshakeTime, err := ParseTime(peer.LatestHandshake)
+			if err != nil {
+				log.Printf("Unable to parse LatestHandshake to time: %v", err)
+			}
+			handshake := "None"
+			if !handshakeTime.IsZero() {
+				secondsAgo := time.Now().UTC().Sub(handshakeTime).Seconds()
+				handshake = fmt.Sprintf("%.0f seconds ago", secondsAgo)
+			}
+			fmt.Fprintf(w, fs, peer.PublicKey, peer.Endpoint, peer.AllowedIPs, handshake, tx, rx)
+		}
+
+		w.Flush()
+
+		return nil
+	}
+
+	err = FormatOutput(encodeOut, peers)
+	if err != nil {
+		log.Fatalf("Failed to print output: %v", err)
+	}
+
+	return nil
+}
+
+// ParseTime attempts to parse a time string in two possible formats to handle UTC and local time differences between Darwin and Linux
+func ParseTime(timeStr string) (time.Time, error) {
+	t, err := time.Parse(time.RFC3339Nano, timeStr)
+	if err != nil {
+		// Custom format
+		t, err = time.Parse("2006-01-02 15:04:05.999999999 -0700 MST", timeStr)
+	}
+	return t.UTC(), err
+}

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -89,3 +89,9 @@ Try `ping` or whatever other connectivity test you prefer.
 ```sh
 ping 100.100.0.1
 ```
+
+Alternatively, you can verify connectivity to the device's peers with the following.
+
+```shell
+sudo nexctl nexd peers ping
+```

--- a/integration-tests/proxy_test.go
+++ b/integration-tests/proxy_test.go
@@ -764,7 +764,7 @@ func TestProxyNexctlConnections(t *testing.T) {
 	err = helper.nexdStatus(ctx, node2)
 	require.NoError(err)
 
-	out, err := helper.containerExec(ctx, node1, []string{"nexctl", "nexd", "connections"})
+	out, err := helper.containerExec(ctx, node1, []string{"nexctl", "nexd", "peers", "ping"})
 	require.NoError(err)
 	require.False(strings.Contains(out, "Unreachable"))
 	require.True(strings.Contains(out, "Reachable"))

--- a/internal/nexodus/ctlpeers.go
+++ b/internal/nexodus/ctlpeers.go
@@ -1,0 +1,31 @@
+package nexodus
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+func (ac *NexdCtl) ListPeers(_ string, result *string) error {
+	if ac.ax.userspaceMode {
+		return fmt.Errorf("userspace mode not currently supported")
+	}
+
+	iface := ac.ax.defaultTunnelDev()
+	if iface == "" {
+		return fmt.Errorf("no tunnel interface found")
+	}
+
+	peers, err := DumpPeers(iface)
+	if err != nil {
+		return fmt.Errorf("error getting list of peers: %w", err)
+	}
+
+	peersJSON, err := json.Marshal(peers)
+	if err != nil {
+		return fmt.Errorf("error marshalling list of peers: %w", err)
+	}
+
+	*result = string(peersJSON)
+
+	return nil
+}

--- a/ops/ansible/aws/validate-connectivity/tasks/main.yml
+++ b/ops/ansible/aws/validate-connectivity/tasks/main.yml
@@ -29,8 +29,8 @@
   become: yes
   shell: |
     printf "====== Connectivity Results from Node: {{ inventory_hostname }} ======\n" > connectivity-results.txt
-    nexctl nexd connections
-    nexctl nexd connections >> connectivity-results.txt 2>&1
+    nexctl nexd peers ping
+    nexctl nexd peers ping >> connectivity-results.txt 2>&1
     printf "\n====== WG Dump from Node: {{ inventory_hostname }} ======\n" >> connectivity-results.txt
     wg show wg0 dump >> connectivity-results.txt 2>&1
     cat connectivity-results.txt


### PR DESCRIPTION
- The adds `nexctl nexd peers list` to display peer information from the wg interface
- Also consolidates `nexctl nexd connections` under peers to now be `nexctl nexd peers ping` which is a cleaner UX.
- This also adds back debugging functionality we lost from wg binary removal.