### PR TITLE
Store peer configs as a map

### DIFF
--- a/internal/nexodus/nexodus.go
+++ b/internal/nexodus/nexodus.go
@@ -129,7 +129,7 @@ type Nexodus struct {
 
 type wgConfig struct {
 	Interface wgLocalConfig
-	Peers     []wgPeerConfig
+	Peers     map[string]wgPeerConfig
 }
 
 type wgPeerConfig struct {
@@ -600,17 +600,17 @@ func (ax *Nexodus) Reconcile() error {
 			return fmt.Errorf("error: %w", err)
 		}
 	}
-	var updatePeers []public.ModelsDevice
-	var changed bool
+	updatePeers := map[string]public.ModelsDevice{}
+	changed := false
 	for _, p := range peerMap {
 		existing, ok := ax.deviceCache[p.PublicKey]
 		if !ok {
 			ax.addToDeviceCache(p)
-			updatePeers = append(updatePeers, p)
+			updatePeers[p.PublicKey] = p
 			changed = true
 		} else if !reflect.DeepEqual(existing.device, p) {
 			ax.addToDeviceCache(p)
-			updatePeers = append(updatePeers, p)
+			updatePeers[p.PublicKey] = p
 			changed = true
 		}
 	}

--- a/internal/nexodus/wg_deploy.go
+++ b/internal/nexodus/wg_deploy.go
@@ -8,7 +8,7 @@ const (
 	persistentKeepalive = "20"
 )
 
-func (ax *Nexodus) DeployWireguardConfig(newPeers []public.ModelsDevice) error {
+func (ax *Nexodus) DeployWireguardConfig(updatedPeers map[string]public.ModelsDevice) error {
 	cfg := &wgConfig{
 		Interface: ax.wgConfig.Interface,
 		Peers:     ax.wgConfig.Peers,
@@ -21,13 +21,13 @@ func (ax *Nexodus) DeployWireguardConfig(newPeers []public.ModelsDevice) error {
 	}
 
 	// add routes and tunnels for the new peers only according to the cache diff
-	for _, newPeer := range newPeers {
-		if newPeer.Id == "" {
+	for _, updatedPeer := range updatedPeers {
+		if updatedPeer.Id == "" {
 			continue
 		}
 		// add routes for each peer candidate (unless the key matches the local nodes key)
 		for _, peer := range cfg.Peers {
-			if peer.PublicKey == newPeer.PublicKey && newPeer.PublicKey != ax.wireguardPubKey {
+			if peer.PublicKey == updatedPeer.PublicKey && updatedPeer.PublicKey != ax.wireguardPubKey {
 				ax.handlePeerRoute(peer)
 				ax.handlePeerTunnel(peer)
 			}

--- a/internal/nexodus/wg_deploy.go
+++ b/internal/nexodus/wg_deploy.go
@@ -26,12 +26,12 @@ func (ax *Nexodus) DeployWireguardConfig(updatedPeers map[string]public.ModelsDe
 			continue
 		}
 		// add routes for each peer candidate (unless the key matches the local nodes key)
-		for _, peer := range cfg.Peers {
-			if peer.PublicKey == updatedPeer.PublicKey && updatedPeer.PublicKey != ax.wireguardPubKey {
-				ax.handlePeerRoute(peer)
-				ax.handlePeerTunnel(peer)
-			}
+		peer, ok := cfg.Peers[updatedPeer.PublicKey]
+		if !ok || peer.PublicKey == ax.wireguardPubKey {
+			continue
 		}
+		ax.handlePeerRoute(peer)
+		ax.handlePeerTunnel(peer)
 	}
 
 	ax.logger.Debug("Peer setup complete")

--- a/internal/nexodus/wg_peers.go
+++ b/internal/nexodus/wg_peers.go
@@ -115,40 +115,32 @@ func (ax *Nexodus) extractPeerPort(localIP string) string {
 // This is the only peer a symmetric NAT node will get unless it also has a direct peering
 func (ax *Nexodus) buildRelayPeer(device public.ModelsDevice, relayAllowedIP []string, localIP, reflexiveIP4 string) wgPeerConfig {
 	device.AllowedIps = append(device.AllowedIps, device.ChildPrefix...)
-	if ax.nodeReflexiveAddressIPv4.Addr().String() == parseIPfromAddrPort(reflexiveIP4) {
-		return wgPeerConfig{
-			PublicKey:           device.PublicKey,
-			Endpoint:            localIP,
-			AllowedIPs:          relayAllowedIP,
-			PersistentKeepAlive: persistentKeepalive,
-		}
-	}
-	return wgPeerConfig{
+	config := wgPeerConfig{
 		PublicKey:           device.PublicKey,
 		Endpoint:            reflexiveIP4,
 		AllowedIPs:          relayAllowedIP,
 		PersistentKeepAlive: persistentKeepalive,
 	}
+	if ax.nodeReflexiveAddressIPv4.Addr().String() == parseIPfromAddrPort(reflexiveIP4) {
+		config.Endpoint = localIP
+	}
+	return config
 }
 
 // buildPeerForRelayNode build a config for all peers if this node is the organization's relay node. Also check for direct peering.
 // The peer for a relay node is currently left blank and assumed to be exposed to all peers, we still build its peer config for flexibility.
 func (ax *Nexodus) buildPeerForRelayNode(device public.ModelsDevice, localIP, reflexiveIP4 string) wgPeerConfig {
 	device.AllowedIps = append(device.AllowedIps, device.ChildPrefix...)
-	if ax.nodeReflexiveAddressIPv4.Addr().String() == parseIPfromAddrPort(reflexiveIP4) {
-		return wgPeerConfig{
-			PublicKey:           device.PublicKey,
-			Endpoint:            localIP,
-			AllowedIPs:          device.AllowedIps,
-			PersistentKeepAlive: persistentKeepalive,
-		}
-	}
-	return wgPeerConfig{
+	config := wgPeerConfig{
 		PublicKey:           device.PublicKey,
 		Endpoint:            reflexiveIP4,
 		AllowedIPs:          device.AllowedIps,
 		PersistentKeepAlive: persistentKeepalive,
 	}
+	if ax.nodeReflexiveAddressIPv4.Addr().String() == parseIPfromAddrPort(reflexiveIP4) {
+		config.Endpoint = localIP
+	}
+	return config
 }
 
 // buildDirectLocalPeer If both nodes are local, peer them directly to one another via their local addresses (includes symmetric nat nodes)


### PR DESCRIPTION
- nexd: Store peer configs in a map
- nexd: Utilize map in DeployWireguardConfig
- nexd: Reduce some peer config duplication


commit c0c46eb6118df68ad0ff964e383804e762bf2173
Author: Russell Bryant <russell.bryant@gmail.com>
Date:   Thu May 25 16:19:28 2023 -0400

    nexd: Reduce some peer config duplication
    
    There were a couple places where some code was slightly duplicated
    when building peer configs. This cleans it up a bit.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>

commit f16f158821659fed9f2667265ccb3b84623fd8a6
Author: Russell Bryant <russell.bryant@gmail.com>
Date:   Thu May 25 16:00:25 2023 -0400

    nexd: Utilize map in DeployWireguardConfig
    
    This method was O(n^2) before. We can now get the wireguard config for
    each updated peer as a map lookup instead of a linear search.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>

commit b5c491d9e9eac61f81d55fd4b25a8dd3a1235db8
Author: Russell Bryant <russell.bryant@gmail.com>
Date:   Thu May 25 15:57:00 2023 -0400

    nexd: Store peer configs in a map
    
    This is another case where we have a set of peers we need to cross
    reference with another set of peer info. Accessing it by public key
    will be faster than linear searches for larger organizations.
    
    There should be no logic changes in this patch, only a change in the
    storage. Benefits of the new storage will come in future patches as
    more code is introduced that needs to reference the last known config.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>
