### PR TITLE
ci(Mergify): configuration update

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -16,12 +16,10 @@ pull_request_rules:
       - base=main
       - label!=hold
       - check-success=DCO
+      - -check-failure=Mixed content - nexodus-docs
       - or:
         - check-success=Header rules - nexodus-docs
         - check-neutral=Header rules - nexodus-docs
-      - or:
-        - check-success=Mixed content - nexodus-docs
-        - check-neutral=Mixed content - nexodus-docs
       - or:
         - check-success=Pages changed - nexodus-docs
         - check-neutral=Pages changed - nexodus-docs


### PR DESCRIPTION
This change has been made by @russellb from Mergify config editor.

The "Mixed Content" job from Netlify was not present at all on PR #1430. Instead of checking for success or neutral, switch to just making sure there's not a failure present for this one.