### PR TITLE
Aliased predefined ports in sec group rules edit UI

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -21,7 +21,7 @@
         "web-vitals": "^3.4.0"
       },
       "devDependencies": {
-        "@mui/material": "^5.14.10",
+        "@mui/material": "^5.14.11",
         "@types/jest": "^29.5.5",
         "@types/react": "^18.2.22",
         "@types/react-dom": "^18.2.7",
@@ -809,14 +809,14 @@
       }
     },
     "node_modules/@mui/base": {
-      "version": "5.0.0-beta.16",
-      "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-beta.16.tgz",
-      "integrity": "sha512-OYxhC81c9bO0wobGcM8rrY5bRwpCXAI21BL0P2wz/2vTv4ek7ALz9+U5M8wgdmtRNUhmCmAB4L2WRwFRf5Cd8Q==",
+      "version": "5.0.0-beta.17",
+      "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-beta.17.tgz",
+      "integrity": "sha512-xNbk7iOXrglNdIxFBN0k3ySsPIFLWCnFxqsAYl7CIcDkD9low4kJ7IUuy6ctwx/HAy2fenrT3KXHr1sGjAMgpQ==",
       "dependencies": {
         "@babel/runtime": "^7.22.15",
         "@floating-ui/react-dom": "^2.0.2",
         "@mui/types": "^7.2.4",
-        "@mui/utils": "^5.14.10",
+        "@mui/utils": "^5.14.11",
         "@popperjs/core": "^2.11.8",
         "clsx": "^2.0.0",
         "prop-types": "^15.8.1"
@@ -848,9 +848,9 @@
       }
     },
     "node_modules/@mui/core-downloads-tracker": {
-      "version": "5.14.10",
-      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-5.14.10.tgz",
-      "integrity": "sha512-kPHu/NhZq1k+vSZR5wq3AyUfD4bnfWAeuKpps0+8PS7ZHQ2Lyv1cXJh+PlFdCIOa0PK98rk3JPwMzS8BMhdHwQ==",
+      "version": "5.14.11",
+      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-5.14.11.tgz",
+      "integrity": "sha512-uY8FLQURhXe3f3O4dS5OSGML9KDm9+IE226cBu78jarVIzdQGPlXwGIlSI9VJR8MvZDA6C0+6XfWDhWCHruC5Q==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mui"
@@ -882,16 +882,16 @@
       }
     },
     "node_modules/@mui/material": {
-      "version": "5.14.10",
-      "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.14.10.tgz",
-      "integrity": "sha512-ejFMppnO+lzBXpzju+N4SSz0Mhmi5sihXUGcr5FxpgB6bfUP0Lpe32O0Sw/3s8xlmLEvG1fqVT0rRyAVMlCA+A==",
+      "version": "5.14.11",
+      "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.14.11.tgz",
+      "integrity": "sha512-DnSdJzcR7lwG12JA5L2t8JF+RDzMygu5rCNW+logWb/KW2/TRzwLyVWO+CorHTBjBRd38DBxnwOCDiYkDd+N3A==",
       "dependencies": {
         "@babel/runtime": "^7.22.15",
-        "@mui/base": "5.0.0-beta.16",
-        "@mui/core-downloads-tracker": "^5.14.10",
-        "@mui/system": "^5.14.10",
+        "@mui/base": "5.0.0-beta.17",
+        "@mui/core-downloads-tracker": "^5.14.11",
+        "@mui/system": "^5.14.11",
         "@mui/types": "^7.2.4",
-        "@mui/utils": "^5.14.10",
+        "@mui/utils": "^5.14.11",
         "@types/react-transition-group": "^4.4.6",
         "clsx": "^2.0.0",
         "csstype": "^3.1.2",
@@ -939,12 +939,12 @@
       "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
     },
     "node_modules/@mui/private-theming": {
-      "version": "5.14.10",
-      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.14.10.tgz",
-      "integrity": "sha512-f67xOj3H06wWDT9xBg7hVL/HSKNF+HG1Kx0Pm23skkbEqD2Ef2Lif64e5nPdmWVv+7cISCYtSuE2aeuzrZe78w==",
+      "version": "5.14.11",
+      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.14.11.tgz",
+      "integrity": "sha512-MSnNNzTu9pfKLCKs1ZAKwOTgE4bz+fQA0fNr8Jm7NDmuWmw0CaN9Vq2/MHsatE7+S0A25IAKby46Uv1u53rKVQ==",
       "dependencies": {
         "@babel/runtime": "^7.22.15",
-        "@mui/utils": "^5.14.10",
+        "@mui/utils": "^5.14.11",
         "prop-types": "^15.8.1"
       },
       "engines": {
@@ -965,9 +965,9 @@
       }
     },
     "node_modules/@mui/styled-engine": {
-      "version": "5.14.10",
-      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-5.14.10.tgz",
-      "integrity": "sha512-EJckxmQHrsBvDbFu1trJkvjNw/1R7jfNarnqPSnL+jEQawCkQIqVELWLrlOa611TFtxSJGkdUfCFXeJC203HVg==",
+      "version": "5.14.11",
+      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-5.14.11.tgz",
+      "integrity": "sha512-jdUlqRgTYQ8RMtPX4MbRZqar6W2OiIb6J5KEFbIu4FqvPrk44Each4ppg/LAqp1qNlBYq5i+7Q10MYLMpDxX9A==",
       "dependencies": {
         "@babel/runtime": "^7.22.15",
         "@emotion/cache": "^11.11.0",
@@ -996,15 +996,15 @@
       }
     },
     "node_modules/@mui/system": {
-      "version": "5.14.10",
-      "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.14.10.tgz",
-      "integrity": "sha512-QQmtTG/R4gjmLiL5ECQ7kRxLKDm8aKKD7seGZfbINtRVJDyFhKChA1a+K2bfqIAaBo1EMDv+6FWNT1Q5cRKjFA==",
+      "version": "5.14.11",
+      "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.14.11.tgz",
+      "integrity": "sha512-yl8xV+y0k7j6dzBsHabKwoShmjqLa8kTxrhUI3JpqLG358VRVMJRW/ES0HhvfcCi4IVXde+Tc2P3K1akGL8zoA==",
       "dependencies": {
         "@babel/runtime": "^7.22.15",
-        "@mui/private-theming": "^5.14.10",
-        "@mui/styled-engine": "^5.14.10",
+        "@mui/private-theming": "^5.14.11",
+        "@mui/styled-engine": "^5.14.11",
         "@mui/types": "^7.2.4",
-        "@mui/utils": "^5.14.10",
+        "@mui/utils": "^5.14.11",
         "clsx": "^2.0.0",
         "csstype": "^3.1.2",
         "prop-types": "^15.8.1"
@@ -1056,9 +1056,9 @@
       }
     },
     "node_modules/@mui/utils": {
-      "version": "5.14.10",
-      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.14.10.tgz",
-      "integrity": "sha512-Rn+vYQX7FxkcW0riDX/clNUwKuOJFH45HiULxwmpgnzQoQr3A0lb+QYwaZ+FAkZrR7qLoHKmLQlcItu6LT0y/Q==",
+      "version": "5.14.11",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.14.11.tgz",
+      "integrity": "sha512-fmkIiCPKyDssYrJ5qk+dime1nlO3dmWfCtaPY/uVBqCRMBZ11JhddB9m8sjI2mgqQQwRJG5bq3biaosNdU/s4Q==",
       "dependencies": {
         "@babel/runtime": "^7.22.15",
         "@types/prop-types": "^15.7.5",

--- a/ui/package.json
+++ b/ui/package.json
@@ -34,7 +34,7 @@
     ]
   },
   "devDependencies": {
-    "@mui/material": "^5.14.10",
+    "@mui/material": "^5.14.11",
     "@types/jest": "^29.5.5",
     "@types/react": "^18.2.22",
     "@types/react-dom": "^18.2.7",

--- a/ui/src/pages/SecurityGroups/SecurityGroupEditRules.tsx
+++ b/ui/src/pages/SecurityGroups/SecurityGroupEditRules.tsx
@@ -9,6 +9,7 @@ import {
   TextField,
   Select,
   MenuItem,
+  Tooltip,
 } from "@mui/material";
 import {
   IpProtocol,
@@ -22,6 +23,7 @@ import Notifications from "../../common/Notifications";
 import * as Mui from "@mui/material";
 import Autocomplete from "@mui/material/Autocomplete";
 import { validateProtocolAndIpRange } from "../../common/IpHelpers";
+import HelpOutlineIcon from "@mui/icons-material/HelpOutline";
 
 interface EditRulesProps {
   groupName: string;
@@ -274,14 +276,6 @@ const EditRules: React.FC<EditRulesProps> = ({
           ip_ranges: [],
         };
         break;
-      case "ip": // All Traffic
-        updatedRule = {
-          ...updatedRule,
-          from_port: 0,
-          to_port: 0,
-          ip_ranges: [],
-        };
-        break;
     }
 
     onRuleChange(index, updatedRule);
@@ -331,7 +325,17 @@ const EditRules: React.FC<EditRulesProps> = ({
       <div style={{ marginTop: "20px", marginBottom: "10px" }}>
         <ButtonGroup variant="outlined" style={{ marginRight: "10px" }}>
           <Button onClick={handleAddRule}>Add Rule</Button>
+          <Tooltip title="Adding a rule will begin blocking all traffic not explicitly allowed by a rule for the traffic direction you are editing (inbound or outbound)">
+            <Button onClick={() => {}}>
+              <HelpOutlineIcon />
+            </Button>
+          </Tooltip>
           <Button onClick={handleSaveRules}>Save Rules</Button>
+          <Tooltip title="Removing all rules will allow all traffic for the rule direction you are editing (inbound or outbound)">
+            <Button onClick={() => {}}>
+              <HelpOutlineIcon />
+            </Button>
+          </Tooltip>
         </ButtonGroup>
       </div>
       <Table>
@@ -381,7 +385,6 @@ const EditRules: React.FC<EditRulesProps> = ({
                     fullWidth
                   >
                     <MenuItem value="">Select Option</MenuItem>
-                    <MenuItem value="ip">All Traffic</MenuItem>
                     <MenuItem value="icmp">All ICMP</MenuItem>
                     <MenuItem value="tcp">TCP</MenuItem>
                     <MenuItem value="udp">UDP</MenuItem>
@@ -494,7 +497,7 @@ const EditRules: React.FC<EditRulesProps> = ({
                 >
                   <Autocomplete
                     multiple
-                    // Disable the dropdown based on the condition such as "All Traffic"
+                    // Disable the dropdown based on the condition such as "All ICMP"
                     disabled={isUnmodifiableIpRange(rule.ip_protocol)}
                     options={[
                       "::/0",


### PR DESCRIPTION
- The predefined ports were getting passed as-is instead of being normalized to a proper protocol, e.g., MYSQL needs to be mapped to TCP to be punched into netfilter. The secgroup rules validation patch brought this to the surface. The ports do not grey out as they did, but I added a todo to do it in another patch to avoid regression here.
- Remove ALL TRAFFIC as an option and replace with tooltips
- Since we are implicitly allowing all traffic it makes more sense to give the user a message to remove all rules to allow all traffic.
- Adds a tooltip explaining adding a rule will implicitly begin dropping all other traffic that isn't explicitly allowed.
- Screencaps for all of the changes in comments.