### PR TITLE
Playground manifest configuration updates to support 10K devices

### DIFF
--- a/deploy/nexodus/base/apiserver/deployment.yaml
+++ b/deploy/nexodus/base/apiserver/deployment.yaml
@@ -24,12 +24,12 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: database-pguser-apiserver
-                  key: host
+                  key: pgbouncer-host
             - name: NEXAPI_DB_PORT
               valueFrom:
                 secretKeyRef:
                   name: database-pguser-apiserver
-                  key: port
+                  key: pgbouncer-port
             - name: NEXAPI_DB_NAME
               valueFrom:
                 secretKeyRef:

--- a/deploy/nexodus/base/auth/deployment.yaml
+++ b/deploy/nexodus/base/auth/deployment.yaml
@@ -18,12 +18,12 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: database-pguser-keycloak
-                  key: host
+                  key: pgbouncer-host
             - name: KC_DB_URL_PORT
               valueFrom:
                 secretKeyRef:
                   name: database-pguser-keycloak
-                  key: port
+                  key: pgbouncer-port
             - name: KC_DB_URL_DATABASE
               valueFrom:
                 secretKeyRef:
@@ -95,6 +95,13 @@ spec:
                   name: auth-providers
                   key: GOOGLE_CLIENT_SECRET
                   optional: true
+          resources:
+            requests:
+              cpu: 200m
+              memory: 400Mi
+            limits:
+              cpu: 200m
+              memory: 400Mi
           ports:
             - name: http
               containerPort: 8080

--- a/deploy/nexodus/base/database/postgres.yaml
+++ b/deploy/nexodus/base/database/postgres.yaml
@@ -7,6 +7,7 @@ spec:
   postgresVersion: 14
   instances:
     - name: instance1
+      replicas: 1
       dataVolumeClaimSpec:
         accessModes:
           - "ReadWriteOnce"
@@ -86,3 +87,29 @@ spec:
       databases:
         - keycloak
       options: "NOSUPERUSER"
+  patroni:
+    dynamicConfiguration:
+      postgresql:
+        parameters:
+          max_connections: 100
+          shared_buffers: 128MB
+  proxy:
+    pgBouncer:
+      image: registry.developers.crunchydata.com/crunchydata/crunchy-pgbouncer:ubi8-1.19-3
+      replicas: 1
+      resources:
+        limits:
+          cpu: 100m
+          memory: 200Mi
+        requests:
+          cpu: 100m
+          memory: 200Mi
+      config:
+        global:
+          pool_mode: session
+          max_client_conn: "100"
+          default_pool_size: "30"
+        databases:
+          ipam: "host=database-primary port=5432 pool_size=15 reserve_pool=5 max_db_connections=20"
+          apiserver: "host=database-primary port=5432 pool_size=35 reserve_pool=5 max_db_connections=40"
+          keycloak: "host=database-primary port=5432 pool_size=35 reserve_pool=5 max_db_connections=40"

--- a/deploy/nexodus/base/ipam/deployment.yaml
+++ b/deploy/nexodus/base/ipam/deployment.yaml
@@ -17,12 +17,12 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: database-pguser-ipam
-                  key: host
+                  key: pgbouncer-host
             - name: GOIPAM_PG_PORT
               valueFrom:
                 secretKeyRef:
                   name: database-pguser-ipam
-                  key: port
+                  key: pgbouncer-port
             - name: GOIPAM_PG_USER
               valueFrom:
                 secretKeyRef:

--- a/deploy/nexodus/overlays/dev/kustomization.yaml
+++ b/deploy/nexodus/overlays/dev/kustomization.yaml
@@ -61,6 +61,12 @@ patches:
         value: nexodus-issuer
   - target:
       kind: Deployment
+      name: auth
+    patch: |-
+      - op: remove
+        path: /spec/template/spec/containers/0/resources/limits
+  - target:
+      kind: Deployment
       name: apiproxy
     patch: |-
       - op: remove

