### PR TITLE
nexd: Eliminiate a traversal of the device cache

### DIFF
--- a/internal/nexodus/nexodus.go
+++ b/internal/nexodus/nexodus.go
@@ -634,6 +634,9 @@ func (ax *Nexodus) Reconcile() error {
 			updatePeers[p.PublicKey] = p
 			changed = true
 		}
+		if p.Relay {
+			ax.relayWgIP = p.AllowedIps[0]
+		}
 	}
 
 	if changed {

--- a/internal/nexodus/wg_peers.go
+++ b/internal/nexodus/wg_peers.go
@@ -20,12 +20,6 @@ func (ax *Nexodus) buildPeersAndRelay() map[string]wgPeerConfig {
 	peers := map[string]wgPeerConfig{}
 
 	_, ax.wireguardPubKeyInConfig = ax.deviceCache[ax.wireguardPubKey]
-	for _, d := range ax.deviceCache {
-		if d.device.Relay {
-			ax.relayWgIP = d.device.AllowedIps[0]
-			break
-		}
-	}
 
 	relayAllowedIP := []string{
 		ax.org.Cidr,


### PR DESCRIPTION
There was a traversal of the device cache looking for a relay to save
off the relay tunnel IP. Move this code into an existing traversal of
the device cache to be more efficient when the device cache gets large.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
