### PR TITLE
Add v6 support for nexd peers ping

### DIFF
--- a/cmd/nexctl/local_unix.go
+++ b/cmd/nexctl/local_unix.go
@@ -194,7 +194,7 @@ func init() {
 			},
 			{
 				Name:  "peers",
-				Usage: "Commands for interacting nexd exit node configuration",
+				Usage: "Commands for interacting with nexd peer connectivity",
 				Subcommands: []*cli.Command{
 					{
 						Name:  "list",
@@ -205,9 +205,18 @@ func init() {
 						},
 					},
 					{
-						Name:   "ping",
-						Usage:  "run a test to check the nexd peer connectivity (host firewalls may block the ICMP probes)",
-						Action: cmdConnStatus,
+						Name:  "ping",
+						Usage: "run a test to check the nexd IPv4 peer connectivity (host firewalls or security groups may block the ICMP probes)",
+						Action: func(cCtx *cli.Context) error {
+							return cmdConnStatus(cCtx, v4)
+						},
+					},
+					{
+						Name:  "ping6",
+						Usage: "run a test to check the nexd IPv6 peer connectivity (host firewalls or security groups may block the ICMP probes)",
+						Action: func(cCtx *cli.Context) error {
+							return cmdConnStatus(cCtx, v6)
+						},
 					},
 				},
 			},

--- a/internal/nexodus/keepalive.go
+++ b/internal/nexodus/keepalive.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"time"
 
+	"github.com/nexodus-io/nexodus/internal/util"
 	"golang.org/x/net/icmp"
 	"golang.org/x/net/ipv4"
 )
@@ -20,6 +21,7 @@ const (
 	PACKETSIZE                         = 64
 	ICMP_TYPE_ECHO_REQUEST             = 8
 	ICMP_ECHO_REPLY_HEADER_IPV4_OFFSET = 20
+	ICMP6_TYPE_ECHO_REQUEST            = 128
 )
 
 type KeepaliveStatus struct {
@@ -28,11 +30,11 @@ type KeepaliveStatus struct {
 	Hostname    string `json:"hostname"`
 }
 
-func (ax *Nexodus) runProbe(peerStatus KeepaliveStatus, c chan struct {
+func (nx *Nexodus) runProbe(peerStatus KeepaliveStatus, c chan struct {
 	KeepaliveStatus
 	IsReachable bool
 }) {
-	err := ax.ping(peerStatus.WgIP)
+	err := nx.ping(peerStatus.WgIP)
 	if err != nil {
 		// peer is not replying
 		c <- struct {
@@ -66,16 +68,19 @@ func cksum(bs []byte) uint16 {
 	return ^uint16(sum)
 }
 
-func (ax *Nexodus) doPing(host string, i uint64, waitFor time.Duration) (string, error) {
-	if ax.userspaceMode {
-		return ax.pingUS(host, i, waitFor)
+func (nx *Nexodus) doPing(host string, i uint64, waitFor time.Duration) (string, error) {
+	if nx.userspaceMode {
+		return nx.pingUS(host, i, waitFor)
 	} else {
-		return ax.pingOS(host, i, waitFor)
+		return nx.pingOS(host, i, waitFor)
 	}
 }
 
-func (ax *Nexodus) pingUS(host string, i uint64, waitFor time.Duration) (string, error) {
-	socket, err := ax.userspaceNet.Dial("ping4", host)
+func (nx *Nexodus) pingUS(host string, i uint64, waitFor time.Duration) (string, error) {
+	if util.IsIPv6Address(host) {
+		return "", fmt.Errorf("IPv6 connectivity check currently not implemented for nexodus userspace mode")
+	}
+	socket, err := nx.userspaceNet.Dial("ping4", host)
 	if err != nil {
 		return "", err
 	}
@@ -115,8 +120,17 @@ func (ax *Nexodus) pingUS(host string, i uint64, waitFor time.Duration) (string,
 	return fmt.Sprintf("%d bytes from %v: icmp_seq=%v, time=%v", n, host, i, time.Since(start)), nil
 }
 
-func (ax *Nexodus) pingOS(host string, i uint64, waitFor time.Duration) (string, error) {
-	netname := "ip4:icmp"
+func (nx *Nexodus) pingOS(host string, i uint64, waitFor time.Duration) (string, error) {
+	var v6Host bool
+	var netname string
+
+	if util.IsIPv6Address(host) {
+		v6Host = true
+		netname = "ip6:ipv6-icmp"
+	} else {
+		netname = "ip4:icmp"
+	}
+
 	c, err := net.Dial(netname, host)
 	if err != nil {
 		return "", fmt.Errorf("net.Dial(%v %v) failed: %w", netname, host, err)
@@ -124,11 +138,15 @@ func (ax *Nexodus) pingOS(host string, i uint64, waitFor time.Duration) (string,
 	defer c.Close()
 	// send echo request
 	if err = c.SetDeadline(time.Now().Add(waitFor)); err != nil {
-		ax.logger.Debugf("probe error: %v", err)
+		nx.logger.Debugf("probe error: %v", err)
 	}
 
 	msg := make([]byte, PACKETSIZE)
-	msg[0] = ICMP_TYPE_ECHO_REQUEST
+	if v6Host {
+		msg[0] = ICMP6_TYPE_ECHO_REQUEST
+	} else {
+		msg[0] = ICMP_TYPE_ECHO_REQUEST
+	}
 	msg[1] = 0
 	binary.BigEndian.PutUint16(msg[6:], uint16(i))
 	binary.BigEndian.PutUint16(msg[4:], uint16(i>>16))
@@ -138,7 +156,7 @@ func (ax *Nexodus) pingOS(host string, i uint64, waitFor time.Duration) (string,
 	}
 	// get echo reply
 	if err = c.SetDeadline(time.Now().Add(waitFor)); err != nil {
-		ax.logger.Debugf("probe error: %v", err)
+		nx.logger.Debugf("probe error: %v", err)
 	}
 	rmsg := make([]byte, PACKETSIZE+256)
 	before := time.Now()
@@ -148,12 +166,11 @@ func (ax *Nexodus) pingOS(host string, i uint64, waitFor time.Duration) (string,
 	}
 	latency := time.Since(before)
 
-	rmsg = rmsg[ICMP_ECHO_REPLY_HEADER_IPV4_OFFSET:]
-	cks := binary.BigEndian.Uint16(rmsg[2:])
-	binary.BigEndian.PutUint16(rmsg[2:], 0)
-	if cks != cksum(rmsg) {
-		return "", fmt.Errorf("bad ICMP checksum: %v (expected %v)", cks, cksum(rmsg))
+	if !v6Host {
+		rmsg = rmsg[ICMP_ECHO_REPLY_HEADER_IPV4_OFFSET:]
 	}
+
+	binary.BigEndian.PutUint16(rmsg[2:], 0)
 	id := binary.BigEndian.Uint16(rmsg[4:])
 	seq := binary.BigEndian.Uint16(rmsg[6:])
 	rseq := uint64(id)<<16 + uint64(seq)
@@ -164,14 +181,11 @@ func (ax *Nexodus) pingOS(host string, i uint64, waitFor time.Duration) (string,
 	return fmt.Sprintf("%d bytes from %v: icmp_seq=%v, time=%v", amt, host, i, latency), nil
 }
 
-func (ax *Nexodus) ping(host string) error {
-	if PACKETSIZE < 8 {
-		return fmt.Errorf("packet size too small (must be >= 8): %v", PACKETSIZE)
-	}
+func (nx *Nexodus) ping(host string) error {
 	interval := time.Duration(interval)
 	waitFor := time.Duration(timeWait) * time.Millisecond
 	for i := uint64(0); i <= iterations; i++ {
-		_, err := ax.doPing(host, i+1, waitFor)
+		_, err := nx.doPing(host, i+1, waitFor)
 		if err != nil {
 			return fmt.Errorf("ping failed: %w", err)
 		}

--- a/ops/ansible/aws/validate-connectivity/tasks/main.yml
+++ b/ops/ansible/aws/validate-connectivity/tasks/main.yml
@@ -31,6 +31,7 @@
     printf "====== Connectivity Results from Node: {{ inventory_hostname }} ======\n" > connectivity-results.txt
     nexctl nexd peers ping
     nexctl nexd peers ping >> connectivity-results.txt 2>&1
+    nexctl nexd peers ping6 >> connectivity-results.txt 2>&1
     printf "\n====== WG Dump from Node: {{ inventory_hostname }} ======\n" >> connectivity-results.txt
     wg show wg0 dump >> connectivity-results.txt 2>&1
     cat connectivity-results.txt


### PR DESCRIPTION
- Adds the command option `nexctl nexd peers ping6`
- Also cleans up some unused constants and a couple of ineffective conditions in keepalive OS.