### PR TITLE
ci: Add png-lint to validate excalidraw exports

### DIFF
--- a/.excalidraw-ignore
+++ b/.excalidraw-ignore
@@ -1,0 +1,11 @@
+pkg/oidcagent/docs/go-oidc-agent-deployment.png
+docs/assets/logo-square.png
+docs/assets/logo.png
+docs/assets/logo_dark.png
+docs/assets/wordmark.png
+docs/assets/wordmark_dark.png
+docs/development/design/nexodus-architecture.png
+docs/development/env-file-screenshot.png
+ui/src/logo.png
+ui/src/wordmark.png
+ui/src/wordmark_dark.png

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -48,20 +48,20 @@ pull_request_rules:
           - check-success=actionlint
         - -files~=.github/.*$
       - or:
-        # PRs that include doc changes should also pass the markdown-lint check
+        # PRs that include doc changes should also pass the docs workflow
         - and:
           - check-success=build-workflow-complete
           - files~=\.md$
-          - check-success=markdown-lint
+          - check-success=docs-workflow-complete
         # PRs that do not include doc changes only need to pass the build workflow
         - and:
           - check-success=build-workflow-complete
           - -files~=\.md$
-        # PRs that do not run the build workflow (e.g. docs-only changes) must have a successful markdown-lint check
+        # PRs that do not run the build workflow (e.g. docs-only changes) must have a successful docs workflow
         - and:
-          - check-success=markdown-lint
+          - check-success=docs-workflow-complete
           # Must stay in sync with the paths in .github/workflows/docs.yml and .github/workflows/build.yml
-          - -files~=^(?!.*\.md$)(?!.*\.png$)(?!.*\.gitignore$)(?!\.vscode\/).*$
+          - -files~=^(?!.*\.md$)(?!.*\.png$)(?!.*\.gitignore$)(?!\.vscode\/)(?!\.excalidraw-ignore$).*$
     actions:
       merge:
         method: merge

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,7 @@ on:
       - '**/*.gitignore'
       - '.vscode/**'
       - '.github/mergify.yml'
+      - '.excalidraw-ignore'
   pull_request:
     branches: ["main"]
     # Must stay in sync with the paths in .github/workflows/docs.yml and .github/mergify.yml
@@ -18,6 +19,7 @@ on:
       - '**/*.gitignore'
       - '.vscode/**'
       - '.github/mergify.yml'
+      - '.excalidraw-ignore'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,6 +8,7 @@ on:
       - '**/*.png'
       - '**/*.gitignore'
       - '.vscode/**'
+      - '.excalidraw-ignore'
   pull_request:
     branches: ["main"]
     # Must stay in sync with the paths in .github/workflows/build.yml and .github/mergify.yml
@@ -16,6 +17,7 @@ on:
       - '**/*.png'
       - '**/*.gitignore'
       - '.vscode/**'
+      - '.excalidraw-ignore'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -30,3 +32,17 @@ jobs:
         uses: DavidAnson/markdownlint-cli2-action@v11
         with:
           globs: '**/*.md'
+
+  png-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: PNG Lint
+        run: make png-lint
+
+  docs-workflow-complete:
+    needs: ["markdown-lint", "png-lint"]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Docs Workflow Complete
+        run: echo "Docs Workflow Complete"

--- a/Makefile
+++ b/Makefile
@@ -206,6 +206,21 @@ k8s-crd-extract: dist/crd-extractor.sh ## Extract the kubernetes CRDs used iin k
 	$(CMD_PREFIX) cp $(HOME)/.datree/crdSchemas/*/* deploy/.crdSchemas
 
 
+.PHONY: png-lint
+png-lint: dist/.png-lint ## Lint the png files from excalidraw
+
+dist/.png-lint: $(shell find . -iname '*.png') | dist
+	$(ECHO_PREFIX) printf "  %-12s ./...\n" "[PNG LINT]"
+	$(CMD_PREFIX) for file in $^; do \
+		if grep -q "$$file" .excalidraw-ignore; then continue ; fi ; \
+		if ! grep -q "excalidraw+json" $$file; then \
+			echo "$$file was not exported from excalidraw with 'Embed Scene' enabled." ; \
+			echo "If this is not an excalidraw file, add it to .excalidraw-ignore" ; \
+			exit 1 ; \
+		fi \
+	done
+	$(CMD_PREFIX) touch $@
+
 .PHONY: md-lint
 md-lint: dist/.md-lint ## Lint markdown files
 


### PR DESCRIPTION
Ensure images exported from excalidraw include the metadata that
allows them to be re-imported and edited again.

Run png-lint in CI and enforce it with mergify

Signed-off-by: Russell Bryant <rbryant@redhat.com>
