### PR TITLE
Update prod manifest to adopt changes from latest kustomize release

### DIFF
--- a/deploy/nexodus/overlays/prod/files/promtail.yaml
+++ b/deploy/nexodus/overlays/prod/files/promtail.yaml
@@ -1,0 +1,51 @@
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 0
+
+clients:
+  - url: http://loki.nexodus-monitoring.svc.cluster.local:3100/loki/api/v1/push
+
+positions:
+  filename: /tmp/positions.yaml
+target_config:
+  sync_period: 10s
+scrape_configs:
+  - job_name: pod-logs
+    kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names:
+            - nexodus
+    pipeline_stages:
+      - cri: {}
+    relabel_configs:
+      - source_labels:
+          - __meta_kubernetes_pod_node_name
+        target_label: __host__
+      - action: labelmap
+        regex: __meta_kubernetes_pod_label_(.+)
+      - action: replace
+        replacement: $1
+        separator: /
+        source_labels:
+          - __meta_kubernetes_namespace
+          - __meta_kubernetes_pod_name
+        target_label: job
+      - action: replace
+        source_labels:
+          - __meta_kubernetes_namespace
+        target_label: namespace
+      - action: replace
+        source_labels:
+          - __meta_kubernetes_pod_name
+        target_label: pod
+      - action: replace
+        source_labels:
+          - __meta_kubernetes_pod_container_name
+        target_label: container
+      - replacement: /var/log/pods/*$1/*.log
+        separator: /
+        source_labels:
+          - __meta_kubernetes_pod_uid
+          - __meta_kubernetes_pod_container_name
+        target_label: __path__

--- a/deploy/nexodus/overlays/prod/kustomization.yaml
+++ b/deploy/nexodus/overlays/prod/kustomization.yaml
@@ -23,6 +23,10 @@ configMapGenerator:
     files:
       - files/limits.yaml
     name: limitador-config
+  - behavior: create
+    files:
+      - files/promtail.yaml
+    name: promtail-config
   - behavior: merge
     literals:
       - APIPROXY_OIDC_URL=https://auth.try.nexodus.io/realms/nexodus


### PR DESCRIPTION
Kustomize release 5.1.0 (our CI job uses this version) made the changes
in the order of processing of resources, components , generators and
transformers. That requires that our top level kustomization yamls
should create the configmaps, rather than replace it,
because with 5.1.0, components will be processed after generators,
 so there won't be any existing configmap to replace.

Following issue has more details about it: https://github.com/kubernetes-sigs/kustomize/pull/5170

Signed-off-by: Anil Kumar Vishnoi <avishnoi@redhat.com>