### PR TITLE
Ignore security groups in device reconcile

### DIFF
--- a/internal/nexodus/nexodus.go
+++ b/internal/nexodus/nexodus.go
@@ -702,7 +702,7 @@ func (ax *Nexodus) Reconcile() error {
 	newLocalConfig := false
 	for _, p := range peerMap {
 		existing, ok := ax.deviceCache[p.PublicKey]
-		if !ok || !reflect.DeepEqual(existing.device, p) {
+		if !ok || !ax.isEqualIgnoreSecurityGroup(existing.device, p) {
 			if p.PublicKey == ax.wireguardPubKey {
 				newLocalConfig = true
 			}
@@ -732,6 +732,20 @@ func (ax *Nexodus) Reconcile() error {
 	}
 
 	return nil
+}
+
+func (ax *Nexodus) isEqualIgnoreSecurityGroup(p1, p2 public.ModelsDevice) bool {
+	// create temporary copies of the instances
+	tmpDev1 := p1
+	tmpDev2 := p2
+	// set the SecurityGroupId to an empty value, so it will not affect the comparison
+	tmpDev1.SecurityGroupId = ""
+	tmpDev2.SecurityGroupId = ""
+	// set the Revision to 0, so it will not affect the comparison
+	tmpDev1.Revision = 0
+	tmpDev2.Revision = 0
+
+	return reflect.DeepEqual(tmpDev1, tmpDev2)
 }
 
 // checkUnsupportedConfigs general matrix checks of required information or constraints to run the agent and join the mesh


### PR DESCRIPTION
- When the security group ID changes on for example, a SG ID deletion, it triggers a peer config change and redeploys the peerings.
- This patch creates a method that will ignores the two device fields, Revision and SecurityGroupId by setting them to a temporary constant and then does a reflect to check for a diff.
- The bug is described further in #1146