### PR TITLE
Add the online health status to device list in nexctl

### DIFF
--- a/cmd/nexctl/device.go
+++ b/cmd/nexctl/device.go
@@ -3,13 +3,16 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/urfave/cli/v2"
 	"log"
 	"strings"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/nexodus-io/nexodus/internal/api/public"
+	"github.com/urfave/cli/v2"
 )
+
+const LocalTimeFormat = "2006-01-02 15:04:05 MST"
 
 func listOrgDevices(cCtx *cli.Context, c *public.APIClient, organizationID uuid.UUID) error {
 	devices, _, err := c.DevicesApi.ListDevicesInOrganization(context.Background(), organizationID.String()).Execute()
@@ -76,14 +79,25 @@ func deviceTableFields(cCtx *cli.Context) []TableField {
 		fields = append(fields, TableField{Header: "ENDPOINT LOCAL IPv4", Field: "EndpointLocalAddressIp4"})
 		fields = append(fields, TableField{Header: "OS", Field: "Os"})
 		fields = append(fields, TableField{Header: "SECURITY GROUP ID", Field: "SecurityGroupId"})
+		fields = append(fields, TableField{Header: "ONLINE", Field: "Online"})
+		fields = append(fields, TableField{Header: "ONLINE SINCE", Field: "OnlineAt"})
 	}
 	return fields
 }
+
 func listAllDevices(cCtx *cli.Context, c *public.APIClient) error {
 	devices, _, err := c.DevicesApi.ListDevices(context.Background()).Execute()
 	if err != nil {
 		log.Fatal(err)
 	}
+
+	// Only modify the time to a user-friendly value if the nexctl output is in column form
+	if cCtx.String("output") == encodeColumn || cCtx.String("output") == encodeNoHeader {
+		for i := range devices {
+			convertDeviceTimeToLocal(&devices[i])
+		}
+	}
+
 	showOutput(cCtx, deviceTableFields(cCtx), devices)
 	return nil
 }
@@ -110,4 +124,22 @@ func deleteDevice(c *public.APIClient, encodeOut, devID string) error {
 	}
 
 	return nil
+}
+
+// convertToLocalTime converts the OnlineAt field to local time
+func convertDeviceTimeToLocal(d *public.ModelsDevice) {
+	if !d.Online {
+		// If the device is not online, set the time field to empty
+		d.OnlineAt = ""
+		return
+	}
+
+	// Try to parse the time and convert it to local time
+	parsedTime, err := time.Parse(time.RFC3339, d.OnlineAt)
+	if err != nil {
+		return
+	}
+
+	localTime := parsedTime.Local()
+	d.OnlineAt = localTime.Format(LocalTimeFormat)
 }


### PR DESCRIPTION
- Converted to local time as well just as a personal preference.
- If the device is no longer online, clear the field.
- The OnlineAt value is only changed to a user-friendly time for column output mode.
