### PR TITLE
rpm: Rename rpm build artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -335,7 +335,7 @@ jobs:
             srpm_distro: fc38
           - mock_root: centos-stream-9-x86_64
             srpm_mock_root: centos-stream-9-x86_64
-            srpm_distroy: el9
+            srpm_distro: el9
     steps:
       - uses: actions/checkout@v3
 
@@ -352,7 +352,7 @@ jobs:
       - name: Upload Artifact
         uses: actions/upload-artifact@v3
         with:
-          name: nexodus
+          name: nexodus-rpms
           path: |
             ${{ steps.build-rpm.outputs.artifact-name }}
 


### PR DESCRIPTION
The rpms built in the build workflow were in a build artifact called
`nexodus`. It was not obvious at all that this was an archive of rpms
built from this PR. Rename the artifact to "nexodus-rpms". This lets
you install an rpm of a given PR.

I also noticed there was a typo in the job configuration that caused
`el9` to get left out of the rpm filenames for centos stream 9.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
