### PR TITLE
nexd: Don't attempt security groups in proxy mode

### DIFF
--- a/internal/nexodus/nexodus.go
+++ b/internal/nexodus/nexodus.go
@@ -271,6 +271,8 @@ func (ax *Nexodus) Start(ctx context.Context, wg *sync.WaitGroup) error {
 
 	if runtime.GOOS != Linux.String() {
 		ax.logger.Info("Security Groups are currently only supported on Linux")
+	} else if ax.userspaceMode {
+		ax.logger.Info("Security Groups are not supported in userspace proxy mode")
 	}
 
 	var options []client.Option
@@ -498,7 +500,7 @@ func (ax *Nexodus) Stop() {
 
 // reconcileSecurityGroups will check the security group and update it if necessary.
 func (ax *Nexodus) reconcileSecurityGroups(ctx context.Context) {
-	if runtime.GOOS != Linux.String() {
+	if runtime.GOOS != Linux.String() || ax.userspaceMode {
 		return
 	}
 


### PR DESCRIPTION
Security groups are not supported in the userspace proxy mode. I saw
some errors when running `nexd proxy` in a Kubernetes Pod. It was
attempting to run some `nft` commands.

Closes #1180

Signed-off-by: Russell Bryant <rbryant@redhat.com>
