### PR TITLE
Add token refresh to client side web ui

### DIFF
--- a/internal/api/public/api_auth.go
+++ b/internal/api/public/api_auth.go
@@ -216,6 +216,27 @@ func (a *AuthApiService) ClaimsExecute(r ApiClaimsRequest) (map[string]interface
 			body:  localVarBody,
 			error: localVarHTTPResponse.Status,
 		}
+		if localVarHTTPResponse.StatusCode == 401 {
+			var v string
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarReturnValue, localVarHTTPResponse, newErr
+			}
+			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
+			newErr.model = v
+			return localVarReturnValue, localVarHTTPResponse, newErr
+		}
+		if localVarHTTPResponse.StatusCode == 500 {
+			var v string
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarReturnValue, localVarHTTPResponse, newErr
+			}
+			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
+			newErr.model = v
+		}
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
@@ -416,6 +437,27 @@ func (a *AuthApiService) LogoutExecute(r ApiLogoutRequest) (*ModelsLogoutRespons
 			body:  localVarBody,
 			error: localVarHTTPResponse.Status,
 		}
+		if localVarHTTPResponse.StatusCode == 401 {
+			var v string
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarReturnValue, localVarHTTPResponse, newErr
+			}
+			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
+			newErr.model = v
+			return localVarReturnValue, localVarHTTPResponse, newErr
+		}
+		if localVarHTTPResponse.StatusCode == 500 {
+			var v string
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarReturnValue, localVarHTTPResponse, newErr
+			}
+			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
+			newErr.model = v
+		}
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
@@ -443,7 +485,7 @@ func (r ApiRefreshRequest) Execute() (*http.Response, error) {
 /*
 Refresh Refresh
 
-Refreshes the access token
+Refreshes the access token and updates the session ID
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@return ApiRefreshRequest
@@ -484,7 +526,7 @@ func (a *AuthApiService) RefreshExecute(r ApiRefreshRequest) (*http.Response, er
 	}
 
 	// to determine the Accept header
-	localVarHTTPHeaderAccepts := []string{}
+	localVarHTTPHeaderAccepts := []string{"application/json"}
 
 	// set Accept header
 	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
@@ -513,6 +555,27 @@ func (a *AuthApiService) RefreshExecute(r ApiRefreshRequest) (*http.Response, er
 			body:  localVarBody,
 			error: localVarHTTPResponse.Status,
 		}
+		if localVarHTTPResponse.StatusCode == 401 {
+			var v string
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarHTTPResponse, newErr
+			}
+			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
+			newErr.model = v
+			return localVarHTTPResponse, newErr
+		}
+		if localVarHTTPResponse.StatusCode == 500 {
+			var v string
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarHTTPResponse, newErr
+			}
+			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
+			newErr.model = v
+		}
 		return localVarHTTPResponse, newErr
 	}
 
@@ -529,9 +592,9 @@ func (r ApiUserInfoRequest) Execute() (*ModelsUserInfoResponse, *http.Response, 
 }
 
 /*
-UserInfo User Info
+UserInfo Retrieve User Information
 
-Returns information about the currently logged-in user
+Fetches the information of the currently logged-in user from the OAuth2 provider.
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@return ApiUserInfoRequest
@@ -604,6 +667,27 @@ func (a *AuthApiService) UserInfoExecute(r ApiUserInfoRequest) (*ModelsUserInfoR
 			body:  localVarBody,
 			error: localVarHTTPResponse.Status,
 		}
+		if localVarHTTPResponse.StatusCode == 401 {
+			var v string
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarReturnValue, localVarHTTPResponse, newErr
+			}
+			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
+			newErr.model = v
+			return localVarReturnValue, localVarHTTPResponse, newErr
+		}
+		if localVarHTTPResponse.StatusCode == 500 {
+			var v string
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarReturnValue, localVarHTTPResponse, newErr
+			}
+			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
+			newErr.model = v
+		}
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
@@ -638,7 +722,7 @@ func (r ApiWebEndRequest) Execute() (*ModelsLoginEndResponse, *http.Response, er
 /*
 WebEnd End Web Login
 
-Called auth server redirect to finish the Oauth login
+Handles the callback from the OAuth2 provider and completes the login process.
 
 	@param ctx context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	@return ApiWebEndRequest
@@ -715,6 +799,38 @@ func (a *AuthApiService) WebEndExecute(r ApiWebEndRequest) (*ModelsLoginEndRespo
 		newErr := &GenericOpenAPIError{
 			body:  localVarBody,
 			error: localVarHTTPResponse.Status,
+		}
+		if localVarHTTPResponse.StatusCode == 400 {
+			var v string
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarReturnValue, localVarHTTPResponse, newErr
+			}
+			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
+			newErr.model = v
+			return localVarReturnValue, localVarHTTPResponse, newErr
+		}
+		if localVarHTTPResponse.StatusCode == 401 {
+			var v string
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarReturnValue, localVarHTTPResponse, newErr
+			}
+			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
+			newErr.model = v
+			return localVarReturnValue, localVarHTTPResponse, newErr
+		}
+		if localVarHTTPResponse.StatusCode == 500 {
+			var v string
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarReturnValue, localVarHTTPResponse, newErr
+			}
+			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
+			newErr.model = v
 		}
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
@@ -815,6 +931,16 @@ func (a *AuthApiService) WebStartExecute(r ApiWebStartRequest) (*ModelsLoginStar
 		newErr := &GenericOpenAPIError{
 			body:  localVarBody,
 			error: localVarHTTPResponse.Status,
+		}
+		if localVarHTTPResponse.StatusCode == 500 {
+			var v string
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = err.Error()
+				return localVarReturnValue, localVarHTTPResponse, newErr
+			}
+			newErr.error = formatErrorMessage(localVarHTTPResponse.Status, &v)
+			newErr.model = v
 		}
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}

--- a/internal/docs/docs.go
+++ b/internal/docs/docs.go
@@ -1912,13 +1912,25 @@ const docTemplate = `{
                             "type": "object",
                             "additionalProperties": true
                         }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "string"
+                        }
                     }
                 }
             }
         },
         "/web/login/end": {
             "post": {
-                "description": "Called auth server redirect to finish the Oauth login",
+                "description": "Handles the callback from the OAuth2 provider and completes the login process.",
                 "produces": [
                     "application/json"
                 ],
@@ -1940,9 +1952,27 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "200": {
-                        "description": "OK",
+                        "description": "Login successful",
                         "schema": {
                             "$ref": "#/definitions/models.LoginEndResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request, usually due to state mismatch or other protocol errors",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized, specifically when login is required",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error, including token validation or exchange issues",
+                        "schema": {
+                            "type": "string"
                         }
                     }
                 }
@@ -1965,6 +1995,12 @@ const docTemplate = `{
                         "schema": {
                             "$ref": "#/definitions/models.LoginStartResponse"
                         }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "string"
+                        }
                     }
                 }
             }
@@ -1986,13 +2022,25 @@ const docTemplate = `{
                         "schema": {
                             "$ref": "#/definitions/models.LogoutResponse"
                         }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "string"
+                        }
                     }
                 }
             }
         },
         "/web/refresh": {
             "get": {
-                "description": "Refreshes the access token",
+                "description": "Refreshes the access token and updates the session ID",
                 "produces": [
                     "application/json"
                 ],
@@ -2004,26 +2052,50 @@ const docTemplate = `{
                 "responses": {
                     "204": {
                         "description": "No Content"
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "string"
+                        }
                     }
                 }
             }
         },
         "/web/user_info": {
             "get": {
-                "description": "Returns information about the currently logged-in user",
+                "description": "Fetches the information of the currently logged-in user from the OAuth2 provider.",
                 "produces": [
                     "application/json"
                 ],
                 "tags": [
                     "Auth"
                 ],
-                "summary": "User Info",
+                "summary": "Retrieve User Information",
                 "operationId": "UserInfo",
                 "responses": {
                     "200": {
-                        "description": "OK",
+                        "description": "Successfully retrieved user information",
                         "schema": {
                             "$ref": "#/definitions/models.UserInfoResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized, user not logged in or session expired",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error, during token validation or info retrieval",
+                        "schema": {
+                            "type": "string"
                         }
                     }
                 }

--- a/internal/docs/swagger.json
+++ b/internal/docs/swagger.json
@@ -1904,13 +1904,25 @@
                             "type": "object",
                             "additionalProperties": true
                         }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "string"
+                        }
                     }
                 }
             }
         },
         "/web/login/end": {
             "post": {
-                "description": "Called auth server redirect to finish the Oauth login",
+                "description": "Handles the callback from the OAuth2 provider and completes the login process.",
                 "produces": [
                     "application/json"
                 ],
@@ -1932,9 +1944,27 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "OK",
+                        "description": "Login successful",
                         "schema": {
                             "$ref": "#/definitions/models.LoginEndResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request, usually due to state mismatch or other protocol errors",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized, specifically when login is required",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error, including token validation or exchange issues",
+                        "schema": {
+                            "type": "string"
                         }
                     }
                 }
@@ -1957,6 +1987,12 @@
                         "schema": {
                             "$ref": "#/definitions/models.LoginStartResponse"
                         }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "string"
+                        }
                     }
                 }
             }
@@ -1978,13 +2014,25 @@
                         "schema": {
                             "$ref": "#/definitions/models.LogoutResponse"
                         }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "string"
+                        }
                     }
                 }
             }
         },
         "/web/refresh": {
             "get": {
-                "description": "Refreshes the access token",
+                "description": "Refreshes the access token and updates the session ID",
                 "produces": [
                     "application/json"
                 ],
@@ -1996,26 +2044,50 @@
                 "responses": {
                     "204": {
                         "description": "No Content"
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "string"
+                        }
                     }
                 }
             }
         },
         "/web/user_info": {
             "get": {
-                "description": "Returns information about the currently logged-in user",
+                "description": "Fetches the information of the currently logged-in user from the OAuth2 provider.",
                 "produces": [
                     "application/json"
                 ],
                 "tags": [
                     "Auth"
                 ],
-                "summary": "User Info",
+                "summary": "Retrieve User Information",
                 "operationId": "UserInfo",
                 "responses": {
                     "200": {
-                        "description": "OK",
+                        "description": "Successfully retrieved user information",
                         "schema": {
                             "$ref": "#/definitions/models.UserInfoResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized, user not logged in or session expired",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error, during token validation or info retrieval",
+                        "schema": {
+                            "type": "string"
                         }
                     }
                 }

--- a/internal/docs/swagger.yaml
+++ b/internal/docs/swagger.yaml
@@ -1669,12 +1669,21 @@ paths:
           schema:
             additionalProperties: true
             type: object
+        "401":
+          description: Unauthorized
+          schema:
+            type: string
+        "500":
+          description: Internal Server Error
+          schema:
+            type: string
       summary: Claims
       tags:
       - Auth
   /web/login/end:
     post:
-      description: Called auth server redirect to finish the Oauth login
+      description: Handles the callback from the OAuth2 provider and completes the
+        login process.
       operationId: WebEnd
       parameters:
       - description: End Login
@@ -1687,9 +1696,23 @@ paths:
       - application/json
       responses:
         "200":
-          description: OK
+          description: Login successful
           schema:
             $ref: '#/definitions/models.LoginEndResponse'
+        "400":
+          description: Bad Request, usually due to state mismatch or other protocol
+            errors
+          schema:
+            type: string
+        "401":
+          description: Unauthorized, specifically when login is required
+          schema:
+            type: string
+        "500":
+          description: Internal Server Error, including token validation or exchange
+            issues
+          schema:
+            type: string
       summary: End Web Login
       tags:
       - Auth
@@ -1704,6 +1727,10 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/models.LoginStartResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            type: string
       summary: Start Web Login
       tags:
       - Auth
@@ -1718,33 +1745,58 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/models.LogoutResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            type: string
+        "500":
+          description: Internal Server Error
+          schema:
+            type: string
       summary: Logout
       tags:
       - Auth
   /web/refresh:
     get:
-      description: Refreshes the access token
+      description: Refreshes the access token and updates the session ID
       operationId: Refresh
       produces:
       - application/json
       responses:
         "204":
           description: No Content
+        "401":
+          description: Unauthorized
+          schema:
+            type: string
+        "500":
+          description: Internal Server Error
+          schema:
+            type: string
       summary: Refresh
       tags:
       - Auth
   /web/user_info:
     get:
-      description: Returns information about the currently logged-in user
+      description: Fetches the information of the currently logged-in user from the
+        OAuth2 provider.
       operationId: UserInfo
       produces:
       - application/json
       responses:
         "200":
-          description: OK
+          description: Successfully retrieved user information
           schema:
             $ref: '#/definitions/models.UserInfoResponse'
-      summary: User Info
+        "401":
+          description: Unauthorized, user not logged in or session expired
+          schema:
+            type: string
+        "500":
+          description: Internal Server Error, during token validation or info retrieval
+          schema:
+            type: string
+      summary: Retrieve User Information
       tags:
       - Auth
 securityDefinitions:

--- a/internal/routers/routers.go
+++ b/internal/routers/routers.go
@@ -69,6 +69,7 @@ func NewAPIRouter(ctx context.Context, o APIRouterOptions) (*gin.Engine, error) 
 		web.GET("/claims", o.BrowserFlow.Claims)
 		web.POST("/logout", o.BrowserFlow.Logout)
 		web.GET("/check_auth", o.BrowserFlow.CheckAuth)
+		web.GET("/refresh", o.BrowserFlow.Refresh)
 	}
 	private := r.Group("/api", loggerMiddleware)
 	{

--- a/pkg/oidcagent/router.go
+++ b/pkg/oidcagent/router.go
@@ -28,6 +28,7 @@ func AddCodeFlowRoutes(r gin.IRouter, auth *OidcAgent) {
 	r.GET("/claims", auth.Claims)
 	r.POST("/logout", auth.Logout)
 	r.GET("/check_auth", auth.CheckAuth)
+	r.GET("/refresh", auth.Refresh)
 }
 
 func NewDeviceFlowRouter(auth *OidcAgent) *gin.Engine {


### PR DESCRIPTION
- This should resolve the hard logout after the initial token expires after 300s. The logic is the OIDC token Refresh() kicks off 5sec before the exp in the keycloak token is set to expire and gets updated with a new refresh token. More details on this method at: https://marmelab.com/blog/2020/07/02/manage-your-jwt-react-admin-authentication-in-memory.html
- Tokens are still managed on the server-side so the client side is not dealing with storage. There are pros and cons for both methods.
- Safari private-mode is the only scenario that doesn't work here, but Safari is notorious for its strictness in cookies so it is likely something related.
- This handles multiple logins from separate browsers on the same host etc.