### PR TITLE
nexd: Support listing peers in proxy mode

### DIFF
--- a/cmd/nexctl/peers.go
+++ b/cmd/nexctl/peers.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"encoding/json"
+
 	"github.com/urfave/cli/v2"
 )
 
@@ -72,12 +73,21 @@ func cmdListPeers(cCtx *cli.Context, encodeOut string) error {
 	return nil
 }
 
-// ParseTime attempts to parse a time string in two possible formats to handle UTC and local time differences between Darwin and Linux
+// ParseTime attempts to parse a time string in three possible formats to handle UTC and local time differences between Darwin and Linux and the proxy mode
 func ParseTime(timeStr string) (time.Time, error) {
-	t, err := time.Parse(time.RFC3339Nano, timeStr)
-	if err != nil {
-		// Custom format
-		t, err = time.Parse("2006-01-02 15:04:05.999999999 -0700 MST", timeStr)
+	var t time.Time
+	var ut int64
+	var err error
+	if t, err = time.Parse(time.RFC3339Nano, timeStr); err == nil {
+		return t.UTC(), nil
+	}
+	if t, err = time.Parse("2006-01-02 15:04:05.999999999 -0700 MST", timeStr); err == nil {
+		return t.UTC(), nil
+	}
+	if ut, err = strconv.ParseInt(timeStr, 10, 64); err == nil {
+		if ut != 0 {
+			t = time.Unix(ut, 0)
+		}
 	}
 	return t.UTC(), err
 }

--- a/internal/nexodus/ctlpeers.go
+++ b/internal/nexodus/ctlpeers.go
@@ -6,16 +6,12 @@ import (
 )
 
 func (ac *NexdCtl) ListPeers(_ string, result *string) error {
-	if ac.ax.userspaceMode {
-		return fmt.Errorf("userspace mode not currently supported")
-	}
-
 	iface := ac.ax.defaultTunnelDev()
 	if iface == "" {
 		return fmt.Errorf("no tunnel interface found")
 	}
 
-	peers, err := DumpPeers(iface)
+	peers, err := ac.ax.DumpPeers(iface)
 	if err != nil {
 		return fmt.Errorf("error getting list of peers: %w", err)
 	}

--- a/internal/util/utils.go
+++ b/internal/util/utils.go
@@ -2,6 +2,8 @@ package util
 
 import (
 	"net"
+	"strconv"
+	"strings"
 )
 
 /* maybe we can use a generic version in the future...
@@ -12,5 +14,21 @@ func IPNetSliceToStringSlice(items []net.IPNet) (result []string) {
 	for _, i := range items {
 		result = append(result, i.String())
 	}
+	return
+}
+
+func StringToInt64(s string) int64 {
+	var result int64
+	result, _ = strconv.ParseInt(s, 10, 64)
+	return result
+}
+
+func SplitKeyValue(s string) (result []string) {
+	i := strings.Index(s, "=")
+	if i == -1 {
+		return
+	}
+	result = append(result, s[:i])
+	result = append(result, s[i+1:])
 	return
 }


### PR DESCRIPTION
Add support for running `nexctl nexd peers list` when running in proxy
mode. This requires collecting peer data using a different API, but
all of the same information is available. It also required updating
`nexctl` to handle parsing the handshake timestamp in a 3rd format.

This was manually tested by running `nexd proxy ${SERVICE_URL}`,
letting it peer like usual, and then running the peer list command.

Closes #1066

Signed-off-by: Russell Bryant <rbryant@redhat.com>
