### PR TITLE
Accept empty inbound/outbound SG rules

### DIFF
--- a/internal/handlers/security_group.go
+++ b/internal/handlers/security_group.go
@@ -353,21 +353,10 @@ func (api *API) UpdateSecurityGroup(c *gin.Context) {
 			return errSecurityGroupNotFound
 		}
 
-		if request.GroupName != "" {
-			securityGroup.GroupName = request.GroupName
-		}
-
-		if request.GroupDescription != "" {
-			securityGroup.GroupDescription = request.GroupDescription
-		}
-
-		if request.InboundRules != nil {
-			securityGroup.InboundRules = request.InboundRules
-		}
-
-		if request.OutboundRules != nil {
-			securityGroup.OutboundRules = request.OutboundRules
-		}
+		securityGroup.GroupName = request.GroupName
+		securityGroup.GroupDescription = request.GroupDescription
+		securityGroup.InboundRules = request.InboundRules
+		securityGroup.OutboundRules = request.OutboundRules
 
 		if res := tx.Save(&securityGroup); res.Error != nil {
 			return res.Error


### PR DESCRIPTION
- Since we are implicitly allowing traffic in the initial phase we need to be able to reset the tables back to default with an empty rule being installed.
- The only limitation here is denying all traffic to be addressed in a future PR described in #1162