### PR TITLE
Keycloak needs atleast default memory/cpu

### DIFF
--- a/deploy/nexodus/base/auth/deployment.yaml
+++ b/deploy/nexodus/base/auth/deployment.yaml
@@ -97,11 +97,11 @@ spec:
                   optional: true
           resources:
             requests:
-              cpu: 200m
-              memory: 400Mi
+              cpu: 500m
+              memory: 1000Mi
             limits:
-              cpu: 200m
-              memory: 400Mi
+              cpu: 500m
+              memory: 1000Mi
           ports:
             - name: http
               containerPort: 8080


### PR DESCRIPTION
During scale testing in playground namespace the value were set to minimum, and playground overwrote it with high value. Prod/Qa doesn't overwrite the value, so keycloak atleast needs default cpu/memory limits to run.