### PR TITLE
fixing panic on peer list due to empty map

### DIFF
--- a/cmd/nexctl/main.go
+++ b/cmd/nexctl/main.go
@@ -593,6 +593,10 @@ func showOutput(cCtx *cli.Context, fields []TableField, result any) {
 		}
 
 		itemsValue := reflect.ValueOf(result)
+		if itemsValue.IsNil() {
+			table.Render()
+			return
+		}
 		// if the itemsValue is not a slice, lets turn it into one.
 		if itemsValue.Type().Kind() != reflect.Slice {
 			itemsValue = reflect.MakeSlice(reflect.SliceOf(itemsValue.Type()), 0, 1)

--- a/integration-tests/helper_test.go
+++ b/integration-tests/helper_test.go
@@ -602,3 +602,17 @@ func (helper *Helper) deleteOrganization(username string, password string, orgID
 		"organization", "delete", "--organization-id", orgID)
 	return err
 }
+func (helper *Helper) peerListNexdDevices(ctx context.Context, ctr testcontainers.Container) error {
+	timeoutCtx, cancel := context.WithTimeout(ctx, time.Second*60)
+	defer cancel()
+	running, _ := util.CheckPeriodically(timeoutCtx, time.Second, func() (bool, error) {
+		statOut, err := helper.containerExec(ctx, ctr, []string{"/bin/nexctl", "nexd", "peers", "list"})
+		helper.Logf("nexd device peer list: %s", statOut)
+		return err != nil, err
+	})
+	if !running {
+		nodeName, _ := ctr.Name(ctx)
+		return fmt.Errorf("failed to run nexd device peer list in node: %s", nodeName)
+	}
+	return nil
+}

--- a/integration-tests/integration_test.go
+++ b/integration-tests/integration_test.go
@@ -823,6 +823,10 @@ func TestNexctl(t *testing.T) {
 	require.NotEmpty(organizations[0].IpCidrV6)
 	require.NotEmpty(organizations[0].Description)
 
+	// verify nexd peers list
+	err = helper.peerListNexdDevices(ctx, node1)
+	require.NoError(err)
+
 	// start nexodus on the nodes
 	helper.runNexd(ctx, node1, "--username", username, "--password", password, "relay")
 


### PR DESCRIPTION
When no device is registered as peers, result is empty

related to https://github.com/nexodus-io/nexodus/issues/1165

When only single device is registered

```
nexctl nexd peers list
panic: reflect: call of reflect.Value.FieldByName on map Value

goroutine 1 [running]:
reflect.flag.mustBe(...)
/usr/local/go/src/reflect/value.go:223
reflect.Value.FieldByName({0x50d8a0?, 0x400000e868?, 0x0?}, {0x5b9d86?, 0x1?})
/usr/local/go/src/reflect/value.go:1345 +0x13c
main.showOutput(0x4000368260?, {0x4000311180, 0x3, 0x4cc980?}, {0x50d8a0?, 0x4000169dd0})
/src/cmd/nexctl/main.go:612 +0x7a4
main.cmdListPeers(0x18?, {0x5b54b1?, 0x6?})
/src/cmd/nexctl/peers.go:73 +0x118
main.init.1.func8(0x4000358000?)
/src/cmd/nexctl/local_unix.go:212 +0x3c
[[github.com/urfave/cli/v2.(*Command](http://github.com/urfave/cli/v2.(*Command)](http://[github.com/urfave/cli/v2.(*Command](http://github.com/urfave/cli/v2.(*Command))).Run(0x4000358000, 0x40003209c0, {0x40003668e0, 0x1, 0x1})
/go/pkg/mod/github.com/urfave/cli/v2@v2.25.3/command.go:274 +0x73c
[[github.com/urfave/cli/v2.(*Command](http://github.com/urfave/cli/v2.(*Command)](http://[github.com/urfave/cli/v2.(*Command](http://github.com/urfave/cli/v2.(*Command))).Run(0x4000157e40, 0x4000320900, {0x400003b880, 0x2, 0x2})
/go/pkg/mod/github.com/urfave/cli/v2@v2.25.3/command.go:267 +0x948
[github.com/urfave/cli/v2.(*Command](http://github.com/urfave/cli/v2.(*Command)).Run(0x4000156b00, 0x4000320780, {0x40001699e0, 0x3, 0x3})
/go/pkg/mod/github.com/urfave/cli/v2@v2.25.3/command.go:267 +0x948
[github.com/urfave/cli/v2.(*Command](http://github.com/urfave/cli/v2.(*Command)).Run(0x400035c6e0, 0x4000320500, {0x4000030080, 0x4, 0x4})
/go/pkg/mod/github.com/urfave/cli/v2@v2.25.3/command.go:267 +0x948
[[github.com/urfave/cli/v2.(*App](http://github.com/urfave/cli/v2.(*App)](http://[github.com/urfave/cli/v2.(*App](http://github.com/urfave/cli/v2.(*App))).RunContext(0x400011a5a0, {0x69a030?, 0x4000036190}, {0x4000030080, 0x4, 0x4})
/go/pkg/mod/github.com/urfave/cli/v2@v2.25.3/app.go:332 +0x568
[github.com/urfave/cli/v2.(*App](http://github.com/urfave/cli/v2.(*App)).Run(...)
/go/pkg/mod/github.com/urfave/cli/v2@v2.25.3/app.go:309
main.main()
/src/cmd/nexctl/main.go:474 +0x1e64
```