### PR TITLE
mergify: Drop use of changes-requested label

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -152,18 +152,3 @@ pull_request_rules:
         remove:
           - missing-tests-label
 
-  # Give a hint via label when a reviewer has requested changes
-  - name: Label when changes are requested
-    conditions:
-      - "#changes-requested-reviews-by>0"
-    actions:
-      label:
-        add:
-          - changes-requested
-  - name: Remove label when no changes are requested
-    conditions:
-      - "#changes-requested-reviews-by=0"
-    actions:
-      label:
-        remove:
-          - changes-requested


### PR DESCRIPTION
Remove the rules that add/remove the changes-requested label.

This does not behave as I expected. It adds the label when I wanted,
but it does not remove it. I expected the label to get removed as soon
as someone re-requests review after changes had been requested.
Instead, that state doesn't change until that reviewer approves the
PR. Based on this behavior, it's not a state we can rely on to signal
when a PR is ready to be reviewed again.

Signed-off-by: Russell Bryant <russell.bryant@gmail.com>
