### PR TITLE
rpm: Fix building srpm in aarch64 rpm jobs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -137,12 +137,16 @@ jobs:
       matrix:
         include:
           - mock_root: fedora-38-x86_64
+            mock_srpm_root: fedora-38-x86_64
             srpm_distro: fc38
           - mock_root: fedora-38-aarch64
+            mock_srpm_root: fedora-38-x86_64
             srpm_distro: fc38
           - mock_root: centos-stream+epel-9-x86_64
+            mock_srpm_root: centos-stream+epel-9-x86_64
             srpm_distro: el9
           - mock_root: centos-stream+epel-9-aarch64
+            mock_srpm_root: centos-stream+epel-9-x86_64
             srpm_distro: el9
     steps:
       - uses: actions/checkout@v3
@@ -157,7 +161,7 @@ jobs:
 
       - name: Build srpm
         run: |
-          MOCK_ROOT="${{ matrix.mock_root }}" SRPM_DISTRO="${{ matrix.srpm_distro }}" make srpm
+          MOCK_ROOT="${{ matrix.mock_root }}" MOCK_SRPM_ROOT="${{ matrix.mock_srpm_root }}" SRPM_DISTRO="${{ matrix.srpm_distro }}" make srpm
           find dist
 
       - name: Submit srpm to copr


### PR DESCRIPTION
When building an srpm to submit to copr for an aarch64 build, just
build the srpm in an x86_64 build root. The arch doesn't matter when
building the srpm, and it'll be more efficient as it will match the
architecture of the host building the srpm.

When setting up the build root for aarch64 for use with `make rpm`,
install `qemu-user-static-aarch64`, as this is needed to build the
aarch64 rpm on an x86_64 host.

Closes #1142

Signed-off-by: Russell Bryant <rbryant@redhat.com>
