### PR TITLE
nexd: Adjust security group reconciliation

### DIFF
--- a/internal/nexodus/wg_deploy.go
+++ b/internal/nexodus/wg_deploy.go
@@ -2,6 +2,7 @@ package nexodus
 
 import (
 	"errors"
+
 	"github.com/nexodus-io/nexodus/internal/api/public"
 )
 
@@ -10,8 +11,7 @@ const (
 )
 
 var (
-	securityGroupErr      = errors.New("nftables setup error")
-	securityGroupNotFound = errors.New("404 Not Found")
+	securityGroupErr = errors.New("nftables setup error")
 )
 
 func (ax *Nexodus) DeployWireguardConfig(updatedPeers map[string]public.ModelsDevice) error {


### PR DESCRIPTION
Adjust the security group reconciliation logic so that it can also be
relied on at startup. This removes some startup-specific code and just
relies on the reconcile loop to do the right thing.

CLoses #1132

Signed-off-by: Russell Bryant <russell.bryant@gmail.com>
