### PR TITLE
fix: avoid ‘net/http: timeout awaiting response headers’ in nexd

### DIFF
--- a/internal/handlers/events.go
+++ b/internal/handlers/events.go
@@ -333,6 +333,8 @@ func stream(c *gin.Context, nextEvent func() models.WatchEvent) {
 		c.JSON(http.StatusInternalServerError, models.NewApiInternalError(fmt.Errorf("streaming unsupported")))
 		return
 	}
+	c.Writer.WriteHeader(200)
+	flusher.Flush()
 	for {
 		result := nextEvent()
 		if result.Type == "close" {


### PR DESCRIPTION
Flush the response headers in the event stream before waiting for the next event.