### PR TITLE
Resolve the nexctl peer list panic

### DIFF
--- a/integration-tests/integration_test.go
+++ b/integration-tests/integration_test.go
@@ -6,14 +6,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/nexodus-io/nexodus/internal/state"
-	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
 	"net"
 	"testing"
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
 	"github.com/nexodus-io/nexodus/internal/models"
+	"github.com/nexodus-io/nexodus/internal/state"
+	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
 )
 
 func TestBasicConnectivity(t *testing.T) {
@@ -825,7 +825,7 @@ func TestNexctl(t *testing.T) {
 	require.NotEmpty(organizations[0].IpCidrV6)
 	require.NotEmpty(organizations[0].Description)
 
-	// verify nexd peers list
+	// validate nexctl nexd peers list does not throw any errors with no peers present
 	err = helper.peerListNexdDevices(ctx, node1)
 	require.NoError(err)
 
@@ -863,6 +863,15 @@ func TestNexctl(t *testing.T) {
 		"device", "list",
 	)
 	require.NoErrorf(err, "nexctl device list error: %v\n", err)
+
+	// validate nexctl nexd peers list does not throw any errors with peers present
+	pListOut, err := helper.containerExec(ctx, node1, []string{"/bin/nexctl", "nexd", "peers", "list"})
+	require.NoError(err)
+	node2Eth0, err := node2.ContainerIP(ctx)
+	require.NoError(err)
+	require.Contains(pListOut, node2Eth0)
+	helper.Logf("nexctl nexd peer list output: %s", pListOut)
+
 	var devices []models.Device
 	err = json.Unmarshal([]byte(allDevices), &devices)
 	require.NoErrorf(err, "nexctl device Unmarshal error: %v\n", err)


### PR DESCRIPTION
- Spent some time trying to get it working with the showOutput function but getting it to handle a map started getting messy. Can revisit but just want to resolve the panic and get it working again for now.

Output looks like the following:

```
$> sudo ./nexctl-dev-linux-arm64 nexd peers list
PUBLIC KEY                                       ENDPOINT                  ALLOWED IPS                    LATEST HANDSHAKE     TRANSMITTED     RECEIVED     HEALTHY
XXXXXXXXXXXX1BGN57LMTdHMVgosVnaQ7oPhXNXkfDI=     XXX.236.195.180:18303     [100.64.0.3/32 200::3/128]     85 seconds ago       7844            7792         true
```