### PR TITLE
[nexodus#1179] Rename all --org-id flags to --organization-id

### DIFF
--- a/cmd/nexctl/main.go
+++ b/cmd/nexctl/main.go
@@ -408,14 +408,14 @@ func main() {
 								Required: true,
 							},
 							&cli.StringFlag{
-								Name:     "org-id",
+								Name:     "organization-id",
 								Required: true,
 							},
 						},
 						Action: func(cCtx *cli.Context) error {
 							encodeOut := cCtx.String("output")
 							userID := cCtx.String("user-id")
-							orgID := cCtx.String("org-id")
+							orgID := cCtx.String("organization-id")
 							return createInvitation(mustCreateAPIClient(cCtx), encodeOut, userID, orgID)
 						},
 					},

--- a/cmd/nexd/main.go
+++ b/cmd/nexd/main.go
@@ -103,7 +103,7 @@ func nexdRun(cCtx *cli.Context, logger *zap.Logger, logLevel *zap.AtomicLevel, m
 		userspaceMode,
 		cCtx.String("state-dir"),
 		ctx,
-		cCtx.String("org-id"),
+		cCtx.String("organization-id"),
 	)
 	if err != nil {
 		logger.Fatal(err.Error())
@@ -356,7 +356,7 @@ func main() {
 				Category: nexServiceOptions,
 			},
 			&cli.StringFlag{
-				Name:     "org-id",
+				Name:     "organization-id",
 				Usage:    "Organization ID to use when registering with the nexodus service",
 				EnvVars:  []string{"NEXD_ORG_ID"},
 				Required: false,

--- a/docs/user-guide/agent.md
+++ b/docs/user-guide/agent.md
@@ -131,10 +131,10 @@ For [try.nexodus.io](https://try.nexodus.io), you may set a password for your ac
 
 When `nexd` starts, it will check to see which organizations it has access to. If no organization is specified, it will connect to the user's default organization. The default is the organization that has the same name as the user.
 
-If `nexd` sees that it has access to multiple organizations, it will require you to specify which one to connect to. You can do this by passing the `--org-id` flag to `nexd`. For example:
+If `nexd` sees that it has access to multiple organizations, it will require you to specify which one to connect to. You can do this by passing the `--organization-id` flag to `nexd`. For example:
 
 ```sh
-sudo nexd --org-id 12345678-1234-1234-1234-123456789012 https://try.nexodus.io
+sudo nexd --organization-id 12345678-1234-1234-1234-123456789012 https://try.nexodus.io
 ```
 
 ### Verifying Agent Setup

--- a/integration-tests/integration_test.go
+++ b/integration-tests/integration_test.go
@@ -298,7 +298,7 @@ func TestChooseOrganization(t *testing.T) {
 	for _, orgID := range useOrgs {
 		args := []string{"--username", username, "--password", password}
 		if orgID != "" {
-			args = append(args, "--org-id", orgID)
+			args = append(args, "--organization-id", orgID)
 		}
 
 		// start nexd on node1

--- a/internal/nexodus/nexodus.go
+++ b/internal/nexodus/nexodus.go
@@ -700,7 +700,7 @@ func (nx *Nexodus) chooseOrganization(organizations []public.ModelsOrganization,
 			for _, org := range organizations {
 				nx.logger.Infof("organization name: '%s'  Id: %s", org.Name, org.Id)
 			}
-			return nil, fmt.Errorf("user belongs to multiple organizations, please specify one with --org-id")
+			return nil, fmt.Errorf("user belongs to multiple organizations, please specify one with --organization-id")
 		}
 		return &organizations[0], nil
 	}


### PR DESCRIPTION
This PR changes flag --org-id to --organization-id. Fixes nexodus#1179.