### PR TITLE
Cleaning up windows logging and routing

### DIFF
--- a/internal/nexodus/nexodus.go
+++ b/internal/nexodus/nexodus.go
@@ -577,7 +577,9 @@ func (nx *Nexodus) Start(ctx context.Context, wg *sync.WaitGroup) error {
 				return
 			case <-stunTicker.C:
 				if err := nx.reconcileStun(modelsDevice.Id); err != nil {
-					nx.logger.Debug(err)
+					if nx.os != Windows.String() { // windows does not currently support reuse port or bpf
+						nx.logger.Debug(err)
+					}
 				}
 			case <-nx.informer.Changed():
 				nx.reconcileDevices(ctx, options)

--- a/internal/nexodus/route_windows.go
+++ b/internal/nexodus/route_windows.go
@@ -12,16 +12,44 @@ import (
 
 // handlePeerRoute when a new configuration is deployed, delete/add the peer allowedIPs
 func (nx *Nexodus) handlePeerRouteOS(wgPeerConfig wgPeerConfig) error {
+	// If child prefix split the two prefixes (host /32) and child prefix
 	for _, allowedIP := range wgPeerConfig.AllowedIPs {
 		// if the host does not support v6, skip adding the route
 		if util.IsIPv6Prefix(allowedIP) && !nx.ipv6Supported {
 			continue
 		}
-		if err := AddRoute(allowedIP, nx.tunnelIface); err != nil {
-			nx.logger.Errorf("route add failed: %v", err)
-			return err
+		routeExists, err := RouteExistsOS(allowedIP)
+		if err != nil {
+			nx.logger.Debugf("failed to check if route exists: %v", err)
+		}
+
+		if util.IsIPv4Prefix(allowedIP) {
+			if routeExists {
+				if err := DeleteRoute(allowedIP, wgIface); err != nil {
+					nx.logger.Debugf("no route deleted: %v", err)
+				}
+			}
+
+			if err := AddRoute(allowedIP, wgIface); err != nil {
+				nx.logger.Errorf("%v", err)
+				return err
+			}
+		}
+
+		if util.IsIPv6Prefix(allowedIP) {
+			if routeExists {
+				if err := DeleteRouteV6(allowedIP, wgIface); err != nil {
+					nx.logger.Debugf("no route deleted: %v", err)
+				}
+			}
+
+			if err := AddRouteV6(allowedIP, wgIface); err != nil {
+				nx.logger.Errorf("%v", err)
+				return err
+			}
 		}
 	}
+
 	return nil
 }
 
@@ -66,4 +94,26 @@ func findInterfaceForIPRoute(ipRoute string) (*net.Interface, error) {
 	}
 
 	return nil, fmt.Errorf("no matching interface found")
+}
+
+// AddRouteV6 adds a route to the specified interface using netsh in Windows
+func AddRouteV6(prefix, dev string) error {
+	// netsh interface ipv6 add route [prefix] [interface] [gateway] [metric]
+	_, err := RunCommand("netsh", "interface", "ipv6", "add", "route", prefix, dev, "::", "metric=256")
+	if err != nil {
+		return fmt.Errorf("v6 route add failed: %w", err)
+	}
+
+	return nil
+}
+
+// DeleteRouteV6 deletes a route from the specified interface using netsh in Windows
+func DeleteRouteV6(prefix, dev string) error {
+	// netsh interface ipv6 delete route [prefix] [interface]
+	_, err := RunCommand("netsh", "interface", "ipv6", "delete", "route", prefix, dev)
+	if err != nil {
+		return fmt.Errorf("no route deleted: %w", err)
+	}
+
+	return nil
 }


### PR DESCRIPTION
- Supressed debug logs from failed STUN lookups since windows is currently unable to resuse the wg port for STUNs.
- Filled out some no-ops in unimplemented routing functions v4/v6.
- More details in #1343