### PR TITLE
nexd: fixes #1426 If your machine's time is set to 15 mins into the future, nexd will fail to login

### DIFF
--- a/internal/api/public/model_models_device_start_response.go
+++ b/internal/api/public/model_models_device_start_response.go
@@ -10,10 +10,16 @@ API version: 1.0
 
 package public
 
+import (
+	"time"
+)
+
 // ModelsDeviceStartResponse struct for ModelsDeviceStartResponse
 type ModelsDeviceStartResponse struct {
 	ClientId string `json:"client_id,omitempty"`
 	// TODO: Remove this once golang/oauth2 supports device flow and when coreos/go-oidc adds device_authorization_endpoint discovery
 	DeviceAuthorizationEndpoint string `json:"device_authorization_endpoint,omitempty"`
 	Issuer                      string `json:"issuer,omitempty"`
+	// the current time on the server, can be used by a client to get an idea of what the time skew is in relation to the server.
+	ServerTime time.Time `json:"server_time,omitempty"`
 }

--- a/internal/docs/docs.go
+++ b/internal/docs/docs.go
@@ -2686,6 +2686,11 @@ const docTemplate = `{
                 },
                 "issuer": {
                     "type": "string"
+                },
+                "server_time": {
+                    "description": "the current time on the server, can be used by a client to get an idea of what the time skew is\nin relation to the server.",
+                    "type": "string",
+                    "format": "date-time"
                 }
             }
         },

--- a/internal/docs/swagger.json
+++ b/internal/docs/swagger.json
@@ -2678,6 +2678,11 @@
                 },
                 "issuer": {
                     "type": "string"
+                },
+                "server_time": {
+                    "description": "the current time on the server, can be used by a client to get an idea of what the time skew is\nin relation to the server.",
+                    "type": "string",
+                    "format": "date-time"
                 }
             }
         },

--- a/internal/docs/swagger.yaml
+++ b/internal/docs/swagger.yaml
@@ -199,6 +199,12 @@ definitions:
         type: string
       issuer:
         type: string
+      server_time:
+        description: |-
+          the current time on the server, can be used by a client to get an idea of what the time skew is
+          in relation to the server.
+        format: date-time
+        type: string
     type: object
   models.Endpoint:
     properties:

--- a/pkg/oidcagent/handlers.go
+++ b/pkg/oidcagent/handlers.go
@@ -491,10 +491,12 @@ func (o *OidcAgent) CheckAuth(c *gin.Context) {
 // @Success     200 {object} models.DeviceStartResponse
 // @Router      /device/login/start [post]
 func (o *OidcAgent) DeviceStart(c *gin.Context) {
+	now := time.Now()
 	c.JSON(http.StatusOK, models.DeviceStartResponse{
 		DeviceAuthURL: o.deviceAuthURL,
 		Issuer:        o.oidcIssuer,
 		ClientID:      o.clientID,
+		ServerTime:    &now,
 	})
 }
 

--- a/pkg/oidcagent/models/models.go
+++ b/pkg/oidcagent/models/models.go
@@ -1,5 +1,7 @@
 package models
 
+import "time"
+
 type LoginStartResponse struct {
 	AuthorizationRequestURL string `json:"authorization_request_url"`
 }
@@ -43,6 +45,9 @@ type DeviceStartResponse struct {
 	DeviceAuthURL string `json:"device_authorization_endpoint"`
 	Issuer        string `json:"issuer"`
 	ClientID      string `json:"client_id"`
+	// the current time on the server, can be used by a client to get an idea of what the time skew is
+	// in relation to the server.
+	ServerTime *time.Time `json:"server_time" format:"date-time"`
 }
 
 type CheckAuthResponse struct {


### PR DESCRIPTION
We now compare the local time with server time to compute if the client needs to adjust for client time skew.