### PR TITLE
rpm: don't overrwrite config on upgrade

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ else
 endif
 
 NEXODUS_VERSION?=$(shell date +%Y.%m.%d)
-NEXODUS_RELEASE?=$(shell git describe --always --exclude qa --exclude prod)
+NEXODUS_RELEASE?=$(shell git describe --always --abbrev=6 --exclude qa --exclude prod)
 NEXODUS_GCFLAGS?=
 
 NEXODUS_KUBE_CONTEXT?=kind-nexodus-dev

--- a/contrib/rpm/nexodus.spec.in
+++ b/contrib/rpm/nexodus.spec.in
@@ -90,7 +90,7 @@ done
 %doc docs DCO CONTRIBUTING.md README.md
 %{_bindir}/*
 /usr/lib/systemd/system/nexodus.service
-%{_sysconfdir}/sysconfig/nexodus
+%config(noreplace) %{_sysconfdir}/sysconfig/nexodus
 %{_mandir}/man8/*
 %{_sysconfdir}/bash_completion.d/*
 


### PR DESCRIPTION
The nexodus service config was not properly marked as a config file in
the rpm spec file. This resulted in overwriting the config every time
the package was upgraded. With this change, if the package includes an
updated version of the default configuration is put in a
`nexodus.rpmnew` file.

In passing, the git hash used in the version is now explicitly limited
to 6 characters. It's usually 6, but when I got a longer one, it broke
my rpm build.

Closes #1495

Signed-off-by: Russell Bryant <rbryant@redhat.com>
