### PR TITLE
Implements a shared informer API for nexd

### DIFF
--- a/deploy/nexodus/base/apiproxy/deployment.yaml
+++ b/deploy/nexodus/base/apiproxy/deployment.yaml
@@ -56,7 +56,7 @@ spec:
               mountPath: /configs/envoy
       containers:
         - name: envoy
-          image: envoyproxy/envoy:v1.25.1
+          image: envoyproxy/envoy:v1.27.0
           imagePullPolicy: IfNotPresent
           securityContext:
             allowPrivilegeEscalation: false

--- a/deploy/nexodus/base/apiproxy/files/envoy.yaml
+++ b/deploy/nexodus/base/apiproxy/files/envoy.yaml
@@ -207,8 +207,7 @@ static_resources:
                         timeout: 0.250s
                       service_name: apiproxy
 
-                common_http_protocol_options:
-                  idle_timeout: 120s
+                request_headers_timeout: 0s
                 upgrade_configs:
                   - upgrade_type: websocket
                 http_filters:
@@ -332,6 +331,38 @@ static_resources:
                                   - generic_key:
                                       descriptor_key: resource_group
                                       descriptor_value: device-auth
+
+                        - name: events
+                          match:
+                            safe_regex:
+                              google_re2: {}
+                              regex: "^\/api\/organizations\/[^/?]+\/events$"
+
+                          request_headers_to_add:
+                            header:
+                              key: "x-jwt-claim-sub"
+                              value: "test %DYNAMIC_METADATA(envoy.filters.http.jwt_authn:payload:sub)%"
+                            keep_empty_value: true
+                            append_action: OVERWRITE_IF_EXISTS_OR_ADD
+                          route:
+                            timeout: 0s
+                            idle_timeout: 0s
+                            cluster: apiserver
+                            rate_limits:
+                              - actions:
+                                  - generic_key:
+                                      descriptor_key: resource_group
+                                      descriptor_value: api
+                                  - generic_key:
+                                      descriptor_key: tier
+                                      descriptor_value: default
+                                  - metadata:
+                                      descriptor_key: sub
+                                      metadata_key:
+                                        key: "envoy.filters.http.jwt_authn"
+                                        path:
+                                          - key: payload
+                                          - key: sub
 
                         - name: default
                           match:

--- a/deploy/nexodus/base/apiproxy/ingress.yaml
+++ b/deploy/nexodus/base/apiproxy/ingress.yaml
@@ -4,6 +4,11 @@ metadata:
   name: apiproxy
   annotations:
     cert-manager.io/issuer: nexodus-issuer
+    # see: https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#proxy-read-timeout
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+    # see: https://docs.openshift.com/container-platform/4.13/networking/routes/route-configuration.html#nw-configuring-route-timeouts_route-configuration
+    haproxy.router.openshift.io/timeout: "3600s"
+
 spec:
   tls:
     - hosts:

--- a/integration-tests/features/events-api.feature
+++ b/integration-tests/features/events-api.feature
@@ -83,7 +83,7 @@ Feature: Events API
       """
       {
         "kind": "device-metadata",
-        "type": "bookmark"
+        "type": "tail"
       }
       """
 
@@ -103,7 +103,7 @@ Feature: Events API
       """
       {
         "kind": "device",
-        "type": "bookmark"
+        "type": "tail"
       }
       """
 

--- a/internal/api/public/api_devices_custom.go
+++ b/internal/api/public/api_devices_custom.go
@@ -1,296 +1,39 @@
 package public
 
 import (
-	"bytes"
-	"encoding/json"
-	"errors"
-	"fmt"
-	"io"
-	"net/http"
-	"net/url"
-	"strings"
-	"sync"
+	"github.com/nexodus-io/nexodus/internal/util"
 )
