### PR TITLE
Bump node and buildx

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,6 +10,7 @@ jobs:
   build-images:
     name: Build Images
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     environment: image-repositories
     strategy:
       matrix:
@@ -48,10 +49,10 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
 
       - name: Setup Docker buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to Quay.io
         uses: redhat-actions/podman-login@v1

--- a/Containerfile.frontend
+++ b/Containerfile.frontend
@@ -1,4 +1,4 @@
-FROM docker.io/library/node:16-alpine AS builder
+FROM docker.io/library/node:current-alpine3.18 AS builder
 
 WORKDIR /app
 


### PR DESCRIPTION
Trying to get frontend-image to work in the arm64 build that is failing in deploy. Also sets a 90m timeout since the build is running the full default 360m (6hrs) until bailing.