### PR TITLE
nexd: Optionally build with pprof support

### DIFF
--- a/Containerfile.nexd
+++ b/Containerfile.nexd
@@ -1,6 +1,7 @@
 FROM docker.io/library/golang:1.20-alpine as build
 
 ARG BUILD_PROFILE=dev
+ARG NEXODUS_PPROF=
 
 WORKDIR /src
 
@@ -12,11 +13,13 @@ COPY . .
 
 RUN CGO_ENABLED=0 NOISY_BUILD=y \
     NEXODUS_LDFLAGS=-extldflags=-static \
+    NEXODUS_PPROF=${NEXODUS_PPROF} \
     NEXODUS_BUILD_PROFILE=$BUILD_PROFILE \
     make dist/nexd
 
 RUN CGO_ENABLED=0 NOISY_BUILD=y \
     NEXODUS_LDFLAGS=-extldflags=-static \
+    NEXODUS_PPROF=${NEXODUS_PPROF} \
     NEXODUS_BUILD_PROFILE=$BUILD_PROFILE \
     make dist/nexctl
 

--- a/cmd/nexd/main.go
+++ b/cmd/nexd/main.go
@@ -58,6 +58,8 @@ func nexdRun(cCtx *cli.Context, logger *zap.Logger, logLevel *zap.AtomicLevel, m
 
 	ctx, _ := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGQUIT, syscall.SIGINT)
 
+	pprof_init(cCtx, logger)
+
 	userspaceMode := false
 	relayNode := false
 	var childPrefix []string

--- a/cmd/nexd/pprof_disabled.go
+++ b/cmd/nexd/pprof_disabled.go
@@ -1,0 +1,12 @@
+//go:build !pprof
+
+package main
+
+import (
+	"github.com/urfave/cli/v2"
+	"go.uber.org/zap"
+)
+
+func pprof_init(_ *cli.Context, _ *zap.Logger) {
+	// nothing to do here, pprof disabled
+}

--- a/cmd/nexd/pprof_enabled.go
+++ b/cmd/nexd/pprof_enabled.go
@@ -1,0 +1,35 @@
+//go:build pprof
+
+package main
+
+import (
+	"fmt"
+	"net/http"
+	// #nosec
+	_ "net/http/pprof"
+	"os"
+	"strconv"
+
+	"github.com/urfave/cli/v2"
+	"go.uber.org/zap"
+)
+
+func pprof_init(cCtx *cli.Context, logger *zap.Logger) {
+	port := "8080"
+	if envVar := os.Getenv("NEXD_PPROF_PORT"); envVar != "" {
+		_, err := strconv.Atoi(port)
+		if err != nil {
+			logger.Sugar().Errorf("NEXD_PPROF_PORT environment variable is invalid: %v", err.Error())
+		} else {
+			port = envVar
+		}
+	}
+
+	go func() {
+		// #nosec
+		err := http.ListenAndServe(fmt.Sprintf(":%s", port), nil)
+		if err != nil {
+			logger.Sugar().Errorf("http.ListenAndServe error: %v", err.Error())
+		}
+	}()
+}

--- a/docs/development/debugging.md
+++ b/docs/development/debugging.md
@@ -36,3 +36,27 @@ This uses Telepresence, so ignore the URLs on the screen from vite, and instead 
 To stop routing traffic from the frontend pod to your machine, run:
 
     make debug-frontend-stop
+
+## Profiling nexd
+
+To profile the performance of `nexd`, build it with `pprof` support enabled. If you run `make all`, you can use the `dist/nexd-pprof` binary. If you need to build for a specific and platform and architecture, you can set `NEXODUS_PPROF=y` and have `pprof` enabled in all binaries:
+
+```sh
+NEXODUS_PPROF=y make all
+```
+
+This also works for building the `nexd` container image.
+
+```sh
+NEXODUS_PPROF=y make image-nexd
+```
+
+Once pprof is enabled, `nexd` will expose performance data over http port `8080`. To change this port, set the `NEXD_PPROF_PORT` environment variable.
+
+To capture performance data and browse the results in a web interface, run this command:
+
+```sh
+go tool pprof -http=: http://<NEXD_HOST>:8080
+```
+
+A flame graph is available by navigating to `View > Flame Graph` in the web UI. Browse around for the other resources that are available.


### PR DESCRIPTION
Go has tooling that makes profiling pretty easy. Add some build
automation and instructions for using it with nexd.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
