### PR TITLE
rpm: drop aarch64 rpm build for epel9

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -145,9 +145,6 @@ jobs:
           - mock_root: centos-stream+epel-9-x86_64
             srpm_mock_root: centos-stream+epel-9-x86_64
             srpm_distro: el9
-          - mock_root: centos-stream+epel-9-aarch64
-            srpm_mock_root: centos-stream+epel-9-x86_64
-            srpm_distro: el9
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
This isn't working, and it looks like nobody uses it anyway. Just drop
it for now.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
