### PR TITLE
Add elevated privileges check at nexd runtime

### DIFF
--- a/internal/nexodus/nexodus.go
+++ b/internal/nexodus/nexodus.go
@@ -247,6 +247,14 @@ func NewNexodus(
 		},
 	}
 	ax.userspaceMode = userspaceMode
+
+	if !ax.userspaceMode {
+		isOk, err := isElevated()
+		if !isOk {
+			return nil, err
+		}
+	}
+
 	ax.tunnelIface = ax.defaultTunnelDev()
 
 	if ax.relay {

--- a/internal/nexodus/utils_darwin.go
+++ b/internal/nexodus/utils_darwin.go
@@ -142,3 +142,11 @@ func isIPv6Supported() bool {
 
 	return true
 }
+
+// isElevatedUnix checks that nexd was started with appropriate permissions for Unix-based OS mode (Linux/macOS)
+func isElevated() (bool, error) {
+	if os.Geteuid() != 0 {
+		return false, fmt.Errorf("nexd OS mode requires elevated privileges, please run again with sudo")
+	}
+	return true, nil
+}

--- a/internal/nexodus/utils_linux.go
+++ b/internal/nexodus/utils_linux.go
@@ -219,3 +219,11 @@ func isIPv6Supported() bool {
 
 	return true
 }
+
+// isElevatedUnix checks that nexd was started with appropriate permissions for Unix-based OS mode (Linux/macOS)
+func isElevated() (bool, error) {
+	if os.Geteuid() != 0 {
+		return false, fmt.Errorf("nexd OS mode requires elevated privileges, please run again with sudo")
+	}
+	return true, nil
+}

--- a/internal/nexodus/utils_windows.go
+++ b/internal/nexodus/utils_windows.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"fmt"
 	"net"
+	"os"
 	"os/exec"
 	"strings"
 
@@ -98,4 +99,13 @@ func isIPv6Supported() bool {
 	}
 
 	return true
+}
+
+// isElevatedWindows checks that nexd was started with appropriate permissions for Windows OS mode
+func isElevated() (bool, error) {
+	_, err := os.Open("\\\\.\\PHYSICALDRIVE0")
+	if err != nil {
+		return false, fmt.Errorf("nexd OS mode requires elevated privileges, please run again with administrative privileges")
+	}
+	return true, nil
 }


### PR DESCRIPTION
- Currently, the only indication we give that the user is running without elevated privleges is throwing a fatal that nexd doesn't have permissions to create a directory. This adds an early check for administrator/root for OS mode.