### PR TITLE
hack: Add more nexd variations to bash history

### DIFF
--- a/hack/update-ca.sh
+++ b/hack/update-ca.sh
@@ -20,6 +20,8 @@ fi
 
 if [ "$1" = "prod" ]; then
   cat << EOF > ~/.bash_history
+NEXD_LOGLEVEL=debug nexd https://qa.nexodus.io
+NEXD_LOGLEVEL=debug nexd https://try.nexodus.io
 nexd https://qa.nexodus.io
 nexd https://try.nexodus.io
 EOF
@@ -36,6 +38,9 @@ EOF
 
 else
   cat << EOF > ~/.bash_history
+NEXD_LOGLEVEL=debug nexd https://try.nexodus.io
+NEXD_LOGLEVEL=debug nexd https://qa.nexodus.io
+NEXD_LOGLEVEL=debug nexd --username admin --password floofykittens https://try.nexodus.127.0.0.1.nip.io
 nexd https://try.nexodus.io
 nexd https://qa.nexodus.io
 nexd --username admin --password floofykittens https://try.nexodus.127.0.0.1.nip.io


### PR DESCRIPTION
When running the nexd container, it comes with some sample nexd
commands in the bash history. Add variations of the commands that
include setting the log level to debug.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
