### PR TITLE
nexd: fix a seg fault

### DIFF
--- a/internal/api/public/api_organizations.go
+++ b/internal/api/public/api_organizations.go
@@ -152,6 +152,17 @@ func (a *OrganizationsApiService) CreateOrganizationExecute(r ApiCreateOrganizat
 			newErr.model = v
 			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
+		if localVarHTTPResponse.StatusCode == 409 {
+			var v ModelsConflictsError
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarReturnValue, localVarHTTPResponse, newErr
+			}
+			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
+			newErr.model = v
+			return localVarReturnValue, localVarHTTPResponse, newErr
+		}
 		if localVarHTTPResponse.StatusCode == 429 {
 			var v ModelsBaseError
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))

--- a/internal/nexodus/userspace_proxy.go
+++ b/internal/nexodus/userspace_proxy.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/bytedance/gopkg/util/logger"
 	"io"
 	"net"
 	"os"
@@ -15,6 +14,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/bytedance/gopkg/util/logger"
 
 	atomicFile "github.com/natefinch/atomic"
 
@@ -570,8 +571,12 @@ func (proxy *UsProxy) runTCP(ctx context.Context, proxyWg *sync.WaitGroup) error
 				break
 			}
 			util.GoWithWaitGroup(proxyWg, func() {
+				remoteAddr := "unknown"
+				if conn.RemoteAddr() != nil {
+					remoteAddr = conn.RemoteAddr().String()
+				}
 				err = proxy.handleTCPConnection(ctx, proxyWg, conn)
-				proxy.logger.Debugf("Connection from %s closed: %v", conn.RemoteAddr().String(), err)
+				proxy.logger.Debugf("Connection from %s closed: %v", remoteAddr, err)
 			})
 		}
 	})


### PR DESCRIPTION
commit b276f998e92ffff3ae4ad36c29c145fb7d051b06
Author: Russell Bryant <russell.bryant@gmail.com>
Date:   Fri Jun 9 18:29:56 2023 -0400

    nexd: fix a seg fault
    
    I observed a seg fault in a CI run against PR #1007 on the following
    line:
    
    ```go
    proxy.logger.Debugf("Connection from %s closed: %v", conn.RemoteAddr().String(), err)
    ```
    
    Based on conventions of the std library, as well as reading the code
    in wireguard-go, it appears that `conn` should never be `nil` here, as
    we only get here after `Accept()` returns `nil` for an error.
    
    However, it is possible that `conn.RemoteAddr()` returns `nil`. Here's
    the corresponding code in the `net` library:
    
    ```go
    func (c *conn) RemoteAddr() Addr {
            if !c.ok() {
                    return nil
            }
            return c.fd.raddr
    }
    ```
    
    and to further explain when it may be `nil`, here's `c.ok()`:
    
    ```go
    func (c *conn) ok() bool { return c != nil && c.fd != nil }
    ```
    
    Just in case the connection gets put in a bad state in our connection
    handler, go ahead and save off the remote address early for use in the
    log message later, if available.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>