### PR TITLE
Update playground/qa manifest to adopt changes from latest kustomize release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -201,6 +201,8 @@ dist/.k8s-lint: $(shell find deploy -type f ) | dist
 	$(CMD_PREFIX) mkdir -p ./dist/kubeconfigs
 	$(CMD_PREFIX) kustomize build ./deploy/nexodus/overlays/dev > ./dist/kubeconfigs/dev.yaml
 	$(CMD_PREFIX) kustomize build ./deploy/nexodus/overlays/prod > ./dist/kubeconfigs/prod.yaml
+	$(CMD_PREFIX) kustomize build ./deploy/nexodus/overlays/qa > ./dist/kubeconfigs/qa.yaml
+	$(CMD_PREFIX) kustomize build ./deploy/nexodus/overlays/playground > ./dist/kubeconfigs/playground.yaml
 	$(CMD_PREFIX) kubeconform -summary -output json -schema-location default -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json' -schema-location 'deploy/.crdSchemas/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json' ./dist/kubeconfigs/
 	$(CMD_PREFIX) touch $@
 

--- a/deploy/nexodus/components/limitador/kustomization.yaml
+++ b/deploy/nexodus/components/limitador/kustomization.yaml
@@ -3,7 +3,3 @@ kind: Component
 resources:
   - limitador-deployment.yaml
   - limitador-service.yaml
-configMapGenerator:
-  - files:
-      - files/limits.yaml
-    name: limitador-config

--- a/deploy/nexodus/components/promtail/kustomization.yaml
+++ b/deploy/nexodus/components/promtail/kustomization.yaml
@@ -1,9 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1alpha1
 kind: Component
-configMapGenerator:
-  - name: promtail-config
-    files:
-      - files/promtail.yaml
 resources:
   - promtail-serviceaccount.yaml
   - promtail-role.yaml

--- a/deploy/nexodus/overlays/dev/files/promtail.yaml
+++ b/deploy/nexodus/overlays/dev/files/promtail.yaml
@@ -1,0 +1,51 @@
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 0
+
+clients:
+  - url: http://loki.nexodus-monitoring.svc.cluster.local:3100/loki/api/v1/push
+
+positions:
+  filename: /tmp/positions.yaml
+target_config:
+  sync_period: 10s
+scrape_configs:
+  - job_name: pod-logs
+    kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names:
+            - nexodus
+    pipeline_stages:
+      - cri: {}
+    relabel_configs:
+      - source_labels:
+          - __meta_kubernetes_pod_node_name
+        target_label: __host__
+      - action: labelmap
+        regex: __meta_kubernetes_pod_label_(.+)
+      - action: replace
+        replacement: $1
+        separator: /
+        source_labels:
+          - __meta_kubernetes_namespace
+          - __meta_kubernetes_pod_name
+        target_label: job
+      - action: replace
+        source_labels:
+          - __meta_kubernetes_namespace
+        target_label: namespace
+      - action: replace
+        source_labels:
+          - __meta_kubernetes_pod_name
+        target_label: pod
+      - action: replace
+        source_labels:
+          - __meta_kubernetes_pod_container_name
+        target_label: container
+      - replacement: /var/log/pods/*$1/*.log
+        separator: /
+        source_labels:
+          - __meta_kubernetes_pod_uid
+          - __meta_kubernetes_pod_container_name
+        target_label: __path__

--- a/deploy/nexodus/overlays/dev/kustomization.yaml
+++ b/deploy/nexodus/overlays/dev/kustomization.yaml
@@ -6,7 +6,7 @@ resources:
 components:
   - ../../components/promtail
 # Uncomment this to enable rate limiting
-#  - ../../components/promtail
+#  - ../../components/limitador
 namespace: nexodus
 secretGenerator:
   - name: auth-secrets
@@ -24,6 +24,10 @@ configMapGenerator:
     literals:
       - ENVOY_COMP_LOG_LEVEL=upstream:info,http:debug,router:debug,jwt:debug
     name: apiproxy
+  - behavior: create
+    files:
+      - files/promtail.yaml
+    name: promtail-config
 patches:
   - target:
       kind: Ingress

--- a/deploy/nexodus/overlays/playground/kustomization.yaml
+++ b/deploy/nexodus/overlays/playground/kustomization.yaml
@@ -6,7 +6,6 @@ resources:
   - sealed-secret.yaml
   - serviceaccount.yaml
 components:
-  #  - ../../components/promtail
   - ../../components/limitador
 namespace: nexodus-playground
 configMapGenerator:
@@ -19,7 +18,7 @@ configMapGenerator:
     files:
       - files/nexodus.json
     name: realm
-  - behavior: replace
+  - behavior: create
     files:
       - files/limits.yaml
     name: limitador-config
@@ -27,10 +26,6 @@ configMapGenerator:
     files:
       - files/envoy.yaml
     name: apiproxy-envoy-config
-  #  - behavior: replace
-  #    files:
-  #      - files/promtail.yaml
-  #    name: promtail-config
   - behavior: merge
     literals:
       - APIPROXY_OIDC_URL=https://auth.playground.nexodus.io/realms/nexodus

--- a/deploy/nexodus/overlays/qa/kustomization.yaml
+++ b/deploy/nexodus/overlays/qa/kustomization.yaml
@@ -19,7 +19,7 @@ configMapGenerator:
     files:
       - files/nexodus.json
     name: realm
-  - behavior: replace
+  - behavior: create
     files:
       - files/limits.yaml
     name: limitador-config
@@ -27,7 +27,7 @@ configMapGenerator:
     files:
       - files/envoy.yaml
     name: apiproxy-envoy-config
-  - behavior: replace
+  - behavior: create
     files:
       - files/promtail.yaml
     name: promtail-config


### PR DESCRIPTION
Kustomize release 5.1.0 (our CI job uses this version) made the changes in the order of processing of resources, components , generators and transformers. That requires that our top level kustomization yamls should create the configmaps, rather than replace it, because with 5.1.0, components will be processed after generators, so there won't be any existing configmap to replace.

Following issue has more details about it:
https://github.com/kubernetes-sigs/kustomize/pull/5170