### PR TITLE
Add utility script to check nexd status of all the

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,4 +55,4 @@ site/
 
 # scale test temp files
 hack/e2e-scripts/kctool/kctool
-hack/e2e-scripts/nexd-init.sh
+hack/e2e-scripts/scale/nexd-init.sh

--- a/hack/e2e-scripts/scale/check-connectivity.sh
+++ b/hack/e2e-scripts/scale/check-connectivity.sh
@@ -26,9 +26,11 @@ print_usage() {
 # Parse command line arguments
 while getopts "d" opt; do
     case $opt in
-        d) print_wg=true ;;
-        \?) echo "Invalid option: -$OPTARG" >&2
-            print_usage ;;
+    d) print_wg=true ;;
+    \?)
+        echo "Invalid option: -$OPTARG" >&2
+        print_usage
+        ;;
     esac
 done
 
@@ -37,29 +39,29 @@ total_orgs=0
 
 # Loop through each container
 for container_id in $container_ids; do
-    total_nexd=$((total_nexd + 1 ))
+    total_nexd=$((total_nexd + 1))
 
     # Get the value of the "user" label for this container
     label_value=$(docker inspect --format '{{ index .Config.Labels "user" }}' $container_id)
 
     # If the label exists and the value is not in the encountered_labels array
     if [ ! -z "$label_value" ] && [[ ! " ${encountered_labels[@]} " =~ " $label_value " ]]; then
-	total_orgs=$((total_orgs + 1))
+        total_orgs=$((total_orgs + 1))
         # Add the label value to the encountered_labels array
         encountered_labels+=("$label_value")
 
-	peers=$(docker  exec -it $container_id wg show wg0 dump |grep -v "off"| wc -l)
-	unreachable=$(docker exec $container_id nexctl nexd peers ping| grep "Unreachable"| wc -l)
+        peers=$(docker exec -it $container_id wg show wg0 dump | grep -v "off" | wc -l)
+        unreachable=$(docker exec $container_id nexctl nexd peers ping | grep "Unreachable" | wc -l)
         # Print the container ID
-	if [ $unreachable -gt 0 ]; then
-		echo -e "container-id: $container_id    user:$label_value    peers:$peers    \e[91munreachable:$unreachable\e[0m"
-	else
-		echo -e "container-id: $container_id    user:$label_value    peers:$peers    \e[32munreachable:$unreachable\e[0m"
-	fi
+        if [ $unreachable -gt 0 ]; then
+            echo -e "container-id: $container_id    user:$label_value    peers:$peers    \e[91munreachable:$unreachable\e[0m"
+        else
+            echo -e "container-id: $container_id    user:$label_value    peers:$peers    \e[32munreachable:$unreachable\e[0m"
+        fi
 
-	if [ "$print_wg" = true ]; then
-		docker exec -it $container_id wg show wg0 dump
-	fi
+        if [ "$print_wg" = true ]; then
+            docker exec -it $container_id wg show wg0 dump
+        fi
     fi
 done
 

--- a/hack/e2e-scripts/scale/check-errors.sh
+++ b/hack/e2e-scripts/scale/check-errors.sh
@@ -18,9 +18,11 @@ print_usage() {
 # Parse command line arguments
 while getopts "l" opt; do
     case $opt in
-        l) print_log=true ;;
-        \?) echo "Invalid option: -$OPTARG" >&2
-            print_usage ;;
+    l) print_log=true ;;
+    \?)
+        echo "Invalid option: -$OPTARG" >&2
+        print_usage
+        ;;
     esac
 done
 
@@ -43,17 +45,17 @@ for container_id in $container_ids; do
     error_stun=$(echo "$logs" | grep -ci "STUN")
     error_timeout=$(echo "$logs" | grep -c "timeout")
     known_error=$((error_400 + error_401 + error_429 + error_500 + error_501 + error_503 + error_json + error_eof + error_stun + error_timeout))
-    error_count=$(echo "$logs" | grep -v '^$'| wc -l)
+    error_count=$(echo "$logs" | grep -v '^$' | wc -l)
 
     if [ "$error_count" -gt 0 ]; then
