### PR TITLE
fix: `make clear-db` and `make recreate-db`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -497,6 +497,8 @@ clear-db:
 		" | make run-sql-apiserver $(PIPE_DEV_NULL)
 	$(CMD_PREFIX) kubectl scale deployment apiserver --replicas=1 -n nexodus $(PIPE_DEV_NULL)
 	$(CMD_PREFIX) kubectl rollout status deploy/apiserver -n nexodus --timeout=5m
+	$(CMD_PREFIX) kubectl rollout restart statefulset redis -n nexodus $(PIPE_DEV_NULL)
+	$(CMD_PREFIX) kubectl rollout status statefulset redis -n nexodus --timeout=5m
 
 ##@ Container Images
 
@@ -699,6 +701,8 @@ recreate-db: ## Delete and bring up a new nexodus database
 	$(CMD_PREFIX) kubectl apply -k ./deploy/nexodus/overlays/$(OVERLAY) | grep -v unchanged
 	$(CMD_PREFIX) OVERLAY=$(OVERLAY) make init-db
 	$(CMD_PREFIX) kubectl wait --for=condition=Ready pods --all -n nexodus -l app.kubernetes.io/part-of=nexodus --timeout=15m
+	$(CMD_PREFIX) kubectl rollout restart statefulset redis -n nexodus $(PIPE_DEV_NULL)
+	$(CMD_PREFIX) kubectl rollout status statefulset redis -n nexodus --timeout=5m
 
 .PHONY: cacerts
 cacerts: ## Install the Self-Signed CA Certificate

--- a/deploy/nexodus/base/redis/redis-statefulset.yaml
+++ b/deploy/nexodus/base/redis/redis-statefulset.yaml
@@ -16,6 +16,14 @@ spec:
       containers:
         - name: redis
           image: redis:6.0
+          args: ["--maxmemory", "200mb", "--maxmemory-policy", "allkeys-lru", "--save", ""]
+          resources:
+            limits:
+              cpu: 250m
+              memory: 250Mi
+            requests:
+              cpu: 250m
+              memory: 250Mi
           ports:
             - containerPort: 6379
               name: redis
@@ -39,17 +47,3 @@ spec:
               command:
                 - redis-cli
                 - ping
-          volumeMounts:
-            - name: redis-storage
-              mountPath: /data
-              subPath: data
-  volumeClaimTemplates:
-    - metadata:
-        name: redis-storage
-      spec:
-        volumeMode: Filesystem
-        accessModes:
-          - ReadWriteOnce
-        resources:
-          requests:
-            storage: 1Gi


### PR DESCRIPTION
They were leaving the service in a bad state where clients would get API errors.  We now made redis non-peristent and bounce it after clearing the DB.