### PR TITLE
nexctl: use `--service-url` instead of `--host`.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,7 +78,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 19
       - run: npm ci
         working-directory: ui
       - run: npx prettier --check .

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,15 +76,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 19
-      - run: npm ci
-        working-directory: ui
-      - run: npx prettier --check .
-        working-directory: ui
-      - run: npm run build
-        working-directory: ui
+      - name: UI Lint
+        run: make ui-lint ui
 
   k8s-lint:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ dist/nexd-pprof: $(NEXD_DEPS) | dist
 dist/nexctl: $(NEXCTL_DEPS) | dist
 	$(ECHO_PREFIX) printf "  %-12s $@\n" "[GO BUILD]"
 	$(CMD_PREFIX) CGO_ENABLED=0 go build $(NEXODUS_BUILD_FLAGS) -gcflags="$(NEXODUS_GCFLAGS)" \
-		-ldflags="$(subst https://,https://api.,$(NEXODUS_LDFLAGS))" -o $@ ./cmd/nexctl
+		-ldflags="$(NEXODUS_LDFLAGS)" -o $@ ./cmd/nexctl
 
 dist/nexd-%: $(NEXD_DEPS) | dist
 	$(ECHO_PREFIX) printf "  %-12s $@\n" "[GO BUILD]"
@@ -109,7 +109,7 @@ dist/nexctl-%: $(NEXCTL_DEPS) | dist
 	$(ECHO_PREFIX) printf "  %-12s $@\n" "[GO BUILD]"
 	$(CMD_PREFIX) CGO_ENABLED=0 GOOS=$(word 2,$(subst -, ,$(basename $@))) GOARCH=$(word 3,$(subst -, ,$(basename $@))) \
 		go build $(NEXODUS_BUILD_FLAGS) -gcflags="$(NEXODUS_GCFLAGS)" \
-		-ldflags="$(subst https://,https://api.,$(NEXODUS_LDFLAGS))" -o $@ ./cmd/nexctl
+		-ldflags="$(NEXODUS_LDFLAGS)" -o $@ ./cmd/nexctl
 
 dist/packages: \
 	dist/packages/nexodus-linux-amd64.tar.gz \

--- a/docs/deployment/nexodus-service.md
+++ b/docs/deployment/nexodus-service.md
@@ -75,7 +75,7 @@ Alternatively, or build the nexctl binary and running a command with it.
 
 ```console
 make dist/nexctl-linux-amd64
-dist/nexctl-linux-amd64 --host https://api.try.nexodus.127.0.0.1.nip.io --username admin --password floofykittens -output json device list
+dist/nexctl-linux-amd64 --service-url https://try.nexodus.127.0.0.1.nip.io --username admin --password floofykittens -output json device list
 ```
 
 For windows, we recommend installing the root certificate via the [MMC snap-in](https://learn.microsoft.com/en-us/troubleshoot/windows-server/windows-security/install-imported-certificates#import-the-certificate-into-the-local-computer-store).

--- a/docs/user-guide/discovery-and-relay.md
+++ b/docs/user-guide/discovery-and-relay.md
@@ -15,7 +15,7 @@ sudo nexd --service-url https://try.nexodus.127.0.0.1.nip.io --stun relay
 You can list the available organizations using the following command
 
 ```sh
-nexctl --host https://api.try.nexodus.127.0.0.1.nip.io --username kitteh1 --password floofykittens organization list
+nexctl --service-url https://try.nexodus.127.0.0.1.nip.io --username kitteh1 --password floofykittens organization list
 Organization ID                          NAME      IPV4 CIDR          IPV6 CIDR     DESCRIPTION
 faa76939-3226-4d09-b695-e981585ab156     kitteh1   100.64.0.0/10     200::/64      kitteh1's organization
 ```

--- a/docs/user-guide/nexctl.md
+++ b/docs/user-guide/nexctl.md
@@ -28,239 +28,149 @@ make dist/nexctl
 ### Usage
 
 ```text
-nexctl(09 June 2023)                                                                                                                           nexctl(09 June 2023)
-
 NAME:
-       nexctl - A new cli application
+   nexctl - controls the Nexodus control and data planes
 
 USAGE:
-       nexctl [global options] command [command options] [arguments...]
+   nexctl [global options] command [command options] [arguments...]
 
 COMMANDS:
-       device Commands relating to devices
-
-       invitation
-              commands relating to invitations
-
-       nexd   Commands for interacting with the local instance of nexd
-
-       organization
-              Commands relating to organizations
-
-       security-group
-              commands relating to security groups
-
-       user   Commands relating to users
-
-       version
-              Get the version of nexctl
-
-       help, h
-              Shows a list of commands or help for one command
+   device          Commands relating to devices
+   invitation      commands relating to invitations
+   nexd            Commands for interacting with the local instance of nexd
+   organization    Commands relating to organizations
+   security-group  commands relating to security groups
+   user            Commands relating to users
+   version         Get the version of nexctl
+   help, h         Shows a list of commands or help for one command
 
 GLOBAL OPTIONS:
-       --debug
-              Enable debug logging (default: false) [$NEXCTL_DEBUG]
-
-       --host value
-              Api server URL (default: "https://api.try.nexodus.127.0.0.1.nip.io")
-
-       --username value
-              Username
-
-       --password value
-              Password
-
-       --output value
-              Output format: json, json-raw, no-header, column (default columns) (default: "column")
-
-       --insecure-skip-tls-verify
-              If true, server certificates will not be checked for validity. This will make your HTTPS connections insecure (default: false)
-
-       --help, -h
-              Show help
-
-                                                                                                                                               nexctl(09 June 2023)
+   --debug                     Enable debug logging (default: false) [$NEXCTL_DEBUG]
+   --service-url value         Api server URL (default: "https://try.nexodus.127.0.0.1.nip.io")
+   --username value            Username
+   --password value            Password
+   --output value              Output format: json, json-raw, no-header, column (default columns) (default: "column")
+   --insecure-skip-tls-verify  If true, server certificates will not be checked for validity. This will make your HTTPS connections insecure (default: false)
+   --help, -h                  Show help
 ```
 
 #### nexctl device
 
 ```text
-nexctl-device(09 June 2023)                                                                                                             nexctl-device(09 June 2023)
-
 NAME:
-       nexctl device - Commands relating to devices
+   nexctl device - Commands relating to devices
 
 USAGE:
-       nexctl device command [command options] [arguments...]
+   nexctl device command [command options] [arguments...]
 
 COMMANDS:
-       list   List all devices
-
-       delete Delete a device
-
-       help, h
-              Shows a list of commands or help for one command
+   list      List all devices
+   delete    Delete a device
+   metadata  Commands relating to device metadata
+   help, h   Shows a list of commands or help for one command
 
 OPTIONS:
-       --help, -h
-              Show help
-
-                                                                                                                                        nexctl-device(09 June 2023)
+   --help, -h  Show help
 ```
 
 #### nexctl invitation
 
 ```text
-nexctl-invitation(09 June 2023)                                                                                                     nexctl-invitation(09 June 2023)
-
 NAME:
-       nexctl invitation - commands relating to invitations
+   nexctl invitation - commands relating to invitations
 
 USAGE:
-       nexctl invitation command [command options] [arguments...]
+   nexctl invitation command [command options] [arguments...]
 
 COMMANDS:
-       create create an invitation
-
-       delete delete an invitation
-
-       accept accept an invitation
-
-       help, h
-              Shows a list of commands or help for one command
+   create   create an invitation
+   delete   delete an invitation
+   accept   accept an invitation
+   help, h  Shows a list of commands or help for one command
 
 OPTIONS:
-       --help, -h
-              Show help
-
-                                                                                                                                    nexctl-invitation(09 June 2023)
+   --help, -h  Show help
 ```
 
 #### nexctl nexd
 
 ```text
-nexctl-nexd(09 June 2023)                                                                                                                 nexctl-nexd(09 June 2023)
-
 NAME:
-       nexctl nexd - Commands for interacting with the local instance of nexd
+   nexctl nexd - Commands for interacting with the local instance of nexd
 
 USAGE:
-       nexctl nexd command [command options] [arguments...]
+   nexctl nexd command [command options] [arguments...]
 
 COMMANDS:
-       version
-              Display the nexd version
-
-       status Display the nexd status
-
-       get    Get a value from the local nexd instance
-
-       set    Set a value on the local nexd instance
-
-       proxy  Commands for interacting nexd's proxy configuration
-
-       peers  Commands for interacting nexd exit node configuration
-
-       help, h
-              Shows a list of commands or help for one command
+   version  Display the nexd version
+   status   Display the nexd status
+   get      Get a value from the local nexd instance
+   set      Set a value on the local nexd instance
+   proxy    Commands for interacting nexd's proxy configuration
+   peers    Commands for interacting with nexd peer connectivity
+   help, h  Shows a list of commands or help for one command
 
 OPTIONS:
-       --unix-socket value
-              Path to the unix socket nexd is listening against (default: "/run/nexd.sock")
-
-       --help, -h
-              Show help
-
-                                                                                                                                          nexctl-nexd(09 June 2023)
+   --unix-socket value  Path to the unix socket nexd is listening against (default: "/var/run/nexd.sock")
+   --help, -h           Show help
 ```
 
 #### nexctl organization
 
 ```text
-nexctl-organization(09 June 2023)                                                                                                 nexctl-organization(09 June 2023)
-
 NAME:
-       nexctl organization - Commands relating to organizations
+   nexctl organization - Commands relating to organizations
 
 USAGE:
-       nexctl organization command [command options] [arguments...]
+   nexctl organization command [command options] [arguments...]
 
 COMMANDS:
-       list   List organizations
-
-       create Create a organizations
-
-       delete Delete a organization
-
-       help, h
-              Shows a list of commands or help for one command
+   list      List organizations
+   create    Create a organizations
+   delete    Delete a organization
+   metadata  Commands relating to device metadata across the organization
+   help, h   Shows a list of commands or help for one command
 
 OPTIONS:
-       --help, -h
-              Show help
-
-                                                                                                                                  nexctl-organization(09 June 2023)
+   --help, -h  Show help
 ```
 
 #### nexctl user
 
 ```text
-nexctl-user(09 June 2023)                                                                                                                 nexctl-user(09 June 2023)
-
 NAME:
-       nexctl user - Commands relating to users
+   nexctl user - Commands relating to users
 
 USAGE:
-       nexctl user command [command options] [arguments...]
+   nexctl user command [command options] [arguments...]
 
 COMMANDS:
-       list   List all users
-
-       get-current
-              Get current user
-
-       delete Delete a user
-
-       remove-user
-              Remove a user from an organization
-
-       help, h
-              Shows a list of commands or help for one command
+   list         List all users
+   get-current  Get current user
+   delete       Delete a user
+   remove-user  Remove a user from an organization
+   help, h      Shows a list of commands or help for one command
 
 OPTIONS:
-       --help, -h
-              Show help
-
-                                                                                                                                          nexctl-user(09 June 2023)
+   --help, -h  Show help
 ```
 
 #### nexctl security-group
 
 ```text
-nexctl-security-group(09 June 2023)                                                                                             nexctl-security-group(09 June 2023)
-
 NAME:
-       nexctl security-group - commands relating to security groups
+   nexctl security-group - commands relating to security groups
 
 USAGE:
-       nexctl security-group command [command options] [arguments...]
+   nexctl security-group command [command options] [arguments...]
 
 COMMANDS:
-       list   List all security groups
-
-       delete Delete a security group
-
-       create create a security group
-
-       update update a security group
-
-       help, h
-              Shows a list of commands or help for one command
+   list     List all security groups
+   delete   Delete a security group
+   create   create a security group
+   update   update a security group
+   help, h  Shows a list of commands or help for one command
 
 OPTIONS:
-       --help, -h
-              Show help
-
-                                                                                                                                nexctl-security-group(09 June 2023)
+   --help, -h  Show help
 ```

--- a/docs/user-guide/security-groups.md
+++ b/docs/user-guide/security-groups.md
@@ -14,7 +14,7 @@ Currently, only one security group per organization is supported. Support for mu
 The default security group rules are empty, as can be seen in the default security group listing of an organization.
 
 ```shell
-nexctl --host https://api.try.nexodus.127.0.0.1.nip.io --username admin --password floofykittens security-group list --organization-id="${ORGANIZATION_ID}"
+nexctl --service-url https://try.nexodus.127.0.0.1.nip.io --username admin --password floofykittens security-group list --organization-id="${ORGANIZATION_ID}"
 SECURITY GROUP ID                        SECURITY GROUP NAME     SECURITY GROUP DESCRIPTION              ORGANIZATION ID                          SECURITY GROUP RULES INBOUND     SECURITY GROUP RULES INBOUND
 cb2e0192-5eb9-41ee-a732-7484602ac883     default                 default organization security group     7e552731-2f5f-421d-9266-10fa46dfe3ee     []                               []
 ```
@@ -30,7 +30,7 @@ In the provided commands, you'll notice variables `ORGANIZATION_ID` and `SECURIT
 You can obtain the IDs from the output of listing organizations.
 
 ```shell
-nexctl --host https://api.try.nexodus.127.0.0.1.nip.io --username admin --password floofykittens organization list
+nexctl --service-url https://try.nexodus.127.0.0.1.nip.io --username admin --password floofykittens organization list
 Organization ID                          NAME      IPV4 CIDR          IPV6 CIDR     DESCRIPTION              SECURITY GROUP ID
 cd0fa8be-1c6a-4319-884a-e0377d915774     admin     100.100.0.0/16     200::/64      admin's organization     151acab0-6dde-4870-bacf-2f7134dc5085
 ```
@@ -44,7 +44,7 @@ Here are some examples of operations you can perform with security groups.
 This command will list all security groups for the specified organization.
 
 ```shell
-nexctl --host https://api.try.nexodus.127.0.0.1.nip.io \
+nexctl --service-url https://try.nexodus.127.0.0.1.nip.io \
     --username admin \
     --password floofykittens \
     security-group list --organization-id=${ORGANIZATION_ID}
@@ -60,13 +60,13 @@ SECURITY_GROUP_ID="<UUID_GOES_HERE>"
 Now you can list the security groups for an organization.
 
 ```bash
-nexctl --host https://api.try.nexodus.127.0.0.1.nip.io --username admin --password floofykittens security-group list --organization-id=${ORGANIZATION_ID} 
+nexctl --service-url https://try.nexodus.127.0.0.1.nip.io --username admin --password floofykittens security-group list --organization-id=${ORGANIZATION_ID} 
 ```
 
 ### Creating a Security Group
 
 ```shell
-nexctl --host https://api.try.nexodus.127.0.0.1.nip.io --username admin --password floofykittens security-group create \
+nexctl --service-url https://try.nexodus.127.0.0.1.nip.io --username admin --password floofykittens security-group create \
     --name test-group --description "test group example" \
     --inbound-rules='[{"ip_protocol": "icmp"}]' \
     --outbound-rules='' \
@@ -77,7 +77,7 @@ nexctl --host https://api.try.nexodus.127.0.0.1.nip.io --username admin --passwo
 
 ```bash
 nexctl \
-    --host https://api.try.nexodus.127.0.0.1.nip.io --username admin --password floofykittens security-group update \
+    --service-url https://try.nexodus.127.0.0.1.nip.io --username admin --password floofykittens security-group update \
     --name="default" --description="security group testing" \
     --inbound-rules='[{"ip_protocol": "icmp"}, {"ip_protocol": "icmpv6"}, {"ip_protocol": "tcp"},{"ip_protocol": "udp"}]' \
     --outbound-rules='[{"ip_protocol": "icmp"}, {"ip_protocol": "icmpv6"}, {"ip_protocol": "tcp"},{"ip_protocol": "udp"}]' \
@@ -91,7 +91,7 @@ Note: if you do not specify an L3 IP destination prefix, both IPv4 and IPv6 will
 
 ```bash
 nexctl \
-    --host https://api.try.nexodus.127.0.0.1.nip.io --username admin --password floofykittens security-group update \
+    --service-url https://try.nexodus.127.0.0.1.nip.io --username admin --password floofykittens security-group update \
     --name="default" --description="security group testing" \
     --inbound-rules='[{"ip_protocol": "tcp", "from_port": 22, "to_port": 22}]' \
     --outbound-rules='[{"ip_protocol": "tcp"}]' \
@@ -103,7 +103,7 @@ If you specify an address family specific destination IP prefix, the rule will o
 
 ```bash
 nexctl \
-    --host https://api.try.nexodus.127.0.0.1.nip.io --username admin --password floofykittens security-group update \
+    --service-url https://try.nexodus.127.0.0.1.nip.io --username admin --password floofykittens security-group update \
     --name="default" --description="security group testing" \
     --inbound-rules='[{"ip_protocol": "tcp", "from_port": 22, "to_port": 22, "ip_ranges": ["200::/64"]}]' \
     --outbound-rules='[{"ip_protocol": "tcp"}]' \
@@ -115,7 +115,7 @@ You can also specify a range of address seperated by a `-` instead of a cidr pre
 
 ```bash
 nexctl \
-    --host https://api.try.nexodus.127.0.0.1.nip.io --username admin --password floofykittens security-group update \
+    --service-url https://try.nexodus.127.0.0.1.nip.io --username admin --password floofykittens security-group update \
     --name="default" --description="security group testing" \
     --inbound-rules='[{"ip_protocol": "tcp", "from_port": 22, "to_port": 22, "ip_ranges": ["100.100.0.1-100.100.0.50"]}]' \
     --outbound-rules='[{"ip_protocol": "tcp"}]' \
@@ -127,7 +127,7 @@ nexctl \
 
 ```bash
 nexctl \
-    --host https://api.try.nexodus.127.0.0.1.nip.io --username admin --password floofykittens security-group update \
+    --service-url https://try.nexodus.127.0.0.1.nip.io --username admin --password floofykittens security-group update \
     --name="default" --description="security group testing" \
     --inbound-rules='[{"ip_protocol": "icmp"}]' \
     --outbound-rules='' \
@@ -143,7 +143,7 @@ Here are a few examples:
 
 ```shell
 nexctl \
-    --host https://api.try.nexodus.127.0.0.1.nip.io --username admin --password floofykittens security-group update \
+    --service-url https://try.nexodus.127.0.0.1.nip.io --username admin --password floofykittens security-group update \
     --name="default" --description="security group testing" \
     --inbound-rules='[{"ip_protocol": "icmp"}, {"ip_protocol": "icmpv6"}, {"ip_protocol": "tcp"},{"ip_protocol": "udp"}]' \
     --outbound-rules='[{"ip_protocol": "icmp"}, {"ip_protocol": "icmpv6"}, {"ip_protocol": "tcp"},{"ip_protocol": "udp"}]' \
@@ -155,7 +155,7 @@ nexctl \
 
 ```shell
 nexctl \
-    --host https://api.try.nexodus.127.0.0.1.nip.io --username admin --password floofykittens security-group update \
+    --service-url https://try.nexodus.127.0.0.1.nip.io --username admin --password floofykittens security-group update \
     --name="default" --description="security group testing" \
     --inbound-rules='' \
     --outbound-rules='' \
@@ -167,7 +167,7 @@ nexctl \
 
 ```shell
 nexctl \
-    --host https://api.try.nexodus.127.0.0.1.nip.io --username admin --password floofykittens security-group update \
+    --service-url https://try.nexodus.127.0.0.1.nip.io --username admin --password floofykittens security-group update \
     --name="default" --description="security group testing" \
     --security-group-id="${SECURITY_GROUP_ID}" \
    --organization-id="${ORGANIZATION_ID}"
@@ -177,7 +177,7 @@ nexctl \
 
 ```bash
 nexctl \
-    --host https://api.try.nexodus.127.0.0.1.nip.io --username admin --password floofykittens security-group update \
+    --service-url https://try.nexodus.127.0.0.1.nip.io --username admin --password floofykittens security-group update \
     --name="default" --description="security group testing" \
     --inbound-rules='[{"ip_protocol": "udp", "from_port": 8080, "to_port": 9000}]' \
     --outbound-rules='[{"ip_protocol": "udp"}]' \
@@ -189,7 +189,7 @@ This is the same rule as above, but only allowing the traffic inbound from the I
 
 ```bash
 nexctl \
-    --host https://api.try.nexodus.127.0.0.1.nip.io --username admin --password floofykittens security-group update \
+    --service-url https://try.nexodus.127.0.0.1.nip.io --username admin --password floofykittens security-group update \
     --name="default" --description="security group testing" \
     --inbound-rules='[{"ip_protocol": "udp", "from_port": 8080, "to_port": 9000, "ip_ranges": ["100.100.0.50"]}]' \
     --outbound-rules='[{"ip_protocol": "udp"}]' \
@@ -201,7 +201,7 @@ nexctl \
 
 ```shell
 nexctl \
-    --host https://api.try.nexodus.127.0.0.1.nip.io --username admin --password floofykittens security-group update \
+    --service-url https://try.nexodus.127.0.0.1.nip.io --username admin --password floofykittens security-group update \
     --name="default" --description="security group testing" \
     --inbound-rules='[
         {"ip_protocol": "udp","ip_ranges": ["10.130.0.1-10.130.0.5"],"from_port": 80,"to_port": 90}, 
@@ -237,7 +237,7 @@ nexctl \
 
 ```bash
 nexctl \
-    --host https://api.try.nexodus.127.0.0.1.nip.io --username admin --password floofykittens \
+    --service-url https://try.nexodus.127.0.0.1.nip.io --username admin --password floofykittens \
     security-group delete \
     --security-group-id="${SECURITY_GROUP_ID}" \
     --organization-id="${ORGANIZATION_ID}"

--- a/hack/nexctl-docs.sh
+++ b/hack/nexctl-docs.sh
@@ -10,13 +10,13 @@ printf "### Usage\n\n" >> docs/user-guide/nexctl.md.tmp
 # generate the usage output
 make dist/nexctl
 echo '```text' >> docs/user-guide/nexctl.md.tmp
-dist/nexctl -h | docker run -i --rm --name txt2man quay.io/nexodus/mock:latest txt2man -t nexctl | man -l - | cat >> docs/user-guide/nexctl.md.tmp
+dist/nexctl -h >> docs/user-guide/nexctl.md.tmp
 echo '```' >> docs/user-guide/nexctl.md.tmp
 
 for subcmd in device invitation nexd organization user security-group; do
     printf "\n#### nexctl $subcmd\n\n" >> docs/user-guide/nexctl.md.tmp
     echo '```text' >> docs/user-guide/nexctl.md.tmp
-    dist/nexctl ${subcmd} -h | docker run -i --rm --name txt2man quay.io/nexodus/mock:latest txt2man -t nexctl-${subcmd} | man -l - | cat >> docs/user-guide/nexctl.md.tmp
+    dist/nexctl ${subcmd} -h >> docs/user-guide/nexctl.md.tmp
     echo '```' >> docs/user-guide/nexctl.md.tmp
 done
 

--- a/internal/nexodus/nexodus_darwin.go
+++ b/internal/nexodus/nexodus_darwin.go
@@ -103,5 +103,5 @@ func deleteDarwinIface(logger *zap.SugaredLogger, dev string) {
 }
 
 func (ax *Nexodus) findLocalIP() (string, error) {
-	return discoverGenericIPv4(ax.logger, ax.controllerURL.Host, "443")
+	return discoverGenericIPv4(ax.logger, ax.apiURL.Host, "443")
 }

--- a/internal/nexodus/nexodus_windows.go
+++ b/internal/nexodus/nexodus_windows.go
@@ -61,7 +61,7 @@ func (ax *Nexodus) removeExistingInterface() {
 }
 
 func (ax *Nexodus) findLocalIP() (string, error) {
-	return discoverGenericIPv4(ax.logger, ax.controllerURL.Host, "443")
+	return discoverGenericIPv4(ax.logger, ax.apiURL.Host, "443")
 }
 
 func buildWindowsWireguardIfaceConf(pvtKey, wgAddress, wgListenPort string) error {

--- a/ui/index.html
+++ b/ui/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -36,13 +36,13 @@ const authProvider = goOidcAgentAuthProvider(backend);
 const baseDataProvider = simpleRestProvider(
   `${backend}/api`,
   fetchJson,
-  "X-Total-Count"
+  "X-Total-Count",
 );
 const dataProvider = {
   ...baseDataProvider,
   getFlag: (name: string) => {
     return fetchJson(new URL(`${backend}/api/fflags/${name}`)).then(
-      (response) => response
+      (response) => response,
     );
   },
 };

--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -4,7 +4,7 @@ import App from "./App";
 import reportWebVitals from "./reportWebVitals";
 
 const root = ReactDOM.createRoot(
-  document.getElementById("root") as HTMLElement
+  document.getElementById("root") as HTMLElement,
 );
 root.render(<App />);
 

--- a/ui/src/layout/AppBar.tsx
+++ b/ui/src/layout/AppBar.tsx
@@ -21,7 +21,7 @@ const darkTheme = createTheme({
 
 const CustomAppBar = (props: JSX.IntrinsicAttributes & AppBarProps) => {
   const isLargeEnough = useMediaQuery<Theme>((theme) =>
-    theme.breakpoints.up("sm")
+    theme.breakpoints.up("sm"),
   );
   return (
     <AppBar

--- a/ui/src/providers/AuthProvider.tsx
+++ b/ui/src/providers/AuthProvider.tsx
@@ -5,7 +5,7 @@ const cleanup = () => {
   window.history.replaceState(
     {},
     window.document.title,
-    window.location.origin
+    window.location.origin,
   );
 };
 


### PR DESCRIPTION
- also set better usage description for the command.
- udpates docs usage.
- `—host` is still supported but deprecated.
- rename controllerUrl field to apiURL.

fixes: #1231