### PR TITLE
mergify: Add a label when changes are requested on a PR

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -151,3 +151,19 @@ pull_request_rules:
       label:
         remove:
           - missing-tests-label
+
+  # Give a hint via label when a reviewer has requested changes
+  - name: Label when changes are requested
+    conditions:
+      - "#changes-requested-reviews-by>0"
+    actions:
+      label:
+        add:
+          - changes-requested
+  - name: Remove label when no changes are requested
+    conditions:
+      - "#changes-requested-reviews-by=0"
+    actions:
+      label:
+        remove:
+          - changes-requested


### PR DESCRIPTION
When scanning open PRs, I often want to know if there are already
changes requested waiting for the PR submitter. This will automate
adding/removing a label that says "changes-requested" when there are
outstanding requests for changes from review.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
