### PR TITLE
Reset the notifcation state to have it re-render on change

### DIFF
--- a/ui/src/pages/SecurityGroups/SecurityGroupEditRules.tsx
+++ b/ui/src/pages/SecurityGroups/SecurityGroupEditRules.tsx
@@ -114,6 +114,10 @@ const EditRules: React.FC<EditRulesProps> = ({
   const [rules, setRules] = useState<SecurityRule[]>(derivedRules);
 
   const handleSaveRules = () => {
+    // Reset notification states
+    setNotificationMessage(null);
+    setNotificationType(null);
+
     let valid = true;
     const errorMessages: {
       index: number;

--- a/ui/src/pages/SecurityGroups/SecurityGroups.tsx
+++ b/ui/src/pages/SecurityGroups/SecurityGroups.tsx
@@ -88,6 +88,9 @@ export const SecurityGroups = () => {
   }, [selectedSecurityGroup]);
 
   const handleExitEditMode = async () => {
+    // Reset notification states
+    setNotificationMessage(null);
+    setNotificationType(null);
     setIsEditing(false);
     if (selectedOrg) {
       try {


### PR DESCRIPTION
- React won't render unless the state has changed. This fixes an issue where only the first save in a rules edit it sent via a notification. This resets the state so react will see a diff and fire the notification for all rule saves.