### PR TITLE
Resolve an issue with switching from symmetric to non-symmetric

### DIFF
--- a/integration-tests/features/device-api.feature
+++ b/integration-tests/features/device-api.feature
@@ -132,7 +132,7 @@ Feature: Device API
         "public_key": "${public_key}",
         "relay": false,
         "revision": ${response.revision},
-        "symmetric_nat": true,
+        "symmetric_nat": false,
         "tunnel_ip": "${response.tunnel_ip}",
         "tunnel_ip_v6": "${response.tunnel_ip_v6}",
         "user_id": "${user_id}"
@@ -171,7 +171,7 @@ Feature: Device API
           "public_key": "${public_key}",
           "relay": false,
           "revision": ${response[0].revision},
-          "symmetric_nat": true,
+          "symmetric_nat": false,
           "tunnel_ip": "${response[0].tunnel_ip}",
           "tunnel_ip_v6": "${response[0].tunnel_ip_v6}",
           "user_id": "${user_id}"
@@ -247,7 +247,7 @@ Feature: Device API
         "public_key": "${public_key}",
         "relay": false,
         "revision": ${response.revision},
-        "symmetric_nat": true,
+        "symmetric_nat": false,
         "tunnel_ip": "${response.tunnel_ip}",
         "tunnel_ip_v6": "${response.tunnel_ip_v6}",
         "user_id": "${user_id}"

--- a/internal/handlers/device.go
+++ b/internal/handlers/device.go
@@ -166,9 +166,7 @@ func (api *API) UpdateDevice(c *gin.Context) {
 			device.OrganizationID = request.OrganizationID
 		}
 
-		if request.SymmetricNat != nil {
-			device.SymmetricNat = *request.SymmetricNat
-		}
+		device.SymmetricNat = request.SymmetricNat
 
 		// check if the updated device child prefix matches the existing device prefix
 		if request.ChildPrefix != nil && !childPrefixEquals(device.ChildPrefix, request.ChildPrefix) {

--- a/internal/models/device.go
+++ b/internal/models/device.go
@@ -50,7 +50,7 @@ type UpdateDevice struct {
 	OrganizationID           uuid.UUID  `json:"organization_id" example:"694aa002-5d19-495e-980b-3d8fd508ea10"`
 	ChildPrefix              []string   `json:"child_prefix" example:"172.16.42.0/24"`
 	EndpointLocalAddressIPv4 string     `json:"endpoint_local_address_ip4" example:"1.2.3.4"`
-	SymmetricNat             *bool      `json:"symmetric_nat"`
+	SymmetricNat             bool       `json:"symmetric_nat"`
 	Hostname                 string     `json:"hostname" example:"myhost"`
 	Endpoints                []Endpoint `json:"endpoints" gorm:"type:JSONB; serializer:json"`
 	Revision                 *uint64    `json:"revision"`


### PR DESCRIPTION
- Joining as symmetric, and then joining from a non-symmetric was being read as nil by the pointer in the device update handler so the node would always return the device as true, even when it was updating with ax.symmetricNat false.