### PR TITLE
nexd: Don't reconcile with stun when behind symmetric NAT

### DIFF
--- a/internal/nexodus/nexodus.go
+++ b/internal/nexodus/nexodus.go
@@ -5,7 +5,6 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
-	"github.com/nexodus-io/nexodus/internal/stun"
 	"net"
 	"net/http"
 	"net/netip"
@@ -18,6 +17,8 @@ import (
 	"sync"
 	"syscall"
 	"time"
+
+	"github.com/nexodus-io/nexodus/internal/stun"
 
 	"github.com/nexodus-io/nexodus/internal/api/public"
 	"github.com/nexodus-io/nexodus/internal/client"
@@ -540,6 +541,10 @@ func (ax *Nexodus) reconcileDevices(ctx context.Context, options []client.Option
 }
 
 func (ax *Nexodus) reconcileStun(deviceID string) error {
+	if ax.symmetricNat {
+		return nil
+	}
+
 	ax.logger.Debug("sending stun request")
 	stunServer1 := stun.NextServer()
 	reflexiveIP, err := stun.Request(ax.logger, stunServer1, ax.listenPort)


### PR DESCRIPTION
The code that automatically reconciles the public NAT binding was not
getting skipped if we had already determined we are behind symmetric
NAT. This simple change fixes the flapping observed when behind
symmetric NAT.

There is another bug still present, though. This code should be
updated further to detect moving in and out of networks with symmetric
NAT. I will file a follow-bug on that scenario.

Closes #1001
Closes #1044

Signed-off-by: Russell Bryant <rbryant@redhat.com>
