### PR TITLE
Publish aarch64 rpms for Fedora and CentOS Stream

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -138,7 +138,11 @@ jobs:
         include:
           - mock_root: fedora-38-x86_64
             srpm_distro: fc38
+          - mock_root: fedora-38-aarch64
+            srpm_distro: fc38
           - mock_root: centos-stream+epel-9-x86_64
+            srpm_distro: el9
+          - mock_root: centos-stream+epel-9-aarch64
             srpm_distro: el9
     steps:
       - uses: actions/checkout@v3

--- a/Makefile
+++ b/Makefile
@@ -634,7 +634,7 @@ cacerts: ## Install the Self-Signed CA Certificate
 dist/rpm:
 	$(CMD_PREFIX) mkdir -p dist/rpm
 
-MOCK_ROOTS:=fedora-38-x86_64 centos-stream+epel-9-x86_64
+MOCK_ROOTS?=fedora-38-x86_64 centos-stream+epel-9-x86_64
 MOCK_DEPS:=golang systemd-rpm-macros systemd-units
 
 .PHONY: image-mock
@@ -654,9 +654,15 @@ image-mock: ## Build and publish updated mock images to quay.io used for buildin
 		docker push quay.io/nexodus/mock:$$(echo $$MOCK_ROOT | cut -f2 -d'+') ; \
 	done
 
+MOCK_ROOTS_AARCH64:=fedora-38-aarch64 centos-stream+epel-9-aarch64
+
+.PHONY: image-mock-aarch64
+image-mock-aarch64: ## Build and publish updated mock images to quay.io used for building rpms
+	MOCK_ROOTS="$(MOCK_ROOTS_AARCH64)" $(MAKE) image-mock
+
 MOCK_ROOT?=fedora-38-x86_64
 SRPM_DISTRO?=fc38
-NEXODUS_AUTORELEASE=0.1.$(shell date --utc +%Y%m%d)git$(NEXODUS_RELEASE).$(SRPM_DISTRO)
+NEXODUS_AUTORELEASE=0.1.$(shell date -u +%Y%m%d)git$(NEXODUS_RELEASE).$(SRPM_DISTRO)
 
 .PHONY: srpm
 srpm: dist/rpm manpages ## Build a source RPM
@@ -684,7 +690,7 @@ rpm: srpm ## Build an RPM
 	docker run --name mock --rm --privileged=true -v $(CURDIR):/nexodus quay.io/nexodus/mock:$$(echo $(MOCK_ROOT) | cut -f2 -d'+') \
 		mock --rebuild --without check --resultdir=/nexodus/dist/rpm/mock --root ${MOCK_ROOT} \
 		--no-clean --no-cleanup-after --enable-network \
-		/nexodus/$(wildcard dist/rpm/mock/nexodus-0-0.1.$(shell date --utc +%Y%m%d)git$(NEXODUS_RELEASE).$(SRPM_DISTRO).src.rpm)
+		/nexodus/$(wildcard dist/rpm/mock/nexodus-0-0.1.$(shell date -u +%Y%m%d)git$(NEXODUS_RELEASE).$(SRPM_DISTRO).src.rpm)
 
 .PHONY: version
 version: ## Print the version string
@@ -700,8 +706,8 @@ contrib/man:
 
 .PHONY: manpages
 manpages: contrib/man dist/nexd dist/nexctl ## Generate manpages in ./contrib/man
-	dist/nexd -h | docker run -i --rm --name txt2man quay.io/nexodus/mock:latest txt2man -t nexd | gzip > contrib/man/nexd.8.gz
-	dist/nexctl -h | docker run -i --rm --name txt2man quay.io/nexodus/mock:latest txt2man -t nexctl | gzip > contrib/man/nexctl.8.gz
+	dist/nexd -h | docker run -i --rm --name txt2man quay.io/nexodus/mock:$$(echo $(MOCK_ROOT) | cut -f2 -d'+') txt2man -t nexd | gzip > contrib/man/nexd.8.gz
+	dist/nexctl -h | docker run -i --rm --name txt2man quay.io/nexodus/mock:$$(echo $(MOCK_ROOT) | cut -f2 -d'+') txt2man -t nexctl | gzip > contrib/man/nexctl.8.gz
 
 # Nothing to see here
 .PHONY: cat


### PR DESCRIPTION
- rpm: Support building aarch64 rpms on a mac
- rpm: Publish aarch64 rpms


commit f0018e32edea790539afedb5248ece128187f70c
Author: Russell Bryant <russell.bryant@gmail.com>
Date:   Tue Jun 6 16:46:51 2023 -0400

    rpm: Support building aarch64 rpms on a mac
    
    - Add a shortcut for building the aarch64 mock environments,
      `make image-mock-aarch64`.
    
    - Use `-u` instead of `--utc`. `-u` is more portable as it works on
      mac, while `--utc` only works on Linux (or `date` from GNU
      coreutils).
    
    - Use the mock build root image instead of `latest` when generating
      man pages. That way it's not accidentally using an x86_64 image on
      an aarch64 host.
    
    With these changes, I can run these commands on my mac to generate
    aarch64 rpms:
    
    ```
    make image-mock-aarch64
    MOCK_ROOT=fedora-38-aarch64 make rpm
    ```
    
    Signed-off-by: Russell Bryant <russell.bryant@gmail.com>

commit 308aeafabb3d24281869f7ec84acd226d6bfbcae
Author: Russell Bryant <russell.bryant@gmail.com>
Date:   Wed Jun 7 11:32:07 2023 -0400

    rpm: Publish aarch64 rpms
    
    Update our CI config to publish aarch64 rpms to the copr repo for
    fedora 38 and CentOS Stream 9.
    
    Signed-off-by: Russell Bryant <russell.bryant@gmail.com>
