### PR TITLE
Bump CI go version to resolve upstream library breakage

### DIFF
--- a/.github/actions/setup-go-env/action.yaml
+++ b/.github/actions/setup-go-env/action.yaml
@@ -7,7 +7,7 @@ runs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: "1.20"
+        go-version: "1.20.5"
 
     - id: go-cache-paths
       shell: bash


### PR DESCRIPTION
- Details at https://go-review.googlesource.com/c/go/+/511155