### PR TITLE
Containerize QA

### DIFF
--- a/.github/workflows/qa-scale-containers.yml
+++ b/.github/workflows/qa-scale-containers.yml
@@ -1,0 +1,194 @@
+# qa-scale workflow is for scale testing against the Nexodus qa deployment
+name: qa-scale-containers
+
+concurrency:
+  group: qa-scale-containers
+
+on:
+  workflow_dispatch:
+    inputs:
+      deployment_size:
+        description: 'deployment size: small | medium | large | xlarge'
+        required: true
+        default: 'small'
+        type: string
+
+      num_containers:
+        description: 'containers per node (default 5):'
+        required: true
+        default: '5'
+
+      aws_instance_type:
+        description: 'ec2 instance type (default t2.micro): t2.micro | t2.small | t2.medium | t2.large'
+        required: true
+        default: 't2.micro'
+        type: string
+
+      pr_or_branch:
+        description: 'pull request number or branch name (default main)'
+        required: true
+        default: 'main'
+
+      debug_pause:
+        description: 'time in minutes to pause before tearing down the infra for debugging'
+        required: false
+        default: '0'
+
+jobs:
+  deploy-qa:
+    name: deploy-qa-ec2
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    env:
+      AWS_REGION: "us-east-1"
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      ANSIBLE_VAULT_PASSWORD_FILE: "vault-secret.txt"
+      ANSIBLE_PRIVATE_KEY_FILE: "nexodus.pem"
+      ANSIBLE_HOST_KEY_CHECKING: "false"
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Determine if pr_or_branch is a PR number
+        id: check_pr
+        run: |
+          if [[ "${{ github.event.inputs.pr_or_branch }}" =~ ^[0-9]+$ ]]; then
+            echo "is_pr=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_pr=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Fetch and checkout PR
+        if: steps.check_pr.outputs.is_pr == 'true'
+        run: |
+          git fetch origin pull/${{ github.event.inputs.pr_or_branch }}/head:pr-${{ github.event.inputs.pr_or_branch }}
+          git checkout pr-${{ github.event.inputs.pr_or_branch }}
+
+      - name: Checkout branch
+        if: steps.check_pr.outputs.is_pr == 'false'
+        run: git checkout ${{ github.event.inputs.pr_or_branch }}
+
+      - name: Login to Quay.io
+        uses: redhat-actions/podman-login@v1
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_ROBOT_USERNAME }}
+          password: ${{ secrets.QUAY_ROBOT_PASSWORD }}
+
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: ./Containerfile.nexd
+          push: true
+          tags: quay.io/nexodus/nexd-qa:latest
+
+      - name: Setup Go
+        uses: ./.github/actions/setup-go-env
+
+      - name: Build
+        run: |
+          make dist/nexd-linux-amd64
+          make dist/nexctl-linux-amd64
+
+      - name:  Copy Binaries to S3
+        run: |
+          aws s3 cp ./dist/nexd-linux-amd64 s3://nexodus-io/ec2-e2e/qa/
+          aws s3 cp ./dist/nexctl-linux-amd64 s3://nexodus-io/ec2-e2e/qa/
+
+      - name:  Build Keycloak Tool
+        run: |
+          go build -o ./ ./hack/e2e-scripts/kctool/
+
+      - name: Create a Keycloak User
+        id: kc-user
+        run: |
+          output=$(./kctool --create-user \
+            -ku "${{ secrets.KC_QA_USERNAME }}" \
+            -kp "${{ secrets.KC_QA_PASSWORD }}" \
+            -u qa \
+            -p "${{ secrets.QA_USER_PASSWORD }}" \
+            https://auth.qa.nexodus.io)
+          echo "USER=$output" >> "$GITHUB_OUTPUT"
+
+      - name: User results from Keycloak
+        run: echo "User is ${{ steps.kc-user.outputs.USER }}"
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Install Ansible and Dependencies
+        run: pip3.10 install boto boto3 ansible-vault ansible-core==2.13.3
+
+      - name: Install amazon.aws Ansible library
+        run: ansible-galaxy collection install amazon.aws
+
+      - name: Set Deployment Size to Small
+        if: github.event.inputs.deployment_size == 'small'
+        run: |
+          echo "${{ secrets.ANSIBLE_QA_SMALL_CONTAINERS }}" > ./ops/ansible/aws/vars.yml
+
+      - name: Set Deployment Size to Medium
+        if: github.event.inputs.deployment_size == 'medium'
+        run: |
+          echo "${{ secrets.ANSIBLE_VARS_MEDIUM_QA }}" > ./ops/ansible/aws/vars.yml
+
+      - name: Set Deployment Size to Large
+        if: github.event.inputs.deployment_size == 'large'
+        run: |
+          echo "${{ secrets.ANSIBLE_VARS_LARGE_QA }}" > ./ops/ansible/aws/vars.yml
+
+      - name: Set Deployment Size to XLarge
+        if: github.event.inputs.deployment_size == 'xlarge'
+        run: |
+          echo "${{ secrets.ANSIBLE_VARS_XLARGE_QA }}" > ./ops/ansible/aws/vars.yml
+
+      - name: Create Ansible Secrets
+        run: |
+          echo "${{ secrets.ANSIBLE_SSH_KEY }}" > nexodus.pem
+          chmod 0400 nexodus.pem
+          echo "${{ secrets.ANSIBLE_VAULT_PASSWORD }}" > vault-secret.txt
+          chmod 0400 vault-secret.txt
+
+      - name: Deploy EC2 Agent Nodes
+        run: |
+          ansible-playbook -vv ./ops/ansible/aws/deploy-ec2-qa-containers.yml \
+          -i ./ops/ansible/aws/inventory.txt \
+          --private-key nexodus.pem \
+          --vault-password-file vault-secret.txt \
+          --extra-vars "nexodus_auth_uid=${{ steps.kc-user.outputs.USER }}" \
+          --extra-vars "nexodus_auth_password=${{ secrets.QA_USER_PASSWORD }}" \
+          --extra-vars "debug_pause=${{ github.event.inputs.debug_pause }}" \
+          --extra-vars "num_containers=${{ github.event.inputs.num_containers }}" \
+          --extra-vars "aws_instance_type=${{ github.event.inputs.aws_instance_type }}" \
+          --extra-vars "aws_nodetype_tag=nexodus-qa-containers"
+
+      - name: Mesh Connectivity Results
+        run: |
+          set -e
+          cat ./ops/ansible/aws/connectivity-results.txt
+          if grep -iq 'Unreachable' ./ops/ansible/aws/connectivity-results.txt; then
+            echo "Connectivity results contain 'Unreachable' nodes, check the connectivity results for details. Failing the job"
+            exit 1
+          else
+            echo "Connectivity results do not contain any 'Unreachable' nodes"
+          fi
+
+      - name: Terminate EC2 Instances
+        if: always()
+        run: |
+          ansible-playbook -vv ./ops/ansible/aws/terminate-instances.yml \
+          --extra-vars "aws_nodetype_tag=nexodus-qa-containers"
+
+      - name: Upload nexd and api-server Logs to Artifacts
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: dev-ec2-artifacts
+          path: ./ops/ansible/aws/nexd-logs/
+          retention-days: 10

--- a/ops/ansible/aws/ansible.cfg
+++ b/ops/ansible/aws/ansible.cfg
@@ -10,9 +10,8 @@ private_key_file = ./nexodus.pem
 # SSH timeout (ansible default is 10)
 timeout = 60
 # reduce the number of SSH connections
-pipelining = true
+; pipelining = true
 # increase task batches from the default of 5
-forks=10
 [ssh_connection]
 # how long the SSH keeps an idle connection open in the background
-ssh_args = -o ControlMaster=auto -o ControlPersist=60s
+; ssh_args = -o ControlMaster=auto -o ControlPersist=60s

--- a/ops/ansible/aws/deploy-ec2-qa-containers.yml
+++ b/ops/ansible/aws/deploy-ec2-qa-containers.yml
@@ -1,0 +1,36 @@
+# QA roles get branched from here
+
+# Deploy the ec2 VMs
+- hosts: localhost
+  vars_files:
+    - vars.yml
+  roles:
+    - role: setup-ec2
+
+# Deploy and start the agent
+- hosts: nexodusNodes
+  vars_files:
+    - vars.yml
+  roles:
+    - role: qa/qa-containers-deploy-mesh
+
+# Deploy and start the relay server (relay)
+- hosts: relayNode
+  vars_files:
+    - vars.yml
+  roles:
+    - role: qa/qa-deploy-relay
+#
+## Deploy and start the relay only agents (--relay-only)
+- hosts: nexodusRelayNodes
+  vars_files:
+    - vars.yml
+  roles:
+    - role: qa/qa-containers-deploy-mesh
+
+## Validate nodes by running a connectivity test from a spoke node to all peers
+- hosts:  "{{ groups['nexodusNodes'][0] }}"
+  vars_files:
+    - vars.yml
+  roles:
+    - role: qa/validate-connectivity-qa-containers

--- a/ops/ansible/aws/qa/qa-containers-deploy-mesh/tasks/main.yml
+++ b/ops/ansible/aws/qa/qa-containers-deploy-mesh/tasks/main.yml
@@ -1,0 +1,151 @@
+---
+# tasks file for qa-containers-deploy-mesh
+- name: Install dependencies
+  become: yes
+  apt:
+    name:
+      - fping
+      - iperf3
+      - nftables
+      - ca-certificates
+      - curl
+      - lsb-release
+      - gnupg
+    update_cache: yes
+    state: present
+
+- name: Add repo GPG key
+  become: yes
+  block:
+    - name: Create /etc/apt/keyrings directory
+      file:
+        path: /etc/apt/keyrings
+        state: directory
+        mode: 0755
+
+    - name: Download and add Docker's GPG key
+      shell: |
+        curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+
+    - name: Set permission for Docker's GPG key
+      file:
+        path: /etc/apt/keyrings/docker.gpg
+        mode: a+r
+
+- name: Set up Docker repository
+  become: yes
+  shell: |
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
+
+- name: Install docker engine and containerd
+  become: yes
+  apt:
+    name:
+      - docker-ce
+      - docker-ce-cli
+      - containerd.io
+    update_cache: yes
+    state: present
+
+- name: Pause for 20 seconds for container runtime to initialize
+  pause:
+    seconds: 20
+
+- name: Start Nexodus QA Containers
+  become: yes
+  shell: |
+    for i in $(seq 1 {{ num_containers }}); do
+        docker run -d --network bridge \
+            --cap-add SYS_MODULE \
+            --cap-add NET_ADMIN \
+            --cap-add NET_RAW \
+            --sysctl net.ipv4.ip_forward=1 \
+            --sysctl net.ipv6.conf.all.disable_ipv6=0 \
+            --sysctl net.ipv6.conf.all.forwarding=1 \
+            --platform=linux/amd64 \
+            quay.io/networkstatic/nexd-qa:latest sleep 100000
+    done
+
+- name: Running the following nexd command
+  debug:
+    msg: "nexd --username {{ nexodus_auth_uid }} --password {{ nexodus_auth_password }} {{ nexodus_url }}"
+  when: "'nexodusNodes' in group_names"
+
+- name: Write command to file
+  become: yes
+  copy:
+    dest: "/home/{{ ansible_user }}/nexd.sh"
+    content: |
+      #!/bin/sh
+      echo "Running command: nexd --username {{ nexodus_auth_uid }} --password {{ nexodus_auth_password }} --relay-only {{ nexodus_url }}" > nexodus-logs.txt
+      NEXD_LOGLEVEL=debug nexd \
+      --username '{{ nexodus_auth_uid }}' \
+      --password '{{ nexodus_auth_password }}' \
+      --relay-only \
+      {{ nexodus_url }} >> nexodus-logs.txt 2>&1
+  when: "'nexodusRelayNodes' in group_names"
+
+- name: Write command to file
+  become: yes
+  copy:
+    dest: "/home/{{ ansible_user }}/nexd.sh"
+    content: |
+      #!/bin/sh
+      echo "Running command: nexd --username {{ nexodus_auth_uid }} --password {{ nexodus_auth_password }} {{ nexodus_url }}" > nexodus-logs.txt
+      NEXD_LOGLEVEL=debug nexd \
+      --username '{{ nexodus_auth_uid }}' \
+      --password '{{ nexodus_auth_password }}' \
+      {{ nexodus_url }} >> nexodus-logs.txt 2>&1
+  when: "'nexodusNodes' in group_names"
+
+- name: Get list of all running containers
+  become: yes
+  command: docker ps -q
+  register: container_ids
+
+- name: Upload nexd.sh to all running Docker containers
+  become: yes
+  shell: |
+    docker cp /home/{{ ansible_user }}/nexd.sh {{ item }}:/
+    docker exec {{ item }} chmod +x /nexd.sh
+  loop: "{{ container_ids.stdout_lines }}"
+
+- name: Run nexd.sh on all running Docker containers
+  become: yes
+  shell: docker exec {{ item }} sh -c "nohup sh ./nexd.sh > /dev/null 2>&1 &"
+  loop: "{{ container_ids.stdout_lines }}"
+
+- name: Pause for 30 seconds for the onboard to complete to scrape the logs
+  pause:
+    seconds: 30
+
+- name: Copy nexodus-logs.txt from each container and store them on the host
+  become: yes
+  shell: |
+    docker cp {{ item }}:/nexodus-logs.txt /home/{{ ansible_user }}/{{ item }}-nexodus-logs-{{ ansible_hostname }}.txt
+  ignore_errors: yes
+  with_items: "{{ container_ids.stdout_lines }}"
+  when: "'nexodusNodes' in group_names"
+
+- name: Copy nexodus-logs.txt from each container and store on host when the node is --relay-only (symmetric NAT)
+  become: yes
+  shell: |
+    docker cp {{ item }}:/nexodus-logs.txt /home/{{ ansible_user }}/{{ item }}-nexodus-relay-only-symmetric-nat-logs-{{ ansible_hostname }}.txt
+  ignore_errors: yes
+  with_items: "{{ container_ids.stdout_lines }}"
+  when: "'nexodusRelayNodes' in group_names"
+
+- name: Register all log files
+  find:
+    paths: "/home/{{ ansible_user }}"
+    patterns: "*.txt"
+  register: files_to_copy
+  ignore_errors: yes
+
+- name: Copy file from remote host to localhost
+  fetch:
+    src: "{{ item.path }}"
+    dest: "./nexd-logs/"
+    flat: yes
+  with_items: "{{ files_to_copy.files }}"
+  ignore_errors: yes

--- a/ops/ansible/aws/qa/qa-deploy-relay/tasks/main.yml
+++ b/ops/ansible/aws/qa/qa-deploy-relay/tasks/main.yml
@@ -49,7 +49,6 @@
   become: yes
   shell: |
     printf "\n\n====== WG Dump from Node: {{ inventory_hostname }} wg0 Addr: {{ ipv4_address_result }} ======\n" >> /home/{{ ansible_user }}/nexodus-logs.txt
-    wg show wg0 dump >> /home/{{ ansible_user }}/nexodus-logs.txt
   ignore_errors: yes
 
 - name: Copy file from remote host to localhost

--- a/ops/ansible/aws/qa/validate-connectivity-qa-containers/tasks/main.yml
+++ b/ops/ansible/aws/qa/validate-connectivity-qa-containers/tasks/main.yml
@@ -1,0 +1,34 @@
+---
+# tasks file for validate-connectivity-qa-containers
+- name: Pause for 60 for convergence
+  pause:
+    seconds: 60
+
+- name: Debug
+  debug:
+    msg: "Running connectivity test on spoke node: {{ inventory_hostname }}"
+
+- name: Verify Connectivity from a spoke node to all spokes
+  become: yes
+  shell: |
+    docker exec $(docker ps -l -q) sh -c '
+      printf "====== Connectivity Results from Node: {{ inventory_hostname }} ======\n" > /tmp/connectivity-results.txt;
+      nexctl nexd connections;
+      nexctl nexd connections >> /tmp/connectivity-results.txt 2>&1;
+      cat /tmp/connectivity-results.txt'
+  register: result
+  ignore_errors: true
+
+- name: Print connectivity results
+  debug:
+    msg: "{{ result.stdout }}"
+
+- name: Copy connectivity results back to the runner
+  become: yes
+  shell: "docker cp $(docker ps -l -q):/tmp/connectivity-results.txt /home/{{ ansible_user }}/connectivity-results.txt"
+
+- name: Fetch connectivity results to Ansible control node
+  fetch:
+    src: "/home/{{ ansible_user }}/connectivity-results.txt"
+    dest: "./"
+    flat: true


### PR DESCRIPTION
- This adds a containerized qa workflow option in order to scale up the amount of nodes we can concurrently test while reducing the time to run a test since we are provisioning far less VMs by replacing the agents in containers.
- This also comments out some Ansible optimizations for high node counts that might create issues on low resource nodes that are getting hammered with runtime installs. Leaving them commented as they may go back in once this is in tree and can be further tested.
- This doesn't disrupt any other QA and is standlone.
- Also adds the ability to pick an ec2 instance type, since if you wanted to spin up 100 containers across 5 nodes, you would need to choose a larger machine than the default t2.micro. There are reasonable defaults for smaller tests.
- Creates a new image on quay named nexd-qa but still uses Containerfile.nexd.