### PR TITLE
nexd: Fix peering health monitoring

### DIFF
--- a/Containerfile.nexd
+++ b/Containerfile.nexd
@@ -56,6 +56,7 @@ RUN dnf update -qy && \
     nftables \
     hostname \
     netcat \
+    tcpdump \
     tmux \
     wireguard-tools \
     && \

--- a/cmd/nexd/main.go
+++ b/cmd/nexd/main.go
@@ -3,9 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/nexodus-io/nexodus/internal/state/fstore"
-	"github.com/nexodus-io/nexodus/internal/state/kstore"
-	log "github.com/sirupsen/logrus"
 	"net/url"
 	"os"
 	"os/signal"
@@ -15,11 +12,16 @@ import (
 	"sync"
 	"syscall"
 
+	"github.com/nexodus-io/nexodus/internal/state/fstore"
+	"github.com/nexodus-io/nexodus/internal/state/kstore"
+	log "github.com/sirupsen/logrus"
+
 	"github.com/nexodus-io/nexodus/internal/nexodus"
 	"github.com/nexodus-io/nexodus/internal/stun"
 	"github.com/nexodus-io/nexodus/internal/util"
 	"github.com/urfave/cli/v2"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
 
 const (
@@ -213,14 +215,13 @@ func main() {
 	if debug != "" {
 		logCfg := zap.NewDevelopmentConfig()
 		logLevel = &logCfg.Level
-		logCfg.EncoderConfig.TimeKey = ""
 		logger, err = logCfg.Build()
 		logger.Info("Debug logging enabled")
 	} else {
 		logCfg := zap.NewProductionConfig()
 		logLevel = &logCfg.Level
 		logCfg.DisableStacktrace = true
-		logCfg.EncoderConfig.TimeKey = ""
+		logCfg.EncoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
 		logger, err = logCfg.Build()
 	}
 	if err != nil {

--- a/internal/nexodus/nexodus.go
+++ b/internal/nexodus/nexodus.go
@@ -6,8 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/nexodus-io/nexodus/internal/state"
-	"golang.org/x/oauth2"
 	"net"
 	"net/http"
 	"net/netip"
@@ -20,6 +18,9 @@ import (
 	"sync"
 	"syscall"
 	"time"
+
+	"github.com/nexodus-io/nexodus/internal/state"
+	"golang.org/x/oauth2"
 
 	"github.com/google/uuid"
 	"github.com/nexodus-io/nexodus/internal/api/public"
@@ -808,18 +809,23 @@ func (nx *Nexodus) deviceCacheLookup(pubKey string) (deviceCacheEntry, bool) {
 }
 
 func (nx *Nexodus) peerIsHealthy(d deviceCacheEntry) bool {
-	// How do we determine a peer is healthy or not?
+	// The most reliable method to passively check for an active wireguard session
+	// is to check that the last handshake is within the REJECT_AFTER_TIME constant
+	// defined in the wireguard paper (180 seconds).
 	//
-	// We have wireguard keepalives turned on, so if we haven't seen
-	// bidirectional traffic in the keepalive interval + the keepalive timeout,
-	// then it is unhealthy. We can watch the tx and rx counters for this.
-	// We can also watch the LastHandshakeTime.
+	// > After REJECT_AFTER_MESSAGES transport data messages or after the
+	// > current secure session is REJECT_AFTER_TIME seconds old, whichever
+	// > comes first, WireGuard will refuse to send or receive any more
+	// > transport data messages using the current secure session, until a new
+	// > secure session is created through the 1-RTT handshake.
 	//
-	// The next method we could use here is to check the LastHandshakeTime.
-	// If it is older than the RekeyAfterTime + RekeyTimeout, then it is unhealthy.
-	// That would result in a slower detection of an unhealthy peer than watching
-	// for counters to increment based on keepalives based on our current keepalive
-	// setting, though.
+	// It is tempting to try to do something with the tx and rx counters availble
+	// in the wireguard stats, but a past attempt helped determine that was not
+	// reliable, as we can only count on keepalives going in one direction,
+	// not both. For even more detail on this, check the git commit logs for this
+	// file.
+	//
+	// For now, we will detect that peering is not working within about 3 minutes.
 
 	if d.lastHandshakeTime.IsZero() {
 		// We haven't seen a handshake yet, so this peer connection is not up.
@@ -831,53 +837,19 @@ func (nx *Nexodus) peerIsHealthy(d deviceCacheEntry) bool {
 		return false
 	}
 
-	keepaliveWindow := keepaliveInterval + device.KeepaliveTimeout
-
-	if time.Since(d.lastHandshakeTime) < keepaliveWindow {
-		// We have seen a handshake recently enough, so this peer connection is up.
-		if !d.peerHealthy {
-			nx.logger.Debugf("peer (hostname:%s pubkey:%s [%s %s]) is now healthy due to lastHandshakeTime: %s < %s",
-				d.device.Hostname, d.device.PublicKey,
-				d.device.Endpoints[0].Address, d.device.Endpoints[1].Address,
-				time.Since(d.lastHandshakeTime).String(), keepaliveWindow.String())
-		}
-		return true
-	}
-
-	if time.Since(d.startTime) < keepaliveWindow {
-		// We haven't been tracking this peer long enough to know if it is healthy or not,
-		// so assume the best.
-		if !d.peerHealthy {
-			nx.logger.Debugf("peer (hostname:%s pubkey:%s [%s %s]) is assumed healthy due to startTime: %s < %s",
-				d.device.Hostname, d.device.PublicKey,
-				d.device.Endpoints[0].Address, d.device.Endpoints[1].Address,
-				time.Since(d.startTime).String(), keepaliveWindow.String())
-		}
-		return true
-	}
-
-	if time.Since(d.lastTxTime) > keepaliveWindow {
+	if time.Since(d.lastHandshakeTime) > device.RejectAfterTime {
+		// It has been too long since the last handshake, so this session has expired.
 		if d.peerHealthy {
-			nx.logger.Debugf("peer (hostname:%s pubkey:%s [%s %s]) is unhealthy due to lastTxTime: %s",
+			nx.logger.Debugf("peer (hostname:%s pubkey:%s [%s %s]) is unhealthy due to lastHandshakeTime: %s > %s",
 				d.device.Hostname, d.device.PublicKey,
 				d.device.Endpoints[0].Address, d.device.Endpoints[1].Address,
-				time.Since(d.lastTxTime).String())
-		}
-		return false
-	}
-
-	if time.Since(d.lastRxTime) > keepaliveWindow {
-		if d.peerHealthy {
-			nx.logger.Debugf("peer (hostname:%s pubkey:%s [%s %s]) is unhealthy due to lastRxTime: %s",
-				d.device.Hostname, d.device.PublicKey,
-				d.device.Endpoints[0].Address, d.device.Endpoints[1].Address,
-				time.Since(d.lastRxTime).String())
+				time.Since(d.lastHandshakeTime).String(), device.RejectAfterTime.String())
 		}
 		return false
 	}
 
 	if !d.peerHealthy {
-		nx.logger.Debugf("peer (hostname:%s pubkey:%s [%s %s]) is now healthy based on tx/rx counter activity",
+		nx.logger.Debugf("peer (hostname:%s pubkey:%s [%s %s]) is now healthy",
 			d.device.Hostname, d.device.PublicKey,
 			d.device.Endpoints[0].Address, d.device.Endpoints[1].Address)
 	}


### PR DESCRIPTION
Closes issue #1383

- nexd: Add tcpdump to nexd container image
- nexd: Restore timestamps in logs
- nexd: Fix peering health monitoring


commit 805b6bfe6699198a80a4fb2c364e58e66d9c8da3
Author: Russell Bryant <russell.bryant@gmail.com>
Date:   Fri Sep 8 11:14:10 2023 -0400

    nexd: Add tcpdump to nexd container image
    
    We include a set of useful debugging tools in the image. I needed
    tcpdump today to debug something. It seems useful to include. It's
    just over 1 MB.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>

commit 0eb2f522fde750c6dd34543dabb5ab2f3ee788d0
Author: Russell Bryant <russell.bryant@gmail.com>
Date:   Fri Sep 8 11:15:55 2023 -0400

    nexd: Restore timestamps in logs
    
    My original reason for dropping the timestamps was two-fold: systemd
    timestamps the logs for nexd and the timestamp format used in the
    production config was unreadable to humans, so I was always annoyed
    looking at the logs.
    
    Relying on systemd (or something else) to timestamp the logs isn't
    appropriate. When running in a container, we don't have that same
    feature present.
    
    Tweak the production log config to use a human-readable timestamp
    format. The default was unix time (seconds since epoch).
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>

commit 4011917df847a2453e6e3dfed624d67b1fa4b73c
Author: Russell Bryant <russell.bryant@gmail.com>
Date:   Fri Sep 8 12:44:43 2023 -0400

    nexd: Fix peering health monitoring
    
    The code added to determine whether a healthy session between two
    peers exists was flawed in multiple ways, resulting in a flapping
    healthy/unhealthy state visible either in `nexctl nexd peers list`,
    or in debug logs.
    
    The wireguard paper, nexd logs, packet captures, and review of the
    kernel implementation of wireguard were used to narrow this down. For
    reference, here is the wireguard paper:
    
      https://www.wireguard.com/papers/wireguard.pdf
    
    The wireguard kernel implementation can be found under
    linux/drivers/net/wireguard in the kernel tree.
    
    Problem 1: The check based on the last handshake time was just
    completely wrong. It assumed a handshake would occur within
    (persistent keepalive interval + KEEPALIVE_TIMEOUT). Not only is this
    the wrong window of time to use, it's two values that are unrelated.
    The keepalive timeout is a constant from the spec related to passive
    keepalives and is not used with optional persistent keepalives.
    
    The fix for problem 1 is to check that the last handshake is within
    the REJECT_AFTER_TIME constant defined in the paper.
    
    > After REJECT_AFTER_MESSAGES transport data messages or after the
    > current secure session is REJECT_AFTER_TIME seconds old, whichever
    > comes first, WireGuard will refuse to send or receive any more
    > transport data messages using the current secure session, until a new
    > secure session is created through the 1-RTT handshake.
    
    Problem 2: The checks based on the TX and RX counters were based on
    flawed assumptions about how keepalives work. The code assumed that we
    should always see the TX and RX counters increase within (persistent
    keepalive interval + KEEPALIVE_TIMEOUT). This is wrong for multiple
    reasons.
    
    First, as noted earlier, the KEEPALIVE_TIMEOUT constant is not related
    to persistent keepalive handling.
    
    Second, the code assumed that when persistent keepalives are enabled,
    they are always sent bidirectionally at that interval. In practice, my
    observation in testing is that happens ... sometimes. There are two
    sources of reading helpful in understanding the observed behavior.
    
    One source, of course, is the Wireguard paper. The protocol details
    are important, but also that it describes a design goal of being
    quiet and minimizing the number of messages necessary to setup and
    maintain a session. This is helpful for security, efficiency, and
    stealth.
    
    However, the paper only makes one passing mention of persistent
    keepalives and does not define exactly how they should be handled in
    the detail given for the rest of the protocol, or that was my read of
    it.
    
    Another helpful resource for me was reviewing the kernel source and
    how persistent keepalives are handled. We can see that the
    implementation takes steps to try to only send the keepalives if it
    deems necessary. The timer for sending a persistent keepalive gets
    reset anytime an authenticated message is sent OR received.
    
    The timer reset is in wireguard/timers.c:
    
        /* Should be called before a packet with authentication, whether
         * keepalive, data, or handshakem is sent, or after one is received.
         */
        void wg_timers_any_authenticated_packet_traversal(struct wg_peer *peer)
        {
                if (peer->persistent_keepalive_interval)
                        mod_peer_timer(peer, &peer->timer_persistent_keepalive,
                                jiffies + peer->persistent_keepalive_interval * HZ);
        }
    
    Next, you can see where this function is called from wireguard/send.c
    and wireguard/receive.c.
    
    On the receive side, it is called from wg_receive_handshake_packet()
    and wg_packet_consume_data_done(). In other words, any time a
    handshake, keepalive, or a data message is received, the timer for
    SENDING a persistent keepalive gets reset.
    
    The send side is similar. It's called from
    wg_packet_send_handshake_initiation(),
    wg_packet_send_handshake_response(), and wg_packet_create_data_done().
    The timer for SENDING a persistent keepalive is reset anytime a
    handshake initiation or response is sent, or when sending a data
    packet.
    
    The result is that persistent keepalives are not very persistent. In
    my local test environment, I often observe keepalives going
    bidirectionally at the same time, but it appears to be because the
    timers are so close to in sync that the timers are expiring close
    enough to the same time that both sides are sending a keepalive before
    their timer can be reset because one was received.
    
    If the timing is off just enough that a keepalive is received and
    processed before the local timer fires, no keepalive will be sent.
    This is the condition that would cause the unhealthy peer status
    flapping in the nexd logs.
    
    Once in the state where nexd believed the session was unhealthy, the
    most reliable point in time where you would see it restored is when
    wireguard does key rotation. If not sooner, a new session will be
    created approximately after REKEY_AFTER_TIME seconds. This handshake
    will always bump both the TX and RX counters, so nexd would be happy
    again.
    
    After all of that, I have dropped any use of the TX and RX counters to
    try to determine peer health because I don't see a way to use it to
    reliably detect a broken session any faster than the calculation done
    against the last handshake time.
    
    I see two possible improvements for faster peeper failure detection:
    
    1) Ensure that nexd always uses a customized fork of wireguard-go that
       includes a change to ensure persistent keepalives are always sent
       if no other data is being sent. The timer could be reset when sending
       other packets, but not when receiving them. That would ensure that
       bidirectional wireguard packets are flowing within a defined
       interval instead of the current case, where it can end up only
       going one direction in between key rotation.
    
    2) Do health checking on top. ICMP is an obvious candidate, though
       it's possible for ICMP packets to be dropped by the destination
       host's firewall or some other middlebox, even though the
       wireguard session is fine, and other traffic is still working.
    
    If we actually feel the need to do this, we should also dig into other
    projects that use wireguard to see what they've come up with. In the
    meantime, detection will take about 3 minutes. That's good enough for
    now.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>
