### PR TITLE
install-tools: Don't assume go bin dir exists

### DIFF
--- a/hack/install-tools.sh
+++ b/hack/install-tools.sh
@@ -26,6 +26,7 @@ if [ -z "$(which kubectl)" ] || [ "$1" = "--force" ]; then
     exit 1
   fi
   chmod 755 kubectl
+  mkdir -p "$(go env GOPATH)/bin"
   mv kubectl "$(go env GOPATH)/bin"
 fi
 if [ -z "$(which kind)" ] || [ "$1" = "--force" ]; then


### PR DESCRIPTION
If the go bin dir does not exist, this script installs kubectl as
$GOPATH/bin, instead of putting kubectl in the bin directory. This
patch ensures the directory is created if it does not exist.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