--- a/deploy/nexodus/overlays/playground/files/envoy.yaml
+++ b/deploy/nexodus/overlays/playground/files/envoy.yaml
@@ -1,0 +1,393 @@
+# The administration endpoint uses a Unix socket instead of TCP in order
+# to avoid exposing it outside of the pod. Requests for metrics and
+# probes will go via an HTTP listener that only accepts requests for the
+# /metrics and /ready paths.
+admin:
+  access_log_path: /dev/null
+  address:
+    pipe:
+      path: /sockets/admin.socket
+
+static_resources:
+  clusters:
+    # upstream server: admin
+    # provides metrics
+    - name: admin
+      connect_timeout: 1s
+      type: STATIC
+      lb_policy: ROUND_ROBIN
+      load_assignment:
+        cluster_name: admin
+        endpoints:
+          - lb_endpoints:
+              - endpoint:
+                  address:
+                    pipe:
+                      path: /sockets/admin.socket
+
+    - name: auth
+      connect_timeout: 5s
+      type: LOGICAL_DNS
+      lb_policy: ROUND_ROBIN
+      load_assignment:
+        cluster_name: auth
+        endpoints:
+          - lb_endpoints:
+              - endpoint:
+                  address:
+                    socket_address:
+                      address: auth
+                      port_value: 8443
+      transport_socket:
+        name: envoy.transport_sockets.tls
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+
+    # upstream server: apiserver
+    - name: apiserver
+      connect_timeout: 10s
+      type: STRICT_DNS
+      dns_refresh_rate: 1s
+      dns_lookup_family: V4_ONLY
+      lb_policy: ROUND_ROBIN
+      circuit_breakers:
+        thresholds:
+          - priority: DEFAULT
+            max_connections: 4000
+            max_pending_requests: 4000
+            max_requests: 4000
+            max_retries: 2
+      load_assignment:
+        cluster_name: apiserver
+        endpoints:
+          - lb_endpoints:
+              - endpoint:
+                  address:
+                    socket_address:
+                      address: apiserver
+                      port_value: 8080
+
+    # upstream server: frontend
+    - name: frontend
+      connect_timeout: 5s
+      type: STRICT_DNS
+      dns_refresh_rate: 1s
+      dns_lookup_family: V4_ONLY
+      lb_policy: ROUND_ROBIN
+      load_assignment:
+        cluster_name: frontend
+        endpoints:
+          - lb_endpoints:
+              - endpoint:
+                  address:
+                    socket_address:
+                      address: frontend
+                      port_value: 3000
+
+    - name: ext-authz
+      type: STRICT_DNS
+      dns_lookup_family: V4_ONLY
+      lb_policy: ROUND_ROBIN
+      connect_timeout: 1s
+      typed_extension_protocol_options:
+        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+          "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+          explicit_http_config:
+            http2_protocol_options: {}
+      load_assignment:
+        cluster_name: ext-authz
+        endpoints:
+          - lb_endpoints:
+              - endpoint:
+                  address:
+                    socket_address:
+                      address: apiserver
+                      port_value: 5080
+
+    # upstream server: ratelimiter
+    # used to access the rate limiting service.
+    - name: ratelimiter
+      connect_timeout: 1s
+      type: STRICT_DNS
+      dns_lookup_family: V4_ONLY
+      lb_policy: ROUND_ROBIN
+      http2_protocol_options: {}
+      load_assignment:
+        cluster_name: ratelimiter
+        endpoints:
+          - lb_endpoints:
+              - endpoint:
+                  address:
+                    socket_address:
+                      address: limitador
+                      port_value: 8081
+
+    # upstream server: tempo
+    # used collect request traces
+    - name: tempo
+      type: STRICT_DNS
+      dns_lookup_family: V4_ONLY
+      lb_policy: ROUND_ROBIN
+      typed_extension_protocol_options:
+        envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
+          "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions
+          explicit_http_config:
+            http2_protocol_options: {}
+      load_assignment:
+        cluster_name: tempo
+        endpoints:
+          - lb_endpoints:
+              - endpoint:
+                  address:
+                    socket_address:
+                      address: tempo.nexodus-monitoring.svc
+                      port_value: 4317
+
+  listeners:
+    # listeners: admin (only accessible within the kube cluster)
+    - name: admin
+      address:
+        socket_address:
+          address: 0.0.0.0
+          port_value: 9000
+      filter_chains:
+        - filters:
+            - name: envoy.filters.network.http_connection_manager
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                stat_prefix: admin
+                http_filters:
+                  - name: envoy.filters.http.router
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+                route_config:
+                  name: admin
+                  virtual_hosts:
+                    - name: admin
+                      domains:
+                        - "*"
+                      routes:
+                        - name: metrics
+                          match:
+                            path: /metrics
+                          route:
+                            cluster: admin
+                            prefix_rewrite: /stats/prometheus
+                        - name: ready
+                          match:
+                            path: /ready
+                          route:
+                            cluster: admin
+
+
+    # listener: ingress - frontend and apiserver
+    - name: ingress
+      address:
+        socket_address:
+          address: 0.0.0.0
+          port_value: 8080
+      filter_chains:
+        - filters:
+            - name: envoy.filters.network.http_connection_manager
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                access_log:
+                  - name: envoy.access_loggers.file
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog
+                      path: /dev/stdout
+                stat_prefix: ingress
+
+                generate_request_id: true
+                tracing:
+                  provider:
+                    name: envoy.tracers.opentelemetry
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.config.trace.v3.OpenTelemetryConfig
+                      grpc_service:
+                        envoy_grpc:
+                          cluster_name: tempo
+                        timeout: 0.250s
+                      service_name: apiproxy
+
+                common_http_protocol_options:
+                  idle_timeout: 120s
+                upgrade_configs:
+                  - upgrade_type: websocket
+                http_filters:
+                  - name: envoy.filters.http.cors
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.cors.v3.Cors
+
+                  - name: envoy.filters.http.ext_authz
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz
+                      grpc_service:
+                        envoy_grpc:
+                          cluster_name: ext-authz
+                        timeout: 2s
+                      transport_api_version: V3
+                      failure_mode_allow: false
+                      status_on_error:
+                        code: 503
+
+                  # For JWT verification
+                  - name: envoy.filters.http.jwt_authn
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.JwtAuthentication
+                      providers:
+                        provider1:
+                          from_headers:
+                            - name: Authorization
+                              value_prefix: "Bearer "
+                          from_cookies:
+                            - AccessToken
+                          forward: true
+                          payload_in_metadata: payload
+                          issuer: "${APIPROXY_OIDC_URL}"
+                          remote_jwks:
+                            http_uri:
+                              uri: "${APIPROXY_OIDC_BACKCHANNEL}/protocol/openid-connect/certs"
+                              cluster: auth
+                              timeout: 2s
+                            cache_duration:
+                              seconds: 300
+                      rules:
+                        - match:
+                            prefix: /api
+                          requires:
+                            provider_name: provider1
+
+                  # This is needed to enable the rate limiter:
+                  - name: envoy.filters.http.ratelimit
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.ratelimit.v3.RateLimit
+                      # domain: "%REQ(:authority)%"
+                      domain: "nexodus"
+                      failure_mode_deny: false
+                      timeout: 0.5s
+                      enable_x_ratelimit_headers: DRAFT_VERSION_03
+                      rate_limit_service:
+                        transport_api_version: V3
+                        grpc_service:
+                          envoy_grpc:
+                            cluster_name: ratelimiter
+
+                  # This is mandatory in order to have the HTTP routes above.
+                  - name: envoy.filters.http.router
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+
+                route_config:
+                  name: frontend
+                  virtual_hosts:
+                    - name: frontend
+                      domains:
+                        - "${APIPROXY_WEB_DOMAIN}"
+                      retry_policy:
+                        num_retries: 2
+                        retry_back_off:
+                          base_interval: 0.25s
+                          max_interval: 60s
+                        retry_on: 5xx,connect-failure,refused-stream
+                      routes:
+                        - name: default
+                          match:
+                            prefix: /
+                          typed_per_filter_config:
+                            envoy.filters.http.ext_authz:
+                              "@type": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute
+                              disabled: true
+                          route:
+                            timeout: 10s
+                            cluster: frontend
+                            rate_limits:
+                              - actions:
+                                  - generic_key:
+                                      descriptor_key: resource_group
+                                      descriptor_value: spa
+
+                    - name: apiserver
+                      domains:
+                        - "${APIPROXY_API_DOMAIN}"
+                      typed_per_filter_config:
+                        envoy.filters.http.cors:
+                          "@type": type.googleapis.com/envoy.extensions.filters.http.cors.v3.CorsPolicy
+                          allow_origin_string_match:
+                            - prefix: "${APIPROXY_WEB_ORIGINS}"
+                          allow_headers: origin,content-type
+                          allow_methods: GET,PUT,POST,DELETE,PATCH
+                          allow_credentials: true
+                      # Adding a retry policy at host level
+                      retry_policy:
+                        num_retries: 2
+                        retry_back_off:
+                          base_interval: 0.25s
+                          max_interval: 60s
+                        retry_on: 5xx
+                      routes:
+                        - match: {prefix: "/web/"}
+                          name: web
+                          route:
+                            priority: DEFAULT
+                            timeout: 30s
+                            cluster: apiserver
+                            rate_limits:
+                              - actions:
+                                  - generic_key:
+                                      descriptor_key: resource_group
+                                      descriptor_value: web-auth
+                        - match: {prefix: "/device/"}
+                          name: device
+                          route:
+                            priority: DEFAULT
+                            timeout: 30s
+                            cluster: apiserver
+                            rate_limits:
+                              - actions:
+                                  - generic_key:
+                                      descriptor_key: resource_group
+                                      descriptor_value: device-auth
+                        - match: {prefix: "/api/"}
+                          name: default
+                          request_headers_to_add:
+                            header:
+                              key: "x-jwt-claim-sub"
+                              value: "test %DYNAMIC_METADATA(envoy.filters.http.jwt_authn:payload:sub)%"
+                            keep_empty_value: true
+                            append_action: OVERWRITE_IF_EXISTS_OR_ADD
+                          route:
+                            priority: DEFAULT
+                            timeout: 30s
+                            cluster: apiserver
+                            rate_limits:
+                              - actions:
+                                  - generic_key:
+                                      descriptor_key: resource_group
+                                      descriptor_value: api
+                                  - generic_key:
+                                      descriptor_key: tier
+                                      descriptor_value: default
+                                  - metadata:
+                                      descriptor_key: sub
+                                      metadata_key:
+                                        key: "envoy.filters.http.jwt_authn"
+                                        path:
+                                          - key: payload
+                                          - key: sub
+
+                # We need this in order to generate JSON responses according to
+                # our API guidelines, otherwise Envoy will generate plain text
+                # responses.
+                local_reply_config:
+                  mappers:
+                    - filter:
+                        status_code_filter:
+                          comparison:
+                            op: EQ
+                            value:
+                              default_value: 429
+                              runtime_key: none
+                      body_format_override:
+                        json_format:
+                          error: "Too Many Requests"

