### PR TITLE
renames ax to nx on receiver functions of internal/nexodus/ctl*.go files

### DIFF
--- a/internal/nexodus/ctlconnectivty.go
+++ b/internal/nexodus/ctlconnectivty.go
@@ -16,7 +16,7 @@ const (
 
 // ConnectivityV4 pings all peers via IPv4
 func (ac *NexdCtl) ConnectivityV4(_ string, keepaliveResults *string) error {
-	res := ac.ax.connectivityProbe(v4)
+	res := ac.nx.connectivityProbe(v4)
 	var err error
 
 	// Marshal the map into a JSON string.
@@ -32,7 +32,7 @@ func (ac *NexdCtl) ConnectivityV4(_ string, keepaliveResults *string) error {
 
 // ConnectivityV6 pings all peers via IPv6
 func (ac *NexdCtl) ConnectivityV6(_ string, keepaliveResults *string) error {
-	res := ac.ax.connectivityProbe(v6)
+	res := ac.nx.connectivityProbe(v6)
 	var err error
 
 	// Marshal the map into a JSON string.

--- a/internal/nexodus/ctlpeers.go
+++ b/internal/nexodus/ctlpeers.go
@@ -6,13 +6,13 @@ import (
 )
 
 func (ac *NexdCtl) ListPeers(_ string, result *string) error {
-	peers, err := ac.ax.DumpPeersDefault()
+	peers, err := ac.nx.DumpPeersDefault()
 	if err != nil {
 		return fmt.Errorf("error getting list of peers: %w", err)
 	}
 
-	ac.ax.deviceCacheIterRead(func(d deviceCacheEntry) {
-		if d.device.PublicKey == ac.ax.wireguardPubKey {
+	ac.nx.deviceCacheIterRead(func(d deviceCacheEntry) {
+		if d.device.PublicKey == ac.nx.wireguardPubKey {
 			return
 		}
 		p, ok := peers[d.device.PublicKey]

--- a/internal/nexodus/ctlserver.go
+++ b/internal/nexodus/ctlserver.go
@@ -9,12 +9,12 @@ import (
 )
 
 type NexdCtl struct {
-	ax *Nexodus
+	nx *Nexodus
 }
 
 func (ac *NexdCtl) Status(_ string, result *string) error {
 	var statusStr string
-	switch ac.ax.status {
+	switch ac.nx.status {
 	case NexdStatusStarting:
 		statusStr = "Starting"
 	case NexdStatusAuth:
@@ -25,33 +25,33 @@ func (ac *NexdCtl) Status(_ string, result *string) error {
 		statusStr = "Unknown"
 	}
 	res := fmt.Sprintf("Status: %s\n", statusStr)
-	if len(ac.ax.statusMsg) > 0 {
-		res += ac.ax.statusMsg
+	if len(ac.nx.statusMsg) > 0 {
+		res += ac.nx.statusMsg
 	}
 	*result = res
 	return nil
 }
 
 func (ac *NexdCtl) Version(_ string, result *string) error {
-	*result = ac.ax.version
+	*result = ac.nx.version
 	return nil
 }
 
 func (ac *NexdCtl) GetTunnelIPv4(_ string, result *string) error {
-	*result = ac.ax.TunnelIP
+	*result = ac.nx.TunnelIP
 	return nil
 }
 
 func (ac *NexdCtl) GetTunnelIPv6(_ string, result *string) error {
-	*result = ac.ax.TunnelIpV6
+	*result = ac.nx.TunnelIpV6
 	return nil
 }
 
 func (ac *NexdCtl) ProxyList(_ string, result *string) error {
 	*result = ""
-	ac.ax.proxyLock.RLock()
-	defer ac.ax.proxyLock.RUnlock()
-	for _, proxy := range ac.ax.proxies {
+	ac.nx.proxyLock.RLock()
+	defer ac.nx.proxyLock.RUnlock()
+	for _, proxy := range ac.nx.proxies {
 		proxy.mu.RLock()
 		for _, rule := range proxy.rules {
 			*result += fmt.Sprintf("%s\n", rule.AsFlag())
@@ -69,13 +69,13 @@ func (ac *NexdCtl) proxyAdd(proxyType ProxyType, rule string, result *string) er
 	}
 	proxyRule.stored = true
 
-	proxy, err := ac.ax.UserspaceProxyAdd(proxyRule)
+	proxy, err := ac.nx.UserspaceProxyAdd(proxyRule)
 	if err != nil {
 		return err
 	}
-	proxy.Start(ac.ax.nexCtx, ac.ax.nexWg, ac.ax.userspaceNet)
+	proxy.Start(ac.nx.nexCtx, ac.nx.nexWg, ac.nx.userspaceNet)
 
-	err = ac.ax.StoreProxyRules()
+	err = ac.nx.StoreProxyRules()
 	if err != nil {
 		return err
 	}
@@ -98,11 +98,11 @@ func (ac *NexdCtl) proxyRemove(proxyType ProxyType, rule string, result *string)
 	}
 	proxyRule.stored = true
 
-	_, err = ac.ax.UserspaceProxyRemove(proxyRule)
+	_, err = ac.nx.UserspaceProxyRemove(proxyRule)
 	if err != nil {
 		return err
 	}
-	err = ac.ax.StoreProxyRules()
+	err = ac.nx.StoreProxyRules()
 	if err != nil {
 		return err
 	}
@@ -119,19 +119,19 @@ func (ac *NexdCtl) ProxyRemoveEgress(rule string, result *string) error {
 }
 
 func (ac *NexdCtl) SetDebugOn(_ string, result *string) error {
-	ac.ax.logLevel.SetLevel(zap.DebugLevel)
+	ac.nx.logLevel.SetLevel(zap.DebugLevel)
 	*result = "Debug logging enabled"
 	return nil
 }
 
 func (ac *NexdCtl) SetDebugOff(_ string, result *string) error {
-	ac.ax.logLevel.SetLevel(zap.InfoLevel)
+	ac.nx.logLevel.SetLevel(zap.InfoLevel)
 	*result = "Debug logging disabled"
 	return nil
 }
 
 func (ac *NexdCtl) GetDebug(_ string, result *string) error {
-	if ac.ax.logLevel.Level() == zap.DebugLevel {
+	if ac.nx.logLevel.Level() == zap.DebugLevel {
 		*result = "on"
 	} else {
 		*result = "off"

--- a/internal/nexodus/ctlserver_unix.go
+++ b/internal/nexodus/ctlserver_unix.go
@@ -17,26 +17,26 @@ import (
 	"github.com/nexodus-io/nexodus/internal/util"
 )
 
-func (ax *Nexodus) CtlServerStart(ctx context.Context, wg *sync.WaitGroup) error {
-	return ax.CtlServerUnixStart(ctx, wg)
+func (nx *Nexodus) CtlServerStart(ctx context.Context, wg *sync.WaitGroup) error {
+	return nx.CtlServerUnixStart(ctx, wg)
 }
 
-func (ax *Nexodus) createListener() (*net.UnixListener, error) {
+func (nx *Nexodus) createListener() (*net.UnixListener, error) {
 	socketPath := api.UnixSocketPath
-	if ax.userspaceMode {
+	if nx.userspaceMode {
 		socketPath = filepath.Base(socketPath)
 	}
 	os.Remove(socketPath)
 	l, err := net.ListenUnix("unix", &net.UnixAddr{Name: socketPath, Net: "unix"})
 	if err != nil {
-		ax.logger.Error("Error creating unix socket: ", err)
+		nx.logger.Error("Error creating unix socket: ", err)
 		return nil, err
 	}
 	return l, nil
 }
 
-func (ax *Nexodus) CtlServerUnixStart(ctx context.Context, wg *sync.WaitGroup) error {
-	l, err := ax.createListener()
+func (nx *Nexodus) CtlServerUnixStart(ctx context.Context, wg *sync.WaitGroup) error {
+	l, err := nx.createListener()
 	if err != nil {
 		return err
 	}
@@ -46,7 +46,7 @@ func (ax *Nexodus) CtlServerUnixStart(ctx context.Context, wg *sync.WaitGroup) e
 			if ctx.Err() != nil {
 				break
 			}
-			l, err = ax.createListener()
+			l, err = nx.createListener()
 			if err != nil {
 				time.Sleep(time.Second * 5)
 				continue
@@ -55,14 +55,14 @@ func (ax *Nexodus) CtlServerUnixStart(ctx context.Context, wg *sync.WaitGroup) e
 			// all of the subroutines have exited before we attempt to restart
 			// the control server.
 			ctlWg := &sync.WaitGroup{}
-			err := ax.CtlServerUnixRun(ctx, ctlWg, l)
+			err := nx.CtlServerUnixRun(ctx, ctlWg, l)
 			l.Close()
 			ctlWg.Wait()
 			if err == nil {
 				// No error means it shut down cleanly because it got a message to stop
 				break
 			}
-			ax.logger.Error("Ctl interface error, restarting: ", err)
+			nx.logger.Error("Ctl interface error, restarting: ", err)
 			time.Sleep(time.Second * 5)
 		}
 	})
@@ -70,12 +70,12 @@ func (ax *Nexodus) CtlServerUnixStart(ctx context.Context, wg *sync.WaitGroup) e
 	return nil
 }
 
-func (ax *Nexodus) CtlServerUnixRun(ctx context.Context, ctlWg *sync.WaitGroup, l *net.UnixListener) error {
+func (nx *Nexodus) CtlServerUnixRun(ctx context.Context, ctlWg *sync.WaitGroup, l *net.UnixListener) error {
 	ac := new(NexdCtl)
-	ac.ax = ax
+	ac.nx = nx
 	err := rpc.Register(ac)
 	if err != nil {
-		ax.logger.Error("Error on rpc.Register(): ", err)
+		nx.logger.Error("Error on rpc.Register(): ", err)
 		return err
 	}
 
@@ -106,10 +106,10 @@ func (ax *Nexodus) CtlServerUnixRun(ctx context.Context, ctlWg *sync.WaitGroup, 
 		case err = <-errChan:
 			// Accept() failed, collect the error and stop the CtlServer
 			stopNow = true
-			ax.logger.Error("Error on Accept(): ", err)
+			nx.logger.Error("Error on Accept(): ", err)
 			break
 		case <-ctx.Done():
-			ax.logger.Info("Stopping CtlServer")
+			nx.logger.Info("Stopping CtlServer")
 			stopNow = true
 			err = nil
 		}


### PR DESCRIPTION
resolves part of issue #1187, had to rename a struct's field aswell.