### PR TITLE
Add bash autocompletion for nexctl and nexd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,7 @@ dist/packages/%: nexd nexctl $(shell find docs/user-guide/ -iname '*.md')
 	$(CMD_PREFIX) cp -r docs/user-guide $(basename $(basename $@))/user-guide
 	$(CMD_PREFIX) cp LICENSE $(basename $(basename $@))
 	$(CMD_PREFIX) cp README.md $(basename $(basename $@))
+	$(CMD_PREFIX) cp contrib/bash_autocomplete $(basename $(basename $@))
 	$(CMD_PREFIX) cp dist/nexd-$(subst nexodus-,,$(basename $(basename $(@F))))$(if $(findstring windows,$@),.exe) $(basename $(basename $@))/nexd$(if $(findstring windows,$@),.exe)
 	$(CMD_PREFIX) cp dist/nexctl-$(subst nexodus-,,$(basename $(basename $(@F))))$(if $(findstring windows,$@),.exe) $(basename $(basename $@))/nexctl$(if $(findstring windows,$@),.exe)
 	$(CMD_PREFIX) if test "$(word 2,$(subst -, ,$(shell basename $@)))" = "windows" ; then \

--- a/cmd/nexctl/main.go
+++ b/cmd/nexctl/main.go
@@ -33,7 +33,8 @@ func main() {
 	// Override usage to capitalize "Show"
 	cli.HelpFlag.(*cli.BoolFlag).Usage = "Show help"
 	app := &cli.App{
-		Name: "nexctl",
+		Name:                 "nexctl",
+		EnableBashCompletion: true,
 		Flags: []cli.Flag{
 			&cli.BoolFlag{
 				Name:    "debug",

--- a/cmd/nexd/main.go
+++ b/cmd/nexd/main.go
@@ -160,9 +160,10 @@ func main() {
 	cli.HelpFlag.(*cli.BoolFlag).Usage = "Show help"
 	// flags are stored in the global flags variable
 	app := &cli.App{
-		Name:      "nexd",
-		Usage:     "Node agent to configure encrypted mesh networking with nexodus.",
-		ArgsUsage: "service-url",
+		Name:                 "nexd",
+		Usage:                "Node agent to configure encrypted mesh networking with nexodus.",
+		ArgsUsage:            "service-url",
+		EnableBashCompletion: true,
 		Commands: []*cli.Command{
 			{
 				Name:  "version",

--- a/contrib/bash_autocomplete
+++ b/contrib/bash_autocomplete
@@ -1,0 +1,36 @@
+#! /bin/bash
+# Source: https://github.com/urfave/cli/blob/v2-maint/autocomplete/bash_autocomplete
+
+: ${PROG:=$(basename ${BASH_SOURCE})}
+
+# Macs have bash3 for which the bash-completion package doesn't include
+# _init_completion. This is a minimal version of that function.
+_cli_init_completion() {
+  COMPREPLY=()
+  _get_comp_words_by_ref "$@" cur prev words cword
+}
+
+_cli_bash_autocomplete() {
+  if [[ "${COMP_WORDS[0]}" != "source" ]]; then
+    local cur opts base words
+    COMPREPLY=()
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    if declare -F _init_completion >/dev/null 2>&1; then
+      _init_completion -n "=:" || return
+    else
+      _cli_init_completion -n "=:" || return
+    fi
+    words=("${words[@]:0:$cword}")
+    if [[ "$cur" == "-"* ]]; then
+      requestComp="${words[*]} ${cur} --generate-bash-completion"
+    else
+      requestComp="${words[*]} --generate-bash-completion"
+    fi
+    opts=$(eval "${requestComp}" 2>/dev/null)
+    COMPREPLY=($(compgen -W "${opts}" -- ${cur}))
+    return 0
+  fi
+}
+
+complete -o bashdefault -o default -o nospace -F _cli_bash_autocomplete $PROG
+unset PROG

--- a/contrib/rpm/nexodus.spec.in
+++ b/contrib/rpm/nexodus.spec.in
@@ -47,6 +47,7 @@ BuildRequires: systemd-units
 Requires(post): systemd-units
 Requires(preun): systemd-units
 Requires(postun): systemd-units
+Requires: bash-completion
 
 %description %{common_description}
 
@@ -81,6 +82,7 @@ install -p -D -m 0644 contrib/rpm/nexodus.service %{buildroot}/usr/lib/systemd/s
 install -p -D -m 0644 contrib/rpm/nexodus.sysconfig %{buildroot}%{_sysconfdir}/sysconfig/nexodus
 for cmd in nexd nexctl ; do
   install -p -D -m 0644 contrib/man/${cmd}.8.gz %{buildroot}%{_mandir}/man8/${cmd}.8.gz
+  install -p -D -m 0644 contrib/bash_autocomplete %{buildroot}%{_sysconfdir}/bash_completion.d/${cmd}
 done
 
 %files
@@ -90,6 +92,7 @@ done
 /usr/lib/systemd/system/nexodus.service
 %{_sysconfdir}/sysconfig/nexodus
 %{_mandir}/man8/*
+%{_sysconfdir}/bash_completion.d/*
 
 %gopkgfiles
 

--- a/docs/user-guide/agent.md
+++ b/docs/user-guide/agent.md
@@ -77,6 +77,8 @@ Extract and install the binaries. For example, on Linux x86-64:
 tar -xzf nexodus-linux-amd64.tar.gz
 cd nexodus-linux-amd64
 sudo install -m 755 nexd nexctl /usr/local/bin
+sudo install -m 644 bash_autocomplete /etc/bash_completion.d/nexd
+sudo install -m 644 bash_autocomplete /etc/bash_completion.d/nexctl
 ```
 
 Proceed by starting `nexd` manually:


### PR DESCRIPTION
- cmd: enable bash autocomplete
- Inclue bash_completion in the manual install packages
- rpm: install bash completion for nexd and nexctl

Closes #1121

commit 668916613dd89df780e85d79ea3230f4850be649
Author: Russell Bryant <russell.bryant@gmail.com>
Date:   Sun Jun 4 19:04:25 2023 -0400

    cmd: enable bash autocomplete
    
    Bash completion is supported natively by urfave/cli. We just have to
    turn it on and use the bash_completion script that comes with the
    library.
    
    The script can either be installed automatically by a package or
    installed manually.
    
    Signed-off-by: Russell Bryant <russell.bryant@gmail.com>

commit d1ba5185f4e9b57dd4bbc24be50165f2405a7128
Author: Russell Bryant <russell.bryant@gmail.com>
Date:   Sun Jun 4 19:40:09 2023 -0400

    Inclue bash_completion in the manual install packages
    
    Signed-off-by: Russell Bryant <russell.bryant@gmail.com>

commit b3c47522fa242fd1c340b62b805572c24ca732ba
Author: Russell Bryant <russell.bryant@gmail.com>
Date:   Sun Jun 4 19:37:01 2023 -0400

    rpm: install bash completion for nexd and nexctl
    
    Signed-off-by: Russell Bryant <russell.bryant@gmail.com>