--- a/deploy/nexodus/overlays/playground/files/limits.yaml
+++ b/deploy/nexodus/overlays/playground/files/limits.yaml
@@ -1,7 +1,7 @@
 ---
 - namespace: nexodus
-  max_value: 200
-  seconds: 1
+  max_value: 2000
+  seconds: 10
   conditions:
     - tier == 'default'
   variables:

--- a/deploy/nexodus/overlays/playground/kustomization.yaml
+++ b/deploy/nexodus/overlays/playground/kustomization.yaml
@@ -23,6 +23,10 @@ configMapGenerator:
     files:
       - files/limits.yaml
     name: limitador-config
+  - behavior: replace
+    files:
+      - files/envoy.yaml
+    name: apiproxy-envoy-config
   #  - behavior: replace
   #    files:
   #      - files/promtail.yaml
@@ -47,6 +51,16 @@ configMapGenerator:
 patches:
   - patch: |-
       - op: replace
+        path: /spec/dnsNames/0
+        value: auth.playground.nexodus.io
+      - op: replace
+        path: /spec/issuerRef/name
+        value: letsencrypt
+    target:
+      kind: Certificate
+      name: nexodus-auth-cert
+  - patch: |-
+      - op: replace
         path: /spec/rules/0/host
         value: api.playground.nexodus.io
       - op: replace
@@ -57,13 +71,6 @@ patches:
         value: letsencrypt
     target:
       kind: Ingress
-      name: apiproxy
-  - patch: |-
-      - op: add
-        path: /spec/template/spec/serviceAccountName
-        value: nexodus-serviceaccount
-    target:
-      kind: Deployment
       name: apiproxy
   - patch: |-
       - op: add
@@ -83,16 +90,6 @@ patches:
     target:
       kind: Ingress
       name: auth
-  - patch: |-
-      - op: replace
-        path: /spec/dnsNames/0
-        value: auth.playground.nexodus.io
-      - op: replace
-        path: /spec/issuerRef/name
-        value: letsencrypt
-    target:
-      kind: Certificate
-      name: nexodus-auth-cert
   - patch: |-
       - op: replace
         path: /spec/rules/0/host
@@ -117,42 +114,116 @@ patches:
       name: promtail-role
   - patch: |-
       - op: replace
+        path: /spec/template/spec/containers/0/resources/limits/cpu
+        value: 500m
+      - op: replace
+        path: /spec/template/spec/containers/0/resources/limits/memory
+        value: 1Gi
+    target:
+      kind: StatefulSet
+      name: redis
+  - patch: |-
+      - op: replace
+        path: /spec/instances/0/replicas
+        value: 1
+      - op: replace
         path: /spec/instances/0/dataVolumeClaimSpec/resources/requests/storage
-        value: 4Gi
+        value: 6Gi
       - op: replace
         path: /spec/instances/0/resources/limits/cpu
-        value: 1000m
+        value: 8000m
       - op: replace
         path: /spec/instances/0/resources/limits/memory
-        value: 2Gi
+        value: 12Gi
+      - op: replace
+        path: /spec/proxy/pgBouncer/replicas
+        value: 2
+      - op: replace
+        path: /spec/proxy/pgBouncer/resources/limits/cpu
+        value: 1000m
+      - op: replace
+        path: /spec/proxy/pgBouncer/resources/limits/memory
+        value: 500Mi
+      - op: replace
+        path: /spec/proxy/pgBouncer/config/databases/ipam
+        value: "host=database-primary port=5432 pool_size=15 reserve_pool=5 max_db_connections=20"
+      - op: replace
+        path: /spec/proxy/pgBouncer/config/databases/apiserver
+        value: "host=database-primary port=5432 pool_size=50 reserve_pool=20 max_db_connections=70"
+      - op: replace
+        path: /spec/proxy/pgBouncer/config/databases/keycloak
+        value: "host=database-primary port=5432 pool_size=50 reserve_pool=20 max_db_connections=70"
+      - op: replace
+        path: /spec/proxy/pgBouncer/config/global/max_client_conn
+        value: "10000"
+      - op: replace
+        path: /spec/patroni/dynamicConfiguration/postgresql/parameters/max_connections
+        value: "300"
+      - op: replace
+        path: /spec/patroni/dynamicConfiguration/postgresql/parameters/shared_buffers
+        value: 512MB
     target:
       kind: PostgresCluster
       name: database
   - patch: |-
-      - op: remove
-        path: /spec/template/spec/containers/0/resources/limits
+      - op: add
+        path: /spec/template/spec/serviceAccountName
+        value: nexodus-serviceaccount
+      - op: replace
+        path: /spec/template/spec/containers/0/resources/limits/cpu
+        value: 500m
+      - op: replace
+        path: /spec/template/spec/containers/0/resources/limits/memory
+        value: 1Gi
+      - op: replace
+        path: /spec/replicas
+        value: 4
     target:
       kind: Deployment
       name: apiproxy
   - patch: |-
       - op: replace
         path: /spec/template/spec/containers/0/resources/limits/cpu
-        value: 1000m
+        value: 2000m
       - op: replace
         path: /spec/template/spec/containers/0/resources/limits/memory
-        value: 1Gi
+        value: 2000Mi
+      - op: replace
+        path: /spec/replicas
+        value: 8
     target:
       kind: Deployment
       name: apiserver
   - patch: |-
-      - op: remove
-        path: /spec/template/spec/containers/0/resources/limits
+      - op: replace
+        path: /spec/replicas
+        value: 2
+      - op: replace
+        path: /spec/template/spec/containers/0/resources/limits/cpu
+        value: 1000m
+      - op: replace
+        path: /spec/template/spec/containers/0/resources/limits/memory
+        value: 2000Mi
+    target:
+      kind: Deployment
+      name: auth
+  - patch: |-
+      - op: replace
+        path: /spec/template/spec/containers/0/resources/limits/cpu
+        value: 200m
+      - op: replace
+        path: /spec/template/spec/containers/0/resources/limits/memory
+        value: 400Mi
     target:
       kind: Deployment
       name: frontend
   - patch: |-
-      - op: remove
-        path: /spec/template/spec/containers/0/resources/limits
+      - op: replace
+        path: /spec/template/spec/containers/0/resources/limits/cpu
+        value: 300m
+      - op: replace
+        path: /spec/template/spec/containers/0/resources/limits/memory
+        value: 500Mi
     target:
       kind: Deployment
       name: ipam


### PR DESCRIPTION
Commit contain following changes that is required to scale control plan to support 10K devices.

- Use pgbouncer for postgres database connection pooling to ensure clients doesn't run out of connections for requests.
- Update apiserver, ipam and auth deployment to use pgbouncer rather than directly using postgres db.
- Update base auth deployment to explicitly set resource limits, so that overlays can override it.
- Add patroni configuration to base database deployment, to configure max_connections and shared_buffer for database server for scale scenario. Base deployment is set to default values, individual overlays can overwrite it.
- Configure PGBouncer to specify pool size and reserve pool per database, rather than per database server.
- Add envoy files in playground overlay, to update with scale configuration for playground overlay. Playground overlay envoy configuration includes circuit breaker configuration and custom timeout values. 
- Update limitador config to increase the request rate limits.
- Update playground kustomization.yaml to overwrite various limits for scaling playground deployment.