### PR TITLE
ci: Don't run make ui

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,7 +77,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: UI Lint
-        run: make ui-lint ui
+        run: make ui-lint
 
   k8s-lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
There is no `ui` target. This works because the `ui` directory exists,
but it's not doing anything useful.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
