### PR TITLE
systemd: Fix support for multiple nexd arguments

### DIFF
--- a/contrib/debian/nexodus.conf
+++ b/contrib/debian/nexodus.conf
@@ -6,7 +6,6 @@
 #   https://try.nexodus.127.0.0.1.nip.io -- when using the development environment
 #   https://try.nexodus.io -- when using the project's hosted instance
 #
-# If additional arguments are needed, add them prior to the URL.
 #
-#NEXD_ARGS="https://try.nexodus.127.0.0.1.nip.io"
-NEXD_ARGS="https://try.nexodus.io"
+#NEXD_ARGS="--service-url https://try.nexodus.127.0.0.1.nip.io"
+NEXD_ARGS="--service-url https://try.nexodus.io"

--- a/contrib/debian/nexodus.service
+++ b/contrib/debian/nexodus.service
@@ -9,7 +9,7 @@ Restart=always
 RestartSec=1
 User=root
 EnvironmentFile=/etc/default/nexodus
-ExecStart=/usr/bin/nexd ${NEXD_ARGS}
+ExecStart=/bin/sh -c '/usr/bin/nexd $${NEXD_ARGS}'
 
 [Install]
 WantedBy=multi-user.target

--- a/contrib/rpm/nexodus.service
+++ b/contrib/rpm/nexodus.service
@@ -9,7 +9,7 @@ Restart=always
 RestartSec=1
 User=root
 EnvironmentFile=/etc/sysconfig/nexodus
-ExecStart=/usr/bin/nexd ${NEXD_ARGS}
+ExecStart=/bin/sh -c '/usr/bin/nexd $${NEXD_ARGS}'
 
 [Install]
 WantedBy=multi-user.target

--- a/contrib/rpm/nexodus.sysconfig
+++ b/contrib/rpm/nexodus.sysconfig
@@ -6,7 +6,6 @@
 #   https://try.nexodus.127.0.0.1.nip.io -- when using the development environment
 #   https://try.nexodus.io -- when using the project's hosted instance
 #
-# If additional arguments are needed, add them prior to the URL.
 #
-#NEXD_ARGS="https://try.nexodus.127.0.0.1.nip.io"
-NEXD_ARGS="https://try.nexodus.io"
+#NEXD_ARGS="--service-url https://try.nexodus.127.0.0.1.nip.io"
+NEXD_ARGS="--service-url https://try.nexodus.io"


### PR DESCRIPTION
The way args were passed to `nexd` made it so all arguments were
passed as a single argument to the process. This change makes it work
as expected.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
