### PR TITLE
Add *.png to the path-ignore for the build action

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -61,7 +61,7 @@ pull_request_rules:
         - and:
           - check-success=markdown-lint
           # Must stay in sync with the paths in .github/workflows/docs.yml and .github/workflows/build.yml
-          - -files~=^(?!.*\.md$)(?!.*\.gitignore$)(?!\.vscode\/).*$
+          - -files~=^(?!.*\.md$)(?!.*\.png$)(?!.*\.gitignore$)(?!\.vscode\/).*$
     actions:
       merge:
         method: merge

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ on:
     branches: ["main"]
     paths-ignore:
       - '**/*.md'
+      - '**/*.png'
       - '**/*.gitignore'
       - '.vscode/**'
       - '.github/mergify.yml'
@@ -13,6 +14,7 @@ on:
     # Must stay in sync with the paths in .github/workflows/docs.yml and .github/mergify.yml
     paths-ignore:
       - '**/*.md'
+      - '**/*.png'
       - '**/*.gitignore'
       - '.vscode/**'
       - '.github/mergify.yml'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,6 +5,7 @@ on:
     branches: ["main"]
     paths:
       - '**/*.md'
+      - '**/*.png'
       - '**/*.gitignore'
       - '.vscode/**'
   pull_request:
@@ -12,6 +13,7 @@ on:
     # Must stay in sync with the paths in .github/workflows/build.yml and .github/mergify.yml
     paths:
       - '**/*.md'
+      - '**/*.png'
       - '**/*.gitignore'
       - '.vscode/**'
 


### PR DESCRIPTION
- Prevent build actions from being triggered from a png extended file