### PR TITLE
Remove legacy organization-hub from nexctl

### DIFF
--- a/cmd/nexctl/main.go
+++ b/cmd/nexctl/main.go
@@ -112,10 +112,6 @@ func main() {
 								Name:     "cidr-v6",
 								Required: false,
 							},
-							&cli.BoolFlag{
-								Name:  "hub-organization",
-								Value: false,
-							},
 						},
 						Action: func(cCtx *cli.Context) error {
 							encodeOut := cCtx.String("output")
@@ -123,8 +119,7 @@ func main() {
 							organizationDescrip := cCtx.String("description")
 							organizationCIDR := cCtx.String("cidr")
 							organizationCIDRv6 := cCtx.String("cidr-v6")
-							organizationHub := cCtx.Bool("hub-organization")
-							return createOrganization(mustCreateAPIClient(cCtx), encodeOut, organizationName, organizationDescrip, organizationCIDR, organizationCIDRv6, organizationHub)
+							return createOrganization(mustCreateAPIClient(cCtx), encodeOut, organizationName, organizationDescrip, organizationCIDR, organizationCIDRv6)
 						},
 					},
 					{

--- a/cmd/nexctl/organization.go
+++ b/cmd/nexctl/organization.go
@@ -40,13 +40,13 @@ func listOrganizations(c *client.APIClient, encodeOut string) error {
 	return nil
 }
 
-func createOrganization(c *client.APIClient, encodeOut, name, description, cidr string, cidrV6 string, hub bool) error {
+func createOrganization(c *client.APIClient, encodeOut, name, description, cidr string, cidrV6 string) error {
 	res, _, err := c.OrganizationsApi.CreateOrganization(context.Background()).Organization(public.ModelsAddOrganization{
 		Name:        name,
 		Description: description,
 		Cidr:        cidr,
 		CidrV6:      cidrV6,
-		HubZone:     hub,
+		HubZone:     false,
 		PrivateCidr: !(cidr == "" && cidrV6 == ""),
 	}).Execute()
 	if err != nil {


### PR DESCRIPTION
- This was the legacy discovery node option that needs removal
- The database migration to remove it from the org models removal will be a separate PR.