-
-type DeviceStream struct {
-	decoder *json.Decoder
-	close   func() error
-}
-
-func (ds *DeviceStream) Receive() (string, ModelsDevice, error) {
-	event := struct {
-		Type  string       `json:"type"`
-		Value ModelsDevice `json:"value"`
-	}{}
-	err := ds.decoder.Decode(&event)
-	if err != nil {
-		return "", event.Value, err
-	}
-	return event.Type, event.Value, nil
-}
-
-func (ds *DeviceStream) Close() error {
-	return ds.close()
-}
-
-func (r ApiListDevicesInOrganizationRequest) Watch() (*DeviceStream, *http.Response, error) {
-	return r.ApiService.ListDevicesInOrganizationWatch(r)
-}
-
-func (a *DevicesApiService) ListDevicesInOrganizationWatch(r ApiListDevicesInOrganizationRequest) (*DeviceStream, *http.Response, error) {
-	var (
-		localVarHTTPMethod = http.MethodGet
-		localVarPostBody   interface{}
-		formFiles          []formFile
-	)
-
-	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "DevicesApiService.ListDevicesInOrganization")
-	if err != nil {
-		return nil, nil, &GenericOpenAPIError{error: err.Error()}
-	}
-
-	localVarPath := localBasePath + "/api/organizations/{organization_id}/devices"
-	localVarPath = strings.Replace(localVarPath, "{"+"organization_id"+"}", url.PathEscape(parameterValueToString(r.organizationId, "organizationId")), -1)
-
-	localVarHeaderParams := make(map[string]string)
-	localVarQueryParams := url.Values{}
-	localVarFormParams := url.Values{}
-
-	if r.gtRevision != nil {
-		parameterAddToHeaderOrQuery(localVarQueryParams, "gt_revision", r.gtRevision, "")
-	}
-	localVarQueryParams["watch"] = []string{"true"}
-
-	// to determine the Content-Type header
-	localVarHTTPContentTypes := []string{}
-
-	// set Content-Type header
-	localVarHTTPContentType := selectHeaderContentType(localVarHTTPContentTypes)
-	if localVarHTTPContentType != "" {
-		localVarHeaderParams["Content-Type"] = localVarHTTPContentType
-	}
-
-	// to determine the Accept header
-	localVarHTTPHeaderAccepts := []string{"application/json"}
-
-	// set Accept header
-	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
-	if localVarHTTPHeaderAccept != "" {
-		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
-	}
-	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	localVarHTTPResponse, err := a.client.callAPI(req)
-	if err != nil || localVarHTTPResponse == nil {
-		return nil, localVarHTTPResponse, err
-	}
-
-	if localVarHTTPResponse.StatusCode >= 300 {
-
-		localVarBody, err := io.ReadAll(localVarHTTPResponse.Body)
-		localVarHTTPResponse.Body.Close()
-		localVarHTTPResponse.Body = io.NopCloser(bytes.NewBuffer(localVarBody))
-		if err != nil {
-			return nil, localVarHTTPResponse, err
-		}
-
-		newErr := &GenericOpenAPIError{
-			body:  localVarBody,
-			error: localVarHTTPResponse.Status,
-		}
-		if localVarHTTPResponse.StatusCode == 400 {
-			var v ModelsBaseError
-			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return nil, localVarHTTPResponse, newErr
-			}
-			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
-			newErr.model = v
-			return nil, localVarHTTPResponse, newErr
-		}
-		if localVarHTTPResponse.StatusCode == 401 {
-			var v ModelsBaseError
-			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return nil, localVarHTTPResponse, newErr
-			}
-			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
-			newErr.model = v
-			return nil, localVarHTTPResponse, newErr
-		}
-		if localVarHTTPResponse.StatusCode == 429 {
-			var v ModelsBaseError
-			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return nil, localVarHTTPResponse, newErr
-			}
-			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
-			newErr.model = v
-			return nil, localVarHTTPResponse, newErr
-		}
-		if localVarHTTPResponse.StatusCode == 500 {
-			var v ModelsBaseError
-			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return nil, localVarHTTPResponse, newErr
-			}
-			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
-			newErr.model = v
-		}
-		return nil, localVarHTTPResponse, newErr
-	}
-
-	return &DeviceStream{
-		close:   localVarHTTPResponse.Body.Close,
-		decoder: json.NewDecoder(localVarHTTPResponse.Body),
-	}, localVarHTTPResponse, nil
-}
 
 // Informer creates a *ApiListDevicesInOrganizationInformer which provides a simpler
 // API to list devices but which is implemented with the Watch api.  The *ApiListDevicesInOrganizationInformer
 // maintains a local device cache which gets updated with the Watch events.
-func (r ApiListDevicesInOrganizationRequest) Informer() *ApiListDevicesInOrganizationInformer {
-	res := &ApiListDevicesInOrganizationInformer{
-		request:        r,
-		modifiedSignal: make(chan struct{}, 1),
-	}
-	return res
+func (r ApiListDevicesInOrganizationRequest) Informer() *Informer[ModelsDevice] {
+	informer := NewInformer[ModelsDevice](&DeviceAdaptor{}, r.gtRevision, ApiWatchEventsRequest{
+		ctx:            r.ctx,
+		ApiService:     r.ApiService.client.OrganizationsApi,
+		organizationId: r.organizationId,
+	})
+	return informer
 }
 
-type ApiListDevicesInOrganizationInformer struct {
-	request        ApiListDevicesInOrganizationRequest
-	stream         *DeviceStream
-	inSync         chan struct{}
-	modifiedSignal chan struct{}
-	mu             sync.RWMutex
-	data           map[string]ModelsDevice
-	response       *http.Response
-	err            error
-	lastRevision   int32
+type DeviceAdaptor struct{}
+
+func (d DeviceAdaptor) Revision(item ModelsDevice) int32 {
+	return item.Revision
 }
 
-var ErrContextCanceled = errors.New("context canceled")
-
-func (s *ApiListDevicesInOrganizationInformer) Changed() <-chan struct{} {
-	return s.modifiedSignal
+func (d DeviceAdaptor) Key(item ModelsDevice) string {
+	return item.PublicKey
 }
 
-func (s *ApiListDevicesInOrganizationInformer) Execute() (map[string]ModelsDevice, *http.Response, error) {
-
-	var err error
-	s.mu.Lock()
-	if s.stream == nil {
-		// after an error we can recover by resuming event's from the last revision.
-		s.request.GtRevision(s.lastRevision)
-		s.stream, s.response, s.err = s.request.ApiService.ListDevicesInOrganizationWatch(s.request)
-		err = s.err
-		if s.err == nil {
-			s.inSync = make(chan struct{})
-			go s.readStream(s.lastRevision)
-		}
-	}
-	s.mu.Unlock()
-
-	// initial api request may have failed...
-	if err != nil {
-		return s.data, s.response, s.err
-	}
-
-	// avoid returning a partial data list by, waiting for the bookmark event
-	// which signals that all known data items have sent.  We wait for the inSync
-	// chanel to close (or the context to be canceled).
-	select {
-	case <-s.request.ctx.Done():
-		return s.data, s.response, ErrContextCanceled
-	case <-s.inSync:
-	}
-
-	// s.data, s.response, s.err are modified with the s.mu write lock
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	return s.data, s.response, s.err
+func (d DeviceAdaptor) Kind() string {
+	return "device"
 }
 
-func (s *ApiListDevicesInOrganizationInformer) readStream(lastRevision int32) {
-	isInSync := false
-
-	defer func() {
-		s.mu.Lock()
-		err := s.stream.Close()
-		if err != nil {
-			s.err = err
-		}
-		s.stream = nil
-		s.mu.Unlock()
-		if !isInSync {
-			isInSync = true
-			close(s.inSync)
-		}
-	}()
-
-	items := map[string]ModelsDevice{}
-	for {
-		event, item, err := s.stream.Receive()
-		if err != nil {
-			s.setResult(nil, lastRevision, err)
-			return
-		}
-		switch event {
-		case "change":
-			lastRevision = item.Revision
-			items[item.Id] = item
-			if isInSync {
-				s.setResult(dataByIdToByKey(items), lastRevision, nil)
-			}
-		case "delete":
-			lastRevision = item.Revision
-			delete(items, item.Id)
-			if isInSync {
-				s.setResult(dataByIdToByKey(items), lastRevision, nil)
-			}
-		case "bookmark":
-			if !isInSync {
-				isInSync = true
-				s.setResult(dataByIdToByKey(items), lastRevision, nil)
-				close(s.inSync)
-			}
-		case "close":
-			return
-		case "error":
-			return
-		default:
-			s.setResult(nil, lastRevision, fmt.Errorf("unknown event type: %s", event))
-			return
-		}
-	}
+func (d DeviceAdaptor) Item(value map[string]interface{}) (ModelsDevice, error) {
+	item := ModelsDevice{}
+	err := util.JsonUnmarshal(value, &item)
+	return item, err
 }
 
-func dataByIdToByKey(dataById map[string]ModelsDevice) map[string]ModelsDevice {
-	// Convert to a map of public keys to devices
-	data := map[string]ModelsDevice{}
-	for _, i := range dataById {
-		data[i.PublicKey] = i
-	}
-	return data
-}
-
-func (s *ApiListDevicesInOrganizationInformer) setResult(data map[string]ModelsDevice, lastRevision int32, err error) {
-	s.mu.Lock()
-	s.data = data
-	s.err = err
-	s.lastRevision = lastRevision
-	s.mu.Unlock()
-
-	select {
-	// try to signal...
-	case s.modifiedSignal <- struct{}{}:
-	default: // so we don't block if a signal is pending.
-	}
-}
+var _ InformerAdaptor[ModelsDevice] = &DeviceAdaptor{}

--- a/internal/api/public/api_organizations.go
+++ b/internal/api/public/api_organizations.go
@@ -632,7 +632,7 @@ type ApiWatchEventsRequest struct {
 	watches        *[]ModelsWatch
 }
 
-// List if events to watch
+// List of events to watch
 func (r ApiWatchEventsRequest) Watches(watches []ModelsWatch) ApiWatchEventsRequest {
 	r.watches = &watches
 	return r

--- a/internal/api/public/api_organizations_custom.go
+++ b/internal/api/public/api_organizations_custom.go
@@ -1,0 +1,478 @@
+package public
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"github.com/nexodus-io/nexodus/internal/util"
+	"go.uber.org/zap"
+	"golang.org/x/exp/maps"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+)
+
+var Logger *zap.SugaredLogger = nil
+
+func (r ApiWatchEventsRequest) WatchEventsStream() (*WatchEventsStream, *http.Response, error) {
+	return r.ApiService.WatchEventsStream(r)
+}
+
+func (a *OrganizationsApiService) WatchEventsStream(r ApiWatchEventsRequest) (*WatchEventsStream, *http.Response, error) {
+	// this is a stream friendly version of WatchEventsExecute
+	var (
+		localVarHTTPMethod  = http.MethodPost
+		localVarPostBody    interface{}
+		formFiles           []formFile
+		localVarReturnValue *WatchEventsStream // different from WatchEventsExecute
+	)
+
+	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "OrganizationsApiService.WatchEvents")
+	if err != nil {
+		return localVarReturnValue, nil, &GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/api/organizations/{organization_id}/events"
+	localVarPath = strings.Replace(localVarPath, "{"+"organization_id"+"}", url.PathEscape(parameterValueToString(r.organizationId, "organizationId")), -1)
+
+	localVarHeaderParams := make(map[string]string)
+	localVarQueryParams := url.Values{}
+	localVarFormParams := url.Values{}
+	if r.watches == nil {
+		return localVarReturnValue, nil, reportError("watches is required and must be specified")
+	}
+
+	// to determine the Content-Type header
+	localVarHTTPContentTypes := []string{"application/json"}
+
+	// set Content-Type header
+	localVarHTTPContentType := selectHeaderContentType(localVarHTTPContentTypes)
+	if localVarHTTPContentType != "" {
+		localVarHeaderParams["Content-Type"] = localVarHTTPContentType
+	}
+
+	// to determine the Accept header
+	localVarHTTPHeaderAccepts := []string{"application/json"}
+
+	// set Accept header
+	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
+	if localVarHTTPHeaderAccept != "" {
+		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
+	}
+	// body params
+	localVarPostBody = r.watches
+	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
+	if err != nil {
+		return localVarReturnValue, nil, err
+	}
+
+	localVarHTTPResponse, err := a.client.callAPI(req)
+	if err != nil || localVarHTTPResponse == nil {
+		return localVarReturnValue, localVarHTTPResponse, err
+	}
+
+	if localVarHTTPResponse.StatusCode >= 300 {
+
+		// different from WatchEventsExecute: start
+		localVarBody, err := io.ReadAll(localVarHTTPResponse.Body)
+		_ = localVarHTTPResponse.Body.Close()
+		localVarHTTPResponse.Body = io.NopCloser(bytes.NewBuffer(localVarBody))
+		if err != nil {
+			return nil, localVarHTTPResponse, err
+		}
+		// different from WatchEventsExecute: end
+
+		newErr := &GenericOpenAPIError{
+			body:  localVarBody,
+			error: localVarHTTPResponse.Status,
+		}
+		if localVarHTTPResponse.StatusCode == 400 {
+			var v ModelsBaseError
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarReturnValue, localVarHTTPResponse, newErr
+			}
+			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
+			newErr.model = v
+			return localVarReturnValue, localVarHTTPResponse, newErr
+		}
+		if localVarHTTPResponse.StatusCode == 401 {
+			var v ModelsBaseError
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarReturnValue, localVarHTTPResponse, newErr
+			}
+			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
+			newErr.model = v
+			return localVarReturnValue, localVarHTTPResponse, newErr
+		}
+		if localVarHTTPResponse.StatusCode == 429 {
+			var v ModelsBaseError
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarReturnValue, localVarHTTPResponse, newErr
+			}
+			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
+			newErr.model = v
+			return localVarReturnValue, localVarHTTPResponse, newErr
+		}
+		if localVarHTTPResponse.StatusCode == 500 {
+			var v ModelsBaseError
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarReturnValue, localVarHTTPResponse, newErr
+			}
+			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
+			newErr.model = v
+		}
+		return localVarReturnValue, localVarHTTPResponse, newErr
+	}
+
+	// different from WatchEventsExecute: start
+	return &WatchEventsStream{
+		close:   localVarHTTPResponse.Body.Close,
+		decoder: json.NewDecoder(localVarHTTPResponse.Body),
+	}, localVarHTTPResponse, nil
+	// different from WatchEventsExecute: end
+
+}
+
+type WatchEventsStream struct {
+	decoder *json.Decoder
+	close   func() error
+}
+
+func (ds *WatchEventsStream) Receive() (ModelsWatchEvent, error) {
+	event := ModelsWatchEvent{}
+	err := ds.decoder.Decode(&event)
+	return event, err
+}
+
+func (ds *WatchEventsStream) Close() error {
+	return ds.close()
+}
+
+// //////////////////////////////////////////////////////////////////////////////////////////////////
+//
+// //////////////////////////////////////////////////////////////////////////////////////////////////
+type watchEventsDataLoaderKeyType struct{}
+
+var watchEventsDataLoaderKey = watchEventsDataLoaderKeyType{}
+
+func (r ApiWatchEventsRequest) NewSharedInformerContext() context.Context {
+	return context.WithValue(r.ctx, watchEventsDataLoaderKey, NewWatchEventsDataLoader(r))
+}
+func getWatchEventsDataLoader(ctx context.Context) *WatchEventsDataLoader {
+	if v, ok := ctx.Value(watchEventsDataLoaderKey).(*WatchEventsDataLoader); ok {
+		return v
+	}
+	return nil
+}
+
+type WatchEventHandler = func(event ModelsWatchEvent, response *http.Response, err error)
+
+type WatchEventsDataLoader struct {
+	mu            sync.RWMutex
+	request       ApiWatchEventsRequest
+	watchHandlers map[*ModelsWatch]WatchEventHandler
+	stream        *WatchEventsStream
+}
+
+func NewWatchEventsDataLoader(r ApiWatchEventsRequest) *WatchEventsDataLoader {
+	return &WatchEventsDataLoader{
+		watchHandlers: map[*ModelsWatch]WatchEventHandler{},
+		request:       r,
+	}
+}
+
+func (dl *WatchEventsDataLoader) Add(w *ModelsWatch, handler WatchEventHandler) bool {
+	dl.mu.Lock()
+	defer dl.mu.Unlock()
+	if dl.stream != nil {
+		return false
+	}
+	dl.watchHandlers[w] = handler
+	return true
+}
+
+func (dl *WatchEventsDataLoader) Remove(w *ModelsWatch) bool {
+	dl.mu.Lock()
+	defer dl.mu.Unlock()
+	if dl.stream != nil {
+		return false
+	}
+	if dl.watchHandlers[w] == nil {
+		return false
+	}
+	delete(dl.watchHandlers, w)
+	return true
+}
+
+func (dl *WatchEventsDataLoader) start() bool {
+	dl.mu.Lock()
+	defer dl.mu.Unlock()
+
+	if dl.stream != nil {
+		return false
+	}
+
+	// we de-dupe watches here.. keep the watches wanting more data..
+	handlers := map[string][]WatchEventHandler{}
+	sharedWatches := map[string]*ModelsWatch{}
+	for w, h := range dl.watchHandlers {
+		handlers[w.Kind] = append(handlers[w.Kind], h)
+		prev := sharedWatches[w.Kind]
+		if prev == nil || w.GtRevision < prev.GtRevision {
+			sharedWatches[w.Kind] = w
+		}
+	}
+	var watches []ModelsWatch
+	for _, watch := range sharedWatches {
+		watches = append(watches, *watch)
+	}
+	request := dl.request
+	request.watches = &watches
+
+	stream, response, err := request.WatchEventsStream()
+	if err != nil {
+		for _, hl := range handlers {
+			for _, h := range hl {
+				h(ModelsWatchEvent{}, response, err)
+			}
+		}
+		return false
+	}
+
+	dl.stream = stream
+	go dl.run(response, handlers)
+	return true
+
+}
+
+func (dl *WatchEventsDataLoader) run(response *http.Response, handlers map[string][]WatchEventHandler) {
+	restart := false
+	defer func() {
+		dl.mu.Lock()
+		_ = dl.stream.Close()
+		dl.stream = nil
+		dl.mu.Unlock()
+		if restart {
+			dl.start()
+		}
+	}()
+
+	for i := 0; ; i++ {
+		event, err := dl.stream.Receive()
+		if err != nil {
+			// right now envoy seems to be terminating our long-lived connections after about 10sec,
+			// when that happens, we get this error, so try to recover.
+			if errors.Is(err, io.ErrUnexpectedEOF) && i >= 0 {
+				if Logger != nil {
+					Logger.Debug("Event stream connection reset")
+				}
+				restart = true
+				return
+			}
+		}
+		for kind, hl := range handlers {
+			for _, h := range hl {
+				if event.Type == "" || event.Kind == kind {
+					h(event, response, err)
+				}
+			}
+		}
+		if err != nil {
+			return
+		}
+		switch event.Type {
+		case "close", "error":
+			return
+		}
+	}
+}
+
+type InformerAdaptor[T any] interface {
+	Kind() string
+	Item(value map[string]interface{}) (T, error)
+	Revision(item T) int32
+	Key(item T) string
+}
+
+type Informer[T any] struct {
+	adaptor               InformerAdaptor[T]
+	watchEventsDataLoader *WatchEventsDataLoader
+	watch                 ModelsWatch
+	bookmarkChan          chan struct{}
+	changed               chan struct{}
+	mu                    sync.RWMutex
+	data                  map[string]T
+	err                   error
+	response              *http.Response
+}
+
+func NewInformer[T any](adaptor InformerAdaptor[T], gtRevision *int32, request ApiWatchEventsRequest) *Informer[T] {
+	informer := Informer[T]{
+		watch: ModelsWatch{
+			Kind: adaptor.Kind(),
+		},
+		adaptor:      adaptor,
+		changed:      make(chan struct{}, 1),
+		data:         make(map[string]T),
+		bookmarkChan: make(chan struct{}),
+	}
+	if gtRevision != nil {
+		informer.watch.GtRevision = *gtRevision
+	}
+
+	informer.watchEventsDataLoader = getWatchEventsDataLoader(request.ctx)
+	if informer.watchEventsDataLoader == nil || !informer.watchEventsDataLoader.Add(&informer.watch, informer.handleWatchEvent) {
+		// Fall back to using an exclusive WatchEventsDataLoader if a shared one can't be used.
+		informer.watchEventsDataLoader = NewWatchEventsDataLoader(request)
+		if !informer.watchEventsDataLoader.Add(&informer.watch, informer.handleWatchEvent) {
+			panic("informer.watchEventsDataLoader.Add failed to add handler")
+		}
+	}
+	return &informer
+}
+
+func (informer *Informer[T]) Changed() <-chan struct{} {
+	return informer.changed
+}
+
+var ErrContextCanceled = errors.New("context canceled")
+
+func (informer *Informer[T]) Execute() (map[string]T, *http.Response, error) {
+
+	informer.mu.Lock()
+	// after a failure... we need to reset some things... so that we can recover...
+	if informer.err != nil {
+		informer.err = nil
+		informer.bookmarkChan = make(chan struct{})
+	}
+	bookmarked := informer.watch.AtTail
+	bookmarkChan := informer.bookmarkChan
+	informer.mu.Unlock()
+
+	informer.watchEventsDataLoader.start()
+
+	// avoid returning a partial data list by, waiting for the bookmark event
+	// which signals that all known data items have sent.
+	canceled := false
+	if !bookmarked {
+		select {
+		case <-informer.watchEventsDataLoader.request.ctx.Done():
+			canceled = true
+		case <-bookmarkChan:
+		}
+	}
+
+	informer.mu.RLock()
+	defer informer.mu.RUnlock()
+	if canceled {
+		return informer.data, informer.response, ErrContextCanceled
+	}
+	return informer.data, informer.response, informer.err
+}
+
+func (informer *Informer[T]) notify() {
+	// try to signal...
+	select {
+	case informer.changed <- struct{}{}:
+	default: // so we don't block if a signal is pending.
+	}
+}
+
+func (informer *Informer[T]) handleWatchEvent(event ModelsWatchEvent, response *http.Response, err error) {
+	informer.mu.Lock()
+	defer informer.mu.Unlock()
+
+	setError := func(err error) {
+		informer.err = err
+		if !informer.watch.AtTail {
+			close(informer.bookmarkChan)
+		}
+		informer.notify()
+	}
+
+	informer.response = response
+	if err != nil {
+		setError(err)
+		return
+	}
+
+	var item T
+	switch event.Type {
+	case "change":
+		item, informer.err = informer.adaptor.Item(event.Value)
+		if err != nil {
+			setError(err)
+			return
+		}
+		revision := informer.adaptor.Revision(item)
+		if revision < informer.watch.GtRevision {
+			return
+		}
+		informer.watch.GtRevision = revision
+
+		data := maps.Clone(informer.data)
+		data[informer.adaptor.Key(item)] = item
+		informer.data = data
+
+		if informer.watch.AtTail {
+			informer.notify()
+		}
+	case "delete":
+
+		item, err = informer.adaptor.Item(event.Value)
+		if err != nil {
+			setError(err)
+			return
+		}
+		revision := informer.adaptor.Revision(item)
+		if revision < informer.watch.GtRevision {
+			return
+		}
+		informer.watch.GtRevision = revision
+
+		data := maps.Clone(informer.data)
+		delete(data, informer.adaptor.Key(item))
+		informer.data = data
+
+		if informer.watch.AtTail {
+			informer.notify()
+		}
+	case "tail":
+		if !informer.watch.AtTail {
+			informer.notify()
+			informer.watch.AtTail = true
+			close(informer.bookmarkChan)
+		}
+	case "close":
+		if err != nil {
+			informer.err = err
+		}
+		if !informer.watch.AtTail {
+			informer.watch.AtTail = true
+			close(informer.bookmarkChan)
+		}
+	case "error":
+		item := ModelsBaseError{}
+		err = util.JsonUnmarshal(event.Value, &item)
+		if err == nil {
+			err = errors.New(item.Error)
+		}
+		setError(err)
+
+	default:
+		informer.err = fmt.Errorf("unknown event type: %s", event.Type)
+		informer.notify()
+	}
+}

--- a/internal/api/public/api_security_group_custom.go
+++ b/internal/api/public/api_security_group_custom.go
@@ -1,283 +1,39 @@
 package public
 
 import (
-	"bytes"
-	"encoding/json"
-	"fmt"
-	"io"
-	"net/http"
-	"net/url"
-	"strings"
-	"sync"
+	"github.com/nexodus-io/nexodus/internal/util"
 )
-
-type SecurityGroupStream struct {
-	decoder *json.Decoder
-	close   func() error
-}
-
-func (ds *SecurityGroupStream) Receive() (string, ModelsSecurityGroup, error) {
-	event := struct {
-		Type  string              `json:"type"`
-		Value ModelsSecurityGroup `json:"value"`
-	}{}
-	err := ds.decoder.Decode(&event)
-	if err != nil {
-		return "", event.Value, err
-	}
-	return event.Type, event.Value, nil
-}
-
-func (ds *SecurityGroupStream) Close() error {
-	return ds.close()
-}
-
-func (r ApiListSecurityGroupsRequest) Watch() (*SecurityGroupStream, *http.Response, error) {
-	return r.ApiService.ListSecurityGroupsWatch(r)
-}
-
-func (a *SecurityGroupApiService) ListSecurityGroupsWatch(r ApiListSecurityGroupsRequest) (*SecurityGroupStream, *http.Response, error) {
-	var (
-		localVarHTTPMethod = http.MethodGet
-		localVarPostBody   interface{}
-		formFiles          []formFile
-	)
-
-	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "SecurityGroupApiService.ListSecurityGroups")
-	if err != nil {
-		return nil, nil, &GenericOpenAPIError{error: err.Error()}
-	}
-
-	localVarPath := localBasePath + "/api/organizations/{organization_id}/security_groups"
-	localVarPath = strings.Replace(localVarPath, "{"+"organization_id"+"}", url.PathEscape(parameterValueToString(r.organizationId, "organizationId")), -1)
-
-	localVarHeaderParams := make(map[string]string)
-	localVarQueryParams := url.Values{}
-	localVarFormParams := url.Values{}
-
-	if r.gtRevision != nil {
-		parameterAddToHeaderOrQuery(localVarQueryParams, "gt_revision", r.gtRevision, "")
-	}
-	localVarQueryParams["watch"] = []string{"true"}
-
-	// to determine the Content-Type header
-	localVarHTTPContentTypes := []string{}
-
-	// set Content-Type header
-	localVarHTTPContentType := selectHeaderContentType(localVarHTTPContentTypes)
-	if localVarHTTPContentType != "" {
-		localVarHeaderParams["Content-Type"] = localVarHTTPContentType
-	}
-
-	// to determine the Accept header
-	localVarHTTPHeaderAccepts := []string{"application/json"}
-
-	// set Accept header
-	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
-	if localVarHTTPHeaderAccept != "" {
-		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
-	}
-	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, formFiles)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	localVarHTTPResponse, err := a.client.callAPI(req)
-	if err != nil || localVarHTTPResponse == nil {
-		return nil, localVarHTTPResponse, err
-	}
-
-	if localVarHTTPResponse.StatusCode >= 300 {
-
-		localVarBody, err := io.ReadAll(localVarHTTPResponse.Body)
-		localVarHTTPResponse.Body.Close()
-		localVarHTTPResponse.Body = io.NopCloser(bytes.NewBuffer(localVarBody))
-		if err != nil {
-			return nil, localVarHTTPResponse, err
-		}
-
-		newErr := &GenericOpenAPIError{
-			body:  localVarBody,
-			error: localVarHTTPResponse.Status,
-		}
-		if localVarHTTPResponse.StatusCode == 400 {
-			var v ModelsBaseError
-			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return nil, localVarHTTPResponse, newErr
-			}
-			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
-			newErr.model = v
-			return nil, localVarHTTPResponse, newErr
-		}
-		if localVarHTTPResponse.StatusCode == 401 {
-			var v ModelsBaseError
-			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return nil, localVarHTTPResponse, newErr
-			}
-			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
-			newErr.model = v
-			return nil, localVarHTTPResponse, newErr
-		}
-		if localVarHTTPResponse.StatusCode == 429 {
-			var v ModelsBaseError
-			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return nil, localVarHTTPResponse, newErr
-			}
-			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
-			newErr.model = v
-			return nil, localVarHTTPResponse, newErr
-		}
-		if localVarHTTPResponse.StatusCode == 500 {
-			var v ModelsBaseError
-			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return nil, localVarHTTPResponse, newErr
-			}
-			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
-			newErr.model = v
-		}
-		return nil, localVarHTTPResponse, newErr
-	}
-
-	return &SecurityGroupStream{
-		close:   localVarHTTPResponse.Body.Close,
-		decoder: json.NewDecoder(localVarHTTPResponse.Body),
-	}, localVarHTTPResponse, nil
-}
 
 // Informer creates a *ApiListSecurityGroupsInformer which provides a simpler
 // API to list devices but which is implemented with the Watch api.  The *ApiListSecurityGroupsInformer
 // maintains a local device cache which gets updated with the Watch events.
