### PR TITLE
fix: don’t use the gorm Scopes() method, it’s behavior is more complex than we realized.

### DIFF
--- a/internal/handlers/events.go
+++ b/internal/handlers/events.go
@@ -58,9 +58,9 @@ func (api *API) WatchEvents(c *gin.Context) {
 	}
 
 	var org models.Organization
-	result := api.db.WithContext(ctx).
-		Scopes(api.OrganizationIsReadableByCurrentUser(c)).
-		First(&org, "id = ?", orgId.String())
+	db := api.db.WithContext(ctx)
+	db = api.OrganizationIsReadableByCurrentUser(c, db)
+	result := db.First(&org, "id = ?", orgId.String())
 
 	if result.Error != nil {
 		if errors.Is(result.Error, gorm.ErrRecordNotFound) {


### PR DESCRIPTION
this also lets up bump the gorm version and still pass the unit tests.

We wanted all the db middleware passed to the scopes method to always get applied, but it seems there are edge cases where the they are not always applied. 