### PR TITLE
nexctl: Trim down peers list output

### DIFF
--- a/cmd/nexctl/local_unix.go
+++ b/cmd/nexctl/local_unix.go
@@ -199,6 +199,14 @@ func init() {
 					{
 						Name:  "list",
 						Usage: "list the nexd peers for this device",
+						Flags: []cli.Flag{
+							&cli.BoolFlag{
+								Name:    "full",
+								Aliases: []string{"f"},
+								Usage:   "display the full set of peer details",
+								Value:   false,
+							},
+						},
 						Action: func(cCtx *cli.Context) error {
 							encodeOut := cCtx.String("output")
 							return cmdListPeers(cCtx, encodeOut)

--- a/cmd/nexctl/peers.go
+++ b/cmd/nexctl/peers.go
@@ -40,10 +40,19 @@ func cmdListPeers(cCtx *cli.Context, encodeOut string) error {
 	}
 
 	if encodeOut == encodeColumn || encodeOut == encodeNoHeader {
+		var fs string
 		w := newTabWriter()
-		fs := "%s\t%s\t%s\t%s\t%s\t%s\t%s\n"
+		if cCtx.Bool("full") {
+			fs = "%s\t%s\t%s\t%s\t%s\t%s\t%s\n"
+		} else {
+			fs = "%s\t%s\t%s\n"
+		}
 		if encodeOut != encodeNoHeader {
-			fmt.Fprintf(w, fs, "PUBLIC KEY", "ENDPOINT", "ALLOWED IPS", "LATEST HANDSHAKE", "TRANSMITTED", "RECEIVED", "HEALTHY")
+			if cCtx.Bool("full") {
+				fmt.Fprintf(w, fs, "PUBLIC KEY", "ENDPOINT", "ALLOWED IPS", "LATEST HANDSHAKE", "TRANSMITTED", "RECEIVED", "HEALTHY")
+			} else {
+				fmt.Fprintf(w, fs, "PUBLIC KEY", "ALLOWED IPS", "HEALTHY")
+			}
 		}
 
 		for _, peer := range peers {
@@ -58,7 +67,11 @@ func cmdListPeers(cCtx *cli.Context, encodeOut string) error {
 				secondsAgo := time.Now().UTC().Sub(handshakeTime).Seconds()
 				handshake = fmt.Sprintf("%.0f seconds ago", secondsAgo)
 			}
-			fmt.Fprintf(w, fs, peer.PublicKey, peer.Endpoint, peer.AllowedIPs, handshake, tx, rx, strconv.FormatBool(peer.Healthy))
+			if cCtx.Bool("full") {
+				fmt.Fprintf(w, fs, peer.PublicKey, peer.Endpoint, peer.AllowedIPs, handshake, tx, rx, strconv.FormatBool(peer.Healthy))
+			} else {
+				fmt.Fprintf(w, fs, peer.PublicKey, peer.AllowedIPs, strconv.FormatBool(peer.Healthy))
+			}
 		}
 
 		w.Flush()


### PR DESCRIPTION
Update the output of `nexctl nexd peers list` with a minimal list of
columns by default. To get full output, you can use the new `--full`
option. This provides output that won't line wrap in most cases.

Closes #1112

Signed-off-by: Russell Bryant <rbryant@redhat.com>
