### PR TITLE
qa-dev: Fix globbing in workflow

### DIFF
--- a/.github/workflows/qa-dev.yml
+++ b/.github/workflows/qa-dev.yml
@@ -133,8 +133,9 @@ jobs:
       - name: Mesh Connectivity Results
         run: |
           set -e
-          cat ./ops/ansible/aws/*-connectivity-results.txt
-          if grep -iq 'Unreachable' ./ops/ansible/aws/*-connectivity-results.txt || grep -iq 'Failed' ./ops/ansible/aws/*-connectivity-results.txt; then
+          /bin/sh -c 'cat ./ops/ansible/aws/*-connectivity-results.txt > ./ops/ansible/aws/mesh-connectivity-results.txt'
+          cat ./ops/ansible/aws/mesh-connectivity-results.txt
+          if grep -iq 'Unreachable' ./ops/ansible/aws/*-connectivity-results.txt || grep -iq 'Failed' ./ops/ansible/aws/mesh-connectivity-results.txt; then
             echo "Connectivity results contain 'Unreachable or Failed' nodes, check the connectivity results and artifacts for details. Failing the job"
             exit 1
           else


### PR DESCRIPTION
The failure showed that the wildcard was not interpreted. Use another
method that will hopefully expand the wildcard.

The failure:

> cat: './ops/ansible/aws/*-connectivity-results.txt': No such file or directory

Signed-off-by: Russell Bryant <rbryant@redhat.com>
