### PR TITLE
Don’t compile in the kstore code introduced in dd822f7

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,9 @@ NEXODUS_BUILD_FLAGS:=
 ifneq ($(NEXODUS_PPROF),)
     NEXODUS_BUILD_FLAGS+=-tags pprof
 endif
+ifneq ($(NEXODUS_BUILD_TAGS),)
+	NEXODUS_BUILD_FLAGS+=-tags $(NEXODUS_BUILD_TAGS)
+endif
 
 SWAGGER_YAML:=internal/docs/swagger.yaml
 

--- a/integration-tests/helper_test.go
+++ b/integration-tests/helper_test.go
@@ -7,8 +7,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/nexodus-io/nexodus/internal/models"
 	"io"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
 	"os/exec"
 	"path/filepath"
 	"runtime"
@@ -39,10 +37,8 @@ const (
 
 type Helper struct {
 	*testing.T
-	require    *require.Assertions
-	assert     *assert.Assertions
-	kubeConfig *rest.Config
-	kubeClient *kubernetes.Clientset
+	require *require.Assertions
+	assert  *assert.Assertions
 }
 
 func NewHelper(t *testing.T) *Helper {

--- a/integration-tests/kube_test.go
+++ b/integration-tests/kube_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build integration && kubernetes
 
 package integration_tests
 
@@ -272,25 +272,18 @@ func (h *Helper) getPodAndTunnelIP(ctx context.Context, client *kubernetes.Clien
 }
 
 func (h *Helper) getKubeConfig() *rest.Config {
-	if h.kubeConfig == nil {
-		// create a kube client..
-		c, err := clientcmd.NewDefaultClientConfigLoadingRules().Load()
-		h.require.NoError(err)
-		clientConfig := clientcmd.NewDefaultClientConfig(*c, nil)
-		config, err := clientConfig.ClientConfig()
-		h.require.NoError(err)
-		h.kubeConfig = config
-	}
-	return h.kubeConfig
+	c, err := clientcmd.NewDefaultClientConfigLoadingRules().Load()
+	h.require.NoError(err)
+	clientConfig := clientcmd.NewDefaultClientConfig(*c, nil)
+	config, err := clientConfig.ClientConfig()
+	h.require.NoError(err)
+	return config
 }
 
 func (h *Helper) getKubeClient() *kubernetes.Clientset {
-	if h.kubeClient == nil {
-		client, err := kubernetes.NewForConfig(h.getKubeConfig())
-		h.require.NoError(err)
-		h.kubeClient = client
-	}
-	return h.kubeClient
+	client, err := kubernetes.NewForConfig(h.getKubeConfig())
+	h.require.NoError(err)
+	return client
 }
 
 func (h *Helper) createKubeCACerts(ctx context.Context, namespace string) {

--- a/internal/state/kstore/kstore_off.go
+++ b/internal/state/kstore/kstore_off.go
@@ -1,0 +1,11 @@
+//go:build !kubernetes
+
+package kstore
+
+import (
+	"github.com/nexodus-io/nexodus/internal/state"
+)
+
+func NewIfInCluster() (state.Store, error) {
+	return nil, nil
+}


### PR DESCRIPTION
That PR tripled the size of the nexd binary, so we decided to not  compile it in by default to rethink how to accomplish the same goal a  different way.

To build with the kstore code run: `NEXODUS_BUILD_TAGS="kubernetes" make clean dist/nexd`