### PR TITLE
localip: drop nexodus dependency

### DIFF
--- a/hack/localip/main.go
+++ b/hack/localip/main.go
@@ -2,13 +2,35 @@ package main
 
 import (
 	"fmt"
+	"net"
 	"os"
-
-	"github.com/nexodus-io/nexodus/internal/nexodus"
 )
 
+func LocalIPv4Address() net.IP {
+	interfaces, _ := net.Interfaces()
+	for _, inter := range interfaces {
+		addrs, err := inter.Addrs()
+		if err != nil {
+			continue
+		}
+		for _, addr := range addrs {
+			switch ip := addr.(type) {
+			case *net.IPNet:
+				if ip.IP.IsLoopback() {
+					continue
+				}
+				if ip.IP.DefaultMask() == nil {
+					continue
+				}
+				return ip.IP
+			}
+		}
+	}
+	return nil
+}
+
 func main() {
-	ip := nexodus.LocalIPv4Address()
+	ip := LocalIPv4Address()
 	if ip == nil {
 		fmt.Fprintln(os.Stderr, "ip not found")
 		os.Exit(1)


### PR DESCRIPTION
This utility depended on nexodus, but for some reason this breaks the
build for me at the moment on mac. It's harmless enough to just copy
in the code we use here. This lets me move on and still run `make
run-nexd-container` on mac for the moment.

Signed-off-by: Russell Bryant <russell.bryant@gmail.com>
