### PR TITLE
nexd: dynamic peering

### DIFF
--- a/cmd/nexctl/connectivity.go
+++ b/cmd/nexctl/connectivity.go
@@ -47,8 +47,8 @@ func cmdConnStatus(cCtx *cli.Context, family string) error {
 
 	if err == nil {
 		w := newTabWriter()
-		fs := "%s\t%s\t%s\t%s\n"
-		fmt.Fprintf(w, fs, "HOSTNAME", "WIREGUARD ADDRESS", "LATENCY", "CONNECTION STATUS")
+		fs := "%s\t%s\t%s\t%s\t%s\n"
+		fmt.Fprintf(w, fs, "HOSTNAME", "WIREGUARD ADDRESS", "LATENCY", "CONNECTION STATUS", "PEERING METHOD")
 
 		keys := make([]string, 0, len(result))
 		for k := range result {
@@ -65,7 +65,7 @@ func cmdConnStatus(cCtx *cli.Context, family string) error {
 			if v.IsReachable {
 				status = fmt.Sprintf("%s Reachable", checkmark)
 			}
-			fmt.Fprintf(w, fs, v.Hostname, k, v.Latency, status) // Added v.Latency to the output
+			fmt.Fprintf(w, fs, v.Hostname, k, v.Latency, status, v.Method) // Added v.Latency to the output
 		}
 
 		w.Flush()

--- a/internal/nexodus/keepalive.go
+++ b/internal/nexodus/keepalive.go
@@ -28,6 +28,7 @@ type KeepaliveStatus struct {
 	IsReachable bool   `json:"is_reachable"`
 	Hostname    string `json:"hostname"`
 	Latency     string `json:""`
+	Method      string `json:"method"`
 }
 
 func (nx *Nexodus) runProbe(peerStatus KeepaliveStatus, c chan struct {
@@ -45,6 +46,7 @@ func (nx *Nexodus) runProbe(peerStatus KeepaliveStatus, c chan struct {
 				WgIP:     peerStatus.WgIP,
 				Hostname: peerStatus.Hostname,
 				Latency:  "-",
+				Method:   peerStatus.Method,
 			},
 			IsReachable: false,
 		}
@@ -57,6 +59,7 @@ func (nx *Nexodus) runProbe(peerStatus KeepaliveStatus, c chan struct {
 				WgIP:     peerStatus.WgIP,
 				Hostname: peerStatus.Hostname,
 				Latency:  latency,
+				Method:   peerStatus.Method,
 			},
 			IsReachable: true,
 		}

--- a/internal/nexodus/wg.go
+++ b/internal/nexodus/wg.go
@@ -158,15 +158,23 @@ func (nx *Nexodus) handlePeerDelete(peerMap map[string]public.ModelsDevice) erro
 			continue
 		}
 
-		nx.logger.Debugf("Deleting peer with key: %s\n", nx.deviceCache[p.device.PublicKey])
-		if err := nx.deletePeer(p.device.PublicKey, nx.tunnelIface); err != nil {
-			return fmt.Errorf("failed to delete peer: %w", err)
+		if err := nx.peerCleanup(p.device); err != nil {
+			return err
 		}
-		// delete the peer route(s)
-		nx.handlePeerRouteDelete(nx.tunnelIface, p.device)
 		// remove peer from local peer and key cache
 		delete(nx.deviceCache, p.device.PublicKey)
 	}
+
+	return nil
+}
+
+func (nx *Nexodus) peerCleanup(peer public.ModelsDevice) error {
+	nx.logger.Debugf("Deleting peering config for key: %s\n", peer.PublicKey)
+	if err := nx.deletePeer(peer.PublicKey, nx.tunnelIface); err != nil {
+		return fmt.Errorf("failed to delete peer: %w", err)
+	}
+	// delete the peer route(s)
+	nx.handlePeerRouteDelete(nx.tunnelIface, peer)
 
 	return nil
 }

--- a/ops/ansible/aws/validate-connectivity/tasks/main.yml
+++ b/ops/ansible/aws/validate-connectivity/tasks/main.yml
@@ -31,6 +31,8 @@
     printf "====== Connectivity Results from Node: {{ inventory_hostname }} ======\n" > {{ inventory_hostname }}-connectivity-results.txt
     printf "IPv4 tunnel IP: " >> {{ inventory_hostname }}-connectivity-results.txt
     nexctl nexd get tunnelip >> {{ inventory_hostname }}-connectivity-results.txt
+    printf "hostname: " >> {{ inventory_hostname }}-connectivity-results.txt
+    hostname >> {{ inventory_hostname }}-connectivity-results.txt
     nexctl nexd peers ping
     nexctl nexd peers ping >> {{ inventory_hostname }}-connectivity-results.txt 2>&1
     nexctl nexd peers ping6 >> {{ inventory_hostname }}-connectivity-results.txt 2>&1


### PR DESCRIPTION
The most common scenario addressed by this change is that after
failing to peer via a peer's local IP or reflexive IP, we can fall
back to using a relay if one is available.

More generally, these changes give a chosen peering method a chance to
work and then fall back to alternative methods. For more examples:

- An attempt to peer via local IP will fall back to peering via 
  reflexive IP

- An attempt to peer via reflexive IP will fall back to using a relay.

- If there is not currently a healthy relay available, it will fall
  back to the beginning and choose the first available method to try 

These retries will keep going until something works, or it will stay
with the relay if one is available. When using a relay, other methods
will be retried after the API sends us changes to a device that
impact peering configuration.

All of this is based on peering health inferred via wireguard stats,
not testing connectivity to each device via ICMP or something else.

Closes #965
Closes #1322

Signed-off-by: Russell Bryant <rbryant@redhat.com>