### PR TITLE
Add wireguard userspace tools to the nexd image

### DIFF
--- a/Containerfile.dev
+++ b/Containerfile.dev
@@ -8,23 +8,23 @@ RUN mkdir /etc/apt/keyrings &&\
 RUN apt-get update -qy && \
     apt-get install --no-install-recommends -qy \
     ca-certificates \
-    iputils-ping \
+    conntrack \
+    curl \
+    docker.io \
+    gcc \
+    git \
     iproute2 \
     iptables \
-    net-tools \
-    traceroute \
-    tcpdump \
-    conntrack \
-    psmisc \
-    curl \
-    python3 \
-    make \
-    git \
-    gcc \
-    docker.io \
-    libc-dev \
-    yamllint \
+    iputils-ping \
     kubectl \
+    libc-dev \
+    make \
+    net-tools \
+    psmisc \
+    python3 \
+    tcpdump \
+    traceroute \
+    yamllint \
     && \
     apt-get clean
 
@@ -39,4 +39,3 @@ RUN cd /src &&\
     go mod download &&\
     cd / &&\
     rm -rf /src
-

--- a/Containerfile.nexd
+++ b/Containerfile.nexd
@@ -51,6 +51,7 @@ RUN dnf update -qy && \
     hostname \
     netcat \
     tmux \
+    wireguard-tools \
     && \
     dnf clean all -y &&\
     rm -rf /var/cache/yum


### PR DESCRIPTION
- Adds about 30m for the wg user space binary. Will be useful to debug user issues and QA early on. We currently get information such as peer listings and stats directly from the wg interface but if nexd isn't running those stats aren't available. Since nexd does not rely on this it is removable at any time but would like to have it available for time saving for installs for now.