### PR TITLE
Use Material-UI theme for useTheme from @mui/material/styles

### DIFF
--- a/ui/src/pages/Dashboard.tsx
+++ b/ui/src/pages/Dashboard.tsx
@@ -15,13 +15,13 @@ import {
   faLinux,
 } from "@fortawesome/free-brands-svg-icons";
 import { faDownload } from "@fortawesome/free-solid-svg-icons";
-import { useTheme } from "react-admin";
+import { useTheme } from "@mui/material/styles";
 
 import CardImage from "../wordmark.png";
 import CardImageDark from "../wordmark_dark.png";
 
 const Dashboard = () => {
-  const [theme, setTheme] = useTheme();
+  const theme = useTheme();
   return (
     <div>
       <Card
@@ -34,7 +34,7 @@ const Dashboard = () => {
         <CardMedia
           component="img"
           height="200"
-          image={theme.palette?.mode == "dark" ? CardImageDark : CardImage}
+          image={theme.palette?.mode === "dark" ? CardImageDark : CardImage}
           alt="nexodus banner"
           sx={{ padding: "1em 1em 0 1em", objectFit: "contain" }}
         />


### PR DESCRIPTION
- useTheme() from "react-admin" returns a ThemeType | RaThemeOptions type, neither of which appear to have a palette property.
- added a strict js check for the theme '==='.
- should allow for #1089 to be merged.
Signed-off-by: Brent Salisbury <bsalisbu@redhat.com>