### PR TITLE
Free up space to avoid runners running out of disk in e2e

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -248,6 +248,11 @@ jobs:
         overlay: ["dev"]
 
     steps:
+      - name: Remove unnecessary files on the runner for additional space
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+
       - uses: actions/checkout@v4
       - uses: docker/setup-buildx-action@v3
 


### PR DESCRIPTION
Im seeing e2e fail with complaints about disk space on the runner. Removing some unnecessary files resolves it in the short term. ¯\\_(ツ)_/¯ I'm curious what would have tipped us over the limit here as well, but getting e2e functional again and back tracking from there seems rational, unless of course someone resolves the root cause first! Only thing that merged for the most part since its failing has been dependabots.

References:
`https://github.com/actions/runner-images/issues/2875`
`https://github.com/actions/runner-images/issues/2840`

Example runner log and the job [6461383807](https://github.com/nexodus-io/nexodus/actions/runs/6461383807):

```
e2e-integration (dev)
Unhandled exception. System.IO.IOException: No space left on device : '/home/runner/runners/2.309.0/_diag/Worker_20231012-032804-utc.log'
```
