### PR TITLE
build: add the --context arg kubectl commands to avoid targeting the wrong cluster.

### DIFF
--- a/cmd/nexd-kstore/main_off.go
+++ b/cmd/nexd-kstore/main_off.go
@@ -1,0 +1,6 @@
+//go:build !kubernetes
+
+// files only exists to avoid getting the following warning in the build:
+//
+//	package github.com/nexodus-io/nexodus/cmd/nexd-kstore: build constraints exclude all Go files in ./nexodus/cmd/nexd-kstore
+package main


### PR DESCRIPTION
Also make the build a little less noisy by suppressing a go warning.