### PR TITLE
nexd: Handle invalid tokens at startup

### DIFF
--- a/internal/util/retry_operation.go
+++ b/internal/util/retry_operation.go
@@ -20,6 +20,14 @@ func RetryOperation(ctx context.Context, wait time.Duration, retries int, operat
 	return err
 }
 
+// RetryOperationExpBackoff retries the operation with an exponential backoff policy.
+func RetryOperationExpBackoff(ctx context.Context, maxWait time.Duration, operation func() error) error {
+	ebo := backoff.NewExponentialBackOff()
+	ebo.MaxInterval = maxWait
+	bo := backoff.WithContext(ebo, ctx)
+	return backoff.Retry(operation, bo)
+}
+
 // RetryOperationForErrors retries the operation with a backoff policy for the specified errors, otherwise will just perform the operation once and return the error if it fails.
 func RetryOperationForErrors(ctx context.Context, wait time.Duration, retries int, retriableErrors []error, operation func() error) error {
 	bo := backoff.WithMaxRetries(


### PR DESCRIPTION
This patch improves the behavior of nexd at startup when it has an
invalid auth token stored. The most common time to see this is when
switching a host to use a different service endpoint, such as
switching between dev, qa, and prod.

This makes nexd clear the invalid auth token and restart the auth
process. The backoff behavior has been adjusted from constant to an
exponential backoff. This ensures the first retry happens quickly,
since in this common scenario the first will fail, but the second
attempt will succeed, so we want to get to that second try quickly. If
the failure is something else, then we want to start backing off.

Signed-off-by: Russell Bryant <russell.bryant@gmail.com>
