### PR TITLE
deploy: Enable apiserver debug in prod

### DIFF
--- a/deploy/nexodus/overlays/prod/kustomization.yaml
+++ b/deploy/nexodus/overlays/prod/kustomization.yaml
@@ -42,7 +42,6 @@ configMapGenerator:
       - NEXAPI_REDIRECT_URL=https://try.nexodus.io/#/login
       - NEXAPI_ORIGINS=https://try.nexodus.io
       - NEXAPI_ENVIRONMENT=production
-      - NEXAPI_DEBUG=0
     name: apiserver
 
 patches:


### PR DESCRIPTION
I'm getting a 500 error trying to connect a device and there's no
hints in the logs about why. Turn on debug to see if anything else
pops up to help.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
