### PR TITLE
fix: the arm64 overlay to work with recent pgbouncer changes.

### DIFF
--- a/deploy/nexodus/overlays/arm64/kustomization.yaml
+++ b/deploy/nexodus/overlays/arm64/kustomization.yaml
@@ -23,22 +23,22 @@ secretGenerator:
       - PGDATA=/data/pgdata
     name: postgres
   - literals:
-      - host=postgres
-      - port=5432
+      - pgbouncer-host=postgres
+      - pgbouncer-port=5432
       - user=apiserver
       - password=password
       - dbname=apiserver
     name: database-pguser-apiserver
   - literals:
-      - host=postgres
-      - port=5432
+      - pgbouncer-host=postgres
+      - pgbouncer-port=5432
       - user=ipam
       - password=password
       - dbname=ipam
     name: database-pguser-ipam
   - literals:
-      - host=postgres
-      - port=5432
+      - pgbouncer-host=postgres
+      - pgbouncer-port=5432
       - user=keycloak
       - password=password
       - dbname=keycloak


### PR DESCRIPTION
`make run-on-kind` was failing on apple silicon macs.