### PR TITLE
Add an accordian view to UI device listing

### DIFF
--- a/ui/src/pages/Devices.tsx
+++ b/ui/src/pages/Devices.tsx
@@ -17,7 +17,11 @@ import OnlineIcon from "@mui/icons-material/CheckCircleOutline";
 import HighlightOffIcon from "@mui/icons-material/HighlightOff";
 import HelpOutlineIcon from "@mui/icons-material/HelpOutline";
 import { useTheme } from "@mui/material/styles";
-import { Tooltip } from "@mui/material";
+import { Tooltip, Accordion, AccordionDetails } from "@mui/material";
+
+interface DeviceAccordionDetailsProps {
+  id: string | number;
+}
 
 const DeviceListBulkActions = () => (
   <div style={{ display: "flex", justifyContent: "space-between" }}>
@@ -28,7 +32,11 @@ const DeviceListBulkActions = () => (
 
 export const DeviceList = () => (
   <List>
-    <Datagrid rowClick="show" bulkActionButtons={<DeviceListBulkActions />}>
+    <Datagrid
+      rowClick="show"
+      expand={<DeviceAccordion />}
+      bulkActionButtons={<DeviceListBulkActions />}
+    >
       <TextField label="Hostname" source="hostname" />
       <TextField label="Tunnel IP" source="tunnel_ip" />
       <ArrayField label="Endpoints" source="endpoints">
@@ -60,6 +68,29 @@ export const DeviceList = () => (
     </Datagrid>
   </List>
 );
+
+const DeviceAccordion: FC = () => {
+  const record = useRecordContext();
+  if (record && record.id !== undefined) {
+    return (
+      <Accordion expanded={true}>
+        <DeviceAccordionDetails id={record.id} />
+      </Accordion>
+    );
+  }
+  return null;
+};
+
+const DeviceAccordionDetails: FC<DeviceAccordionDetailsProps> = ({ id }) => {
+  // Use the same layout as DeviceShow
+  return (
+    <AccordionDetails>
+      <div>
+        <DeviceShowLayout />
+      </div>
+    </AccordionDetails>
+  );
+};
 
 const ConditionalOnlineSinceField = () => {
   const record = useRecordContext();


### PR DESCRIPTION
Not a huge fan of the click to new window view as is without breadcrumbs. This adds an accordion view but still preserves the click view for now. The accordion view contents are the DeviceShow FC.

<img width="904" alt="image" src="https://github.com/nexodus-io/nexodus/assets/1711674/bb742634-b2d7-4012-9471-6683696e69ad">