-func (r ApiListSecurityGroupsRequest) Informer() *ApiListSecurityGroupsInformer {
-	res := &ApiListSecurityGroupsInformer{
-		request:        r,
-		modifiedSignal: make(chan struct{}, 1),
-	}
-	return res
+func (r ApiListSecurityGroupsRequest) Informer() *Informer[ModelsSecurityGroup] {
+	informer := NewInformer[ModelsSecurityGroup](&SecurityGroupAdaptor{}, r.gtRevision, ApiWatchEventsRequest{
+		ctx:            r.ctx,
+		ApiService:     r.ApiService.client.OrganizationsApi,
+		organizationId: r.organizationId,
+	})
+	return informer
 }
 
-type ApiListSecurityGroupsInformer struct {
-	request        ApiListSecurityGroupsRequest
-	stream         *SecurityGroupStream
-	inSync         chan struct{}
-	modifiedSignal chan struct{}
-	mu             sync.RWMutex
-	data           map[string]ModelsSecurityGroup
-	response       *http.Response
-	err            error
-	lastRevision   int32
+type SecurityGroupAdaptor struct{}
+
+func (d SecurityGroupAdaptor) Revision(item ModelsSecurityGroup) int32 {
+	return item.Revision
 }
 
-func (s *ApiListSecurityGroupsInformer) Changed() <-chan struct{} {
-	return s.modifiedSignal
+func (d SecurityGroupAdaptor) Key(item ModelsSecurityGroup) string {
+	return item.Id
 }
 
-func (s *ApiListSecurityGroupsInformer) Execute() (map[string]ModelsSecurityGroup, *http.Response, error) {
-
-	var err error
-	s.mu.Lock()
-	if s.stream == nil {
-		// after an error we can recover by resuming event's from the last revision.
-		s.request.GtRevision(s.lastRevision)
-		s.stream, s.response, s.err = s.request.ApiService.ListSecurityGroupsWatch(s.request)
-		err = s.err
-		if s.err == nil {
-			s.inSync = make(chan struct{})
-			go s.readStream(s.lastRevision)
-		}
-	}
-	s.mu.Unlock()
-
-	// initial api request may have failed...
-	if err != nil {
-		return s.data, s.response, s.err
-	}
-
-	// avoid returning a partial data list by, waiting for the bookmark event
-	// which signals that all known data items have sent.  We wait for the inSync
-	// chanel to close (or the context to be canceled).
-	select {
-	case <-s.request.ctx.Done():
-		return s.data, s.response, ErrContextCanceled
-	case <-s.inSync:
-	}
-
-	// s.data, s.response, s.err are modified with the s.mu write lock
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	return s.data, s.response, s.err
+func (d SecurityGroupAdaptor) Kind() string {
+	return "security-group"
 }
 
-func (s *ApiListSecurityGroupsInformer) readStream(lastRevision int32) {
-	isInSync := false
-
-	defer func() {
-		s.mu.Lock()
-		err := s.stream.Close()
-		if err != nil {
-			s.err = err
-		}
-		s.stream = nil
-		s.mu.Unlock()
-		if !isInSync {
-			isInSync = true
-			close(s.inSync)
-		}
-	}()
-
-	items := map[string]ModelsSecurityGroup{}
-	for {
-		event, item, err := s.stream.Receive()
-		if err != nil {
-			s.setResult(nil, lastRevision, err)
-			return
-		}
-		switch event {
-		case "change":
-			lastRevision = item.Revision
-			items[item.Id] = item
-			if isInSync {
-				s.setResult(items, lastRevision, nil)
-			}
-		case "delete":
-			lastRevision = item.Revision
-			delete(items, item.Id)
-			if isInSync {
-				s.setResult(items, lastRevision, nil)
-			}
-		case "bookmark":
-			if !isInSync {
-				isInSync = true
-				s.setResult(items, lastRevision, nil)
-				close(s.inSync)
-			}
-		case "close":
-			return
-		case "error":
-			return
-		default:
-			s.setResult(nil, lastRevision, fmt.Errorf("unknown event type: %s", event))
-			return
-		}
-	}
+func (d SecurityGroupAdaptor) Item(value map[string]interface{}) (ModelsSecurityGroup, error) {
+	item := ModelsSecurityGroup{}
+	err := util.JsonUnmarshal(value, &item)
+	return item, err
 }
-func (s *ApiListSecurityGroupsInformer) setResult(data map[string]ModelsSecurityGroup, lastRevision int32, err error) {
-	s.mu.Lock()
-	s.data = data
-	s.err = err
-	s.lastRevision = lastRevision
-	s.mu.Unlock()
 
-	select {
-	// try to signal...
-	case s.modifiedSignal <- struct{}{}:
-	default: // so we don't block if a signal is pending.
-	}
-}
+var _ InformerAdaptor[ModelsSecurityGroup] = &SecurityGroupAdaptor{}

--- a/internal/api/public/model_models_watch.go
+++ b/internal/api/public/model_models_watch.go
@@ -12,6 +12,7 @@ package public
 
 // ModelsWatch struct for ModelsWatch
 type ModelsWatch struct {
+	AtTail     bool                   `json:"at_tail,omitempty"`
 	GtRevision int32                  `json:"gt_revision,omitempty"`
 	Kind       string                 `json:"kind,omitempty"`
 	Options    map[string]interface{} `json:"options,omitempty"`

--- a/internal/docs/docs.go
+++ b/internal/docs/docs.go
@@ -1223,7 +1223,7 @@ const docTemplate = `{
                 "operationId": "WatchEvents",
                 "parameters": [
                     {
-                        "description": "List if events to watch",
+                        "description": "List of events to watch",
                         "name": "Watches",
                         "in": "body",
                         "required": true,

--- a/internal/docs/docs.go
+++ b/internal/docs/docs.go
@@ -2531,6 +2531,9 @@ const docTemplate = `{
         "models.Watch": {
             "type": "object",
             "properties": {
+                "at_tail": {
+                    "type": "boolean"
+                },
                 "gt_revision": {
                     "type": "integer"
                 },

--- a/internal/docs/swagger.json
+++ b/internal/docs/swagger.json
@@ -2523,6 +2523,9 @@
         "models.Watch": {
             "type": "object",
             "properties": {
+                "at_tail": {
+                    "type": "boolean"
+                },
                 "gt_revision": {
                     "type": "integer"
                 },

--- a/internal/docs/swagger.json
+++ b/internal/docs/swagger.json
@@ -1215,7 +1215,7 @@
                 "operationId": "WatchEvents",
                 "parameters": [
                     {
-                        "description": "List if events to watch",
+                        "description": "List of events to watch",
                         "name": "Watches",
                         "in": "body",
                         "required": true,

--- a/internal/docs/swagger.yaml
+++ b/internal/docs/swagger.yaml
@@ -1190,7 +1190,7 @@ paths:
       description: Watches events occurring in the organization
       operationId: WatchEvents
       parameters:
-      - description: List if events to watch
+      - description: List of events to watch
         in: body
         name: Watches
         required: true

--- a/internal/docs/swagger.yaml
+++ b/internal/docs/swagger.yaml
@@ -362,6 +362,8 @@ definitions:
     type: object
   models.Watch:
     properties:
+      at_tail:
+        type: boolean
       gt_revision:
         type: integer
       kind:

--- a/internal/handlers/events.go
+++ b/internal/handlers/events.go
@@ -23,14 +23,14 @@ type Watch struct {
 	atTail     bool
 }
 
-// WatchEvents lists all devices in an Organization
+// WatchEvents lets you watch for resource change events
 // @Summary      Watch events occurring in the organization
 // @Description  Watches events occurring in the organization
 // @Id           WatchEvents
 // @Tags         Organizations
 // @Accept       json
 // @Produce      json
-// @Param        Watches         body   []models.Watch  true "List if events to watch"
+// @Param        Watches         body   []models.Watch  true "List of events to watch"
 // @Param		 organization_id path   string          true "Organization ID"
 // @Success      200  {object}  models.WatchEvent
 // @Failure      400  {object}  models.BaseError

--- a/internal/handlers/stream.go
+++ b/internal/handlers/stream.go
@@ -59,7 +59,7 @@ func (api *API) sendListOrWatch(c *gin.Context, ctx context.Context, signal stri
 				if err != nil {
 					return models.WatchEvent{
 						Type:  "error",
-						Value: err.Error(),
+						Value: models.NewApiInternalError(err),
 					}
 				}
 				if list != nil && idx < list.Len() {
@@ -148,6 +148,8 @@ func stream(c *gin.Context, nextEvent func() models.WatchEvent) {
 		c.JSON(http.StatusInternalServerError, models.NewApiInternalError(fmt.Errorf("streaming unsupported")))
 		return
 	}
+	c.Writer.WriteHeader(200)
+	c.Writer.Flush()
 	for {
 		result := nextEvent()
 		if result.Type == "close" {

--- a/internal/models/watch_event.go
+++ b/internal/models/watch_event.go
@@ -4,6 +4,7 @@ package models
 type Watch struct {
 	Kind       string                 `json:"kind,omitempty"`
 	GtRevision uint64                 `json:"gt_revision,omitempty"`
+	AtTail     bool                   `json:"at_tail,omitempty"`
 	Options    map[string]interface{} `json:"options,omitempty"`
 }
 

--- a/internal/util/json.go
+++ b/internal/util/json.go
@@ -1,0 +1,19 @@
+package util
+
+import "encoding/json"
+
+func JsonUnmarshal(from map[string]interface{}, to interface{}) error {
+	b, err := json.Marshal(from)
+	if err != nil {
+		return err
+	}
+	return json.Unmarshal(b, to)
+}
+
+func MustJsonMarshalToString(x interface{}) string {
+	bs, err := json.Marshal(x)
+	if err != nil {
+		panic(err)
+	}
+	return string(bs)
+}


### PR DESCRIPTION
Depends on #1382, this provides a shared informer so that a single REST api call can be used to watch multiple types of events like device or security group changes.