### PR TITLE
fix SRPM variable name in Makefile

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -331,8 +331,10 @@ jobs:
       matrix:
         include:
           - mock_root: fedora-38-x86_64
+            srpm_mock_root: fedora-38-x86_64
             srpm_distro: fc38
           - mock_root: centos-stream-9-x86_64
+            srpm_mock_root: centos-stream-9-x86_64
             srpm_distroy: el9
     steps:
       - uses: actions/checkout@v3
@@ -344,7 +346,7 @@ jobs:
       - name: Build rpm
         id: build-rpm
         run: |
-          MOCK_ROOT=${{ matrix.mock_root}} SRPM_DISTRO=${{ matrix.srpm_distro }} make rpm
+          MOCK_ROOT="${{ matrix.mock_root}}" SRPM_MOCK_ROOT="${{ matrix.srpm_mock_root }}" SRPM_DISTRO="${{ matrix.srpm_distro }}" make rpm
           echo "artifact-name=$(pwd)/dist/rpm/mock/nexodus-*.x86_64.rpm" >> "$GITHUB_OUTPUT"
 
       - name: Upload Artifact

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -137,16 +137,16 @@ jobs:
       matrix:
         include:
           - mock_root: fedora-38-x86_64
-            mock_srpm_root: fedora-38-x86_64
+            srpm_mock_root: fedora-38-x86_64
             srpm_distro: fc38
           - mock_root: fedora-38-aarch64
-            mock_srpm_root: fedora-38-x86_64
+            srpm_mock_root: fedora-38-x86_64
             srpm_distro: fc38
           - mock_root: centos-stream+epel-9-x86_64
-            mock_srpm_root: centos-stream+epel-9-x86_64
+            srpm_mock_root: centos-stream+epel-9-x86_64
             srpm_distro: el9
           - mock_root: centos-stream+epel-9-aarch64
-            mock_srpm_root: centos-stream+epel-9-x86_64
+            srpm_mock_root: centos-stream+epel-9-x86_64
             srpm_distro: el9
     steps:
       - uses: actions/checkout@v3
@@ -161,7 +161,7 @@ jobs:
 
       - name: Build srpm
         run: |
-          MOCK_ROOT="${{ matrix.mock_root }}" MOCK_SRPM_ROOT="${{ matrix.mock_srpm_root }}" SRPM_DISTRO="${{ matrix.srpm_distro }}" make srpm
+          MOCK_ROOT="${{ matrix.mock_root }}" SRPM_MOCK_ROOT="${{ matrix.srpm_mock_root }}" SRPM_DISTRO="${{ matrix.srpm_distro }}" make srpm
           find dist
 
       - name: Submit srpm to copr

--- a/Makefile
+++ b/Makefile
@@ -686,9 +686,9 @@ srpm: dist/rpm manpages ## Build a source RPM
 	cp contrib/rpm/nexodus.spec.in contrib/rpm/nexodus.spec
 	sed -i -e "s/##NEXODUS_COMMIT##/${NEXODUS_RELEASE}/" contrib/rpm/nexodus.spec
 	sed -i -e "s/##NEXODUS_AUTORELEASE##/$(NEXODUS_AUTORELEASE)/" contrib/rpm/nexodus.spec
-	docker run --name mock --rm --privileged=true -v $(CURDIR):/nexodus quay.io/nexodus/mock:$$(echo $(MOCK_SRPM_ROOT) | cut -f2 -d'+') \
+	docker run --name mock --rm --privileged=true -v $(CURDIR):/nexodus quay.io/nexodus/mock:$$(echo $(SRPM_MOCK_ROOT) | cut -f2 -d'+') \
 		mock --buildsrpm -D "_commit ${NEXODUS_RELEASE}" --resultdir=/nexodus/dist/rpm/mock --no-clean --no-cleanup-after \
-		--spec /nexodus/contrib/rpm/nexodus.spec --sources /nexodus/dist/rpm/ --root ${MOCK_SRPM_ROOT}
+		--spec /nexodus/contrib/rpm/nexodus.spec --sources /nexodus/dist/rpm/ --root ${SRPM_MOCK_ROOT}
 	rm -f dist/rpm/nexodus-${NEXODUS_RELEASE}.tar.gz
 
 .PHONY: rpm


### PR DESCRIPTION
Updated name of variable as the variable declared was not the same as what was being referenced. 

This resulted in the following issue in the build, where we echoed an empty string.

```bash
docker run --name mock --rm --privileged=true -v /home/runner/work/nexodus/nexodus:/nexodus quay.io/nexodus/mock:$(echo  | cut -f2 -d'+') \
47
    mock --buildsrpm -D "_commit 4c837fd" --resultdir=/nexodus/dist/rpm/mock --no-clean --no-cleanup-after \
48
    --spec /nexodus/contrib/rpm/nexodus.spec --sources /nexodus/dist/rpm/ --root 
49
docker: invalid reference format.
```