### PR TITLE
Change no security group supoport for non-linux to informational

### DIFF
--- a/internal/nexodus/nexodus.go
+++ b/internal/nexodus/nexodus.go
@@ -265,7 +265,7 @@ func (ax *Nexodus) Start(ctx context.Context, wg *sync.WaitGroup) error {
 	}
 
 	if runtime.GOOS != Linux.String() {
-		ax.logger.Debug("Security Groups are currently only supported on Linux")
+		ax.logger.Info("Security Groups are currently only supported on Linux")
 	}
 
 	var options []client.Option


### PR DESCRIPTION
- Change this from debug to informational to notify the user security groups are only supported on Linux.