### PR TITLE
apiserver: Added in retry handling for transaction for duplicate key …

### DIFF
--- a/internal/handlers/user.go
+++ b/internal/handlers/user.go
@@ -5,10 +5,12 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"github.com/nexodus-io/nexodus/internal/models"
+	"github.com/nexodus-io/nexodus/internal/util"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 	"gorm.io/gorm"
@@ -53,25 +55,45 @@ func (api *API) createUserIfNotExists(ctx context.Context, id string, userName s
 	var uuid uuid.UUID
 
 	err := api.transaction(ctx, func(tx *gorm.DB) error {
-		// First lets check if the user has ever existed in the database
-		res := tx.Unscoped().First(&user, "id = ?", id)
+		// Retry the operation if we get a duplicate key error which can occur on concurrent requests when creating a user
+		return util.RetryOperationForErrors(ctx, time.Millisecond*10, 1, []error{gorm.ErrDuplicatedKey}, func() error {
+			// First lets check if the user has ever existed in the database
+			res := tx.Unscoped().First(&user, "id = ?", id)
 
-		// If the user exists, then lets restore their status in the database
-		if res.Error == nil {
-			if user.DeletedAt.Valid {
-				user.DeletedAt = gorm.DeletedAt{}
-				if res := tx.Unscoped().Model(&user).Update("DeletedAt", user.DeletedAt); res.Error != nil {
-					return res.Error
+			// If the user exists, then lets restore their status in the database
+			if res.Error == nil {
+				if user.DeletedAt.Valid {
+					user.DeletedAt = gorm.DeletedAt{}
+					if res := tx.Unscoped().Model(&user).Update("DeletedAt", user.DeletedAt); res.Error != nil {
+						return res.Error
+					}
 				}
+
+				// Check if the UserName has changed since the last time we saw this user
+				if user.UserName != userName {
+					if res := tx.Model(&user).Update("UserName", userName); res.Error != nil {
+						return res.Error
+					}
+				}
+
+				var err error
+				uuid, err = api.createUserOrgIfNotExists(ctx, tx, id, userName)
+				if err != nil {
+					return err
+				}
+
+				return nil
 			}
 
-			// Check if the UserName has changed since the last time we saw this user
-			if user.UserName != userName {
-				if res := tx.Model(&user).Update("UserName", userName); res.Error != nil {
-					return res.Error
-				}
+			if !errors.Is(res.Error, gorm.ErrRecordNotFound) {
+				return fmt.Errorf("can't find record for user id %s: %w", id, res.Error)
 			}
 
+			user.ID = id
+			user.UserName = userName
+			if res = tx.Create(&user); res.Error != nil {
+				return res.Error
+			}
 			var err error
 			uuid, err = api.createUserOrgIfNotExists(ctx, tx, id, userName)
 			if err != nil {
@@ -79,24 +101,7 @@ func (api *API) createUserIfNotExists(ctx context.Context, id string, userName s
 			}
 
 			return nil
-		}
-
-		if !errors.Is(res.Error, gorm.ErrRecordNotFound) {
-			return fmt.Errorf("can't find record for user id %s: %w", id, res.Error)
-		}
-
-		user.ID = id
-		user.UserName = userName
-		if res = tx.Create(&user); res.Error != nil {
-			return res.Error
-		}
-		var err error
-		uuid, err = api.createUserOrgIfNotExists(ctx, tx, id, userName)
-		if err != nil {
-			return err
-		}
-
-		return nil
+		})
 	})
 
 	if err != nil {

--- a/internal/util/retry_operation.go
+++ b/internal/util/retry_operation.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
@@ -15,6 +16,30 @@ func RetryOperation(ctx context.Context, wait time.Duration, retries int, operat
 	)
 	bo = backoff.WithContext(bo, ctx)
 	err := backoff.Retry(operation, bo)
+
+	return err
+}
+
+// RetryOperationForErrors retries the operation with a backoff policy for the specified errors, otherwise will just return the error.
+func RetryOperationForErrors(ctx context.Context, wait time.Duration, retries int, retriableErrors []error, operation func() error) error {
+	bo := backoff.WithMaxRetries(
+		backoff.NewConstantBackOff(wait),
+		uint64(retries),
+	)
+	bo = backoff.WithContext(bo, ctx)
+
+	err := backoff.Retry(func() error {
+		err := operation()
+		for _, retriableError := range retriableErrors {
+			if errors.Is(err, retriableError) {
+				return err
+			}
+		}
+		if err != nil {
+			return backoff.Permanent(err)
+		}
+		return nil
+	}, bo)
 
 	return err
 }

--- a/internal/util/retry_operation_test.go
+++ b/internal/util/retry_operation_test.go
@@ -87,3 +87,92 @@ func TestRetryOperation(t *testing.T) {
 		})
 	}
 }
+
+func TestRetryOperationForErrors(t *testing.T) {
+	temporaryErr := errors.New("temporary error")
+	nonRetriableError := errors.New("non-retriable error")
+	tests := []struct {
+		name           string
+		wait           time.Duration
+		retries        int
+		operation      func() error
+		expectedResult error
+	}{
+		{
+			name:    "Success on first attempt",
+			wait:    10 * time.Millisecond,
+			retries: 3,
+			operation: func() error {
+				return nil
+			},
+			expectedResult: nil,
+		},
+		{
+			name:    "Success after retries",
+			wait:    10 * time.Millisecond,
+			retries: 3,
+			operation: func() error {
+				return temporaryErr
+			},
+			expectedResult: nil,
+		},
+		{
+			name:    "Non-retriable error",
+			wait:    10 * time.Millisecond,
+			retries: 3,
+			operation: func() error {
+				return nonRetriableError
+			},
+			expectedResult: nonRetriableError,
+		},
+		{
+			name:    "Context canceled",
+			wait:    50 * time.Millisecond,
+			retries: 3,
+			operation: func() error {
+				return temporaryErr
+			},
+			expectedResult: context.Canceled,
+		},
+	}
+
+	callCount := 0
+	for _, tt := range tests {
+		callCount = 0 // Reset the callCount before each test
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+			defer cancel()
+
+			if tt.name == "Context canceled" {
+				go func() {
+					time.Sleep(25 * time.Millisecond)
+					cancel()
+				}()
+			}
+
+			// Update the "Success after retries" test case to use the callCount variable
+			if tt.name == "Success after retries" {
+				tt.operation = func() error {
+					if callCount < 2 { // Assuming it will succeed after 2 retries (total 3 attempts)
+						callCount++
+						return temporaryErr
+					}
+					return nil
+				}
+			}
+
+			err := RetryOperationForErrors(ctx, tt.wait, tt.retries, []error{temporaryErr}, tt.operation)
+			if tt.expectedResult == nil {
+				assert.Nil(t, err)
+			} else if errors.Is(err, nonRetriableError) {
+				// We should expect the error to be returned as-is and the call count to not have increased
+				assert.Equal(t, tt.expectedResult, err)
+				assert.Equal(t, 0, callCount)
+			} else if errors.Is(err, context.Canceled) {
+				assert.Equal(t, tt.expectedResult, err)
+			} else {
+				assert.True(t, isMaxRetriesReachedErr(err))
+			}
+		})
+	}
+}


### PR DESCRIPTION
Added in retriable error handling for the create user/org transaction. This is to support error case when concurrent creation requests are done.

Closes https://github.com/nexodus-io/nexodus/issues/1216