-	    if [ "$error_count" -eq "$known_error" ]; then
-		    echo -e "$container_id\t$user_id\t\t$error_count\t $error_json\t $error_eof\t $error_stun\t $error_timeout\t $error_400\t $error_401\t $error_429\t $error_500\t $error_501\t $error_503\t \e[32mNo\e[0m"
-	    else
-		echo -e "$container_id\t$user_id\t\t$error_count\t $error_json\t $error_eof\t $error_stun\t $error_timeout\t $error_400\t $error_401\t $error_429\t $error_500\t $error_501\t $error_503\t \e[91mYes\e[0m"
-	    fi
+        if [ "$error_count" -eq "$known_error" ]; then
+            echo -e "$container_id\t$user_id\t\t$error_count\t $error_json\t $error_eof\t $error_stun\t $error_timeout\t $error_400\t $error_401\t $error_429\t $error_500\t $error_501\t $error_503\t \e[32mNo\e[0m"
+        else
+            echo -e "$container_id\t$user_id\t\t$error_count\t $error_json\t $error_eof\t $error_stun\t $error_timeout\t $error_400\t $error_401\t $error_429\t $error_500\t $error_501\t $error_503\t \e[91mYes\e[0m"
+        fi
 
-	    if [ "$print_log" = true ]; then
-	    	echo "$logs"
-	    fi
+        if [ "$print_log" = true ]; then
+            echo "$logs"
+        fi
     fi
 done

--- a/hack/e2e-scripts/scale/check-nexd-status.sh
+++ b/hack/e2e-scripts/scale/check-nexd-status.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+# Script picks the containers in each org/user and
+# check the status of the nexd agent. By default it
+# prints only the agent that is not running.
+
+# Array to store encountered label values
+encountered_labels=()
+
+# Get a list of all container IDs that is currently running.
+container_ids=$(docker ps -q)
+
+# Print status of all the containers
+print_all=false
+
+print_usage() {
+	echo "Usage: $0 [-v]"a
+	echo "  -v    Print nexd status for all the containers"
+	exit 1
+}
+
+# Parse command line arguments
+while getopts "d" opt; do
+	case $opt in
+	d) print_wg=true ;;
+	\?)
+		echo "Invalid option: -$OPTARG" >&2
+		print_usage
+		;;
+	esac
+done
+
+total_nexd=0
+total_nexd_failed=0
+total_orgs=0
+
+# Loop through each container
+for container_id in $container_ids; do
+	total_nexd=$((total_nexd + 1))
+
+	# Get the value of the "user" label for this container
+	label_value=$(docker inspect --format '{{ index .Config.Labels "user" }}' $container_id)
+
+	# If the label exists and the value is not in the encountered_labels array
+	if [ ! -z "$label_value" ] && [[ ! " ${encountered_labels[@]} " =~ " $label_value " ]]; then
+		total_orgs=$((total_orgs + 1))
+		# Add the label value to the encountered_labels array
+		encountered_labels+=("$label_value")
+		nexds=$(docker ps --filter "label=user=$label_value" --format "{{.ID}}")
+
+		nexd_count=$(echo $nexds | wc -w)
+		not_running=0
+		# loop through each container in the org
+		for nexd in $nexds; do
+			# check if the nexd agent is running
+			if [ "$(docker exec $nexd nexctl nexd status | grep "Running" | wc -l)" -eq 0 ]; then
+				echo -e "container-id: $nexd    user:$label_value    \e[91m Not Running\e[0m"
+				not_running=$((not_running + 1))
+			else
+				if [ "$print_all" = true ]; then
+					echo -e "container-id: $nexd    user:$label_value    \e[32m Running\e[0m"
+				fi
+			fi
+		done
+		total_nexd_failed=$((total_nexd_failed + not_running))
+		echo -e "\e[92m org: $label_value       total-nexd:$nexd_count      Running: $((nexd_count - not_running))     Failed: $not_running\e[0m"
+	fi
+done
+
+echo -e "\e[92m total-orgs: $total_orgs       total-nexd:$total_nexd       total-nexd-failed: $total_nexd_failed \e[0m"


### PR DESCRIPTION
nexd agent onboarded across the organizations.
Useful when you have >1K containers running and want to detect how many devices/nexd didn't onboard successfully.