### PR TITLE
Runner space optimizations and cleanup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -133,8 +133,8 @@ jobs:
           file: ./Containerfile.${{ matrix.name }}
           tags: ${{ matrix.tags }}
           outputs: type=docker,dest=/tmp/${{ matrix.name }}.tar
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=${{ matrix.name }}
+          cache-to: type=gha,scope=${{ matrix.name }},mode=max
 
       - name: Upload ${{ matrix.name }} artifact
         uses: actions/upload-artifact@v3
@@ -252,6 +252,9 @@ jobs:
         run: |
           sudo rm -rf /usr/share/dotnet
           sudo rm -rf /opt/ghc
+          sudo apt-get clean
+          sudo apt-get autoremove
+          docker system prune -a -f
 
       - uses: actions/checkout@v4
       - uses: docker/setup-buildx-action@v3
@@ -325,6 +328,10 @@ jobs:
         with:
           name: e2e-${{ matrix.overlay }}-logs
           path: logs.txt
+
+      - name: Check Disk Space
+        if: always()
+        run: df -h
 
   build-rpm:
     needs: [ go-lint-linux, generate ]


### PR DESCRIPTION
Adds inline caching which should help with disk space and time for layers that haven't changed between builds.

Free space at the end of the workflow is now `/dev/sdb1   14G  4.1G  9.0G  31% /mnt`.

```
Filesystem      Size  Used Avail Use% Mounted on
/dev/root        84G   77G  6.7G  92% /
tmpfs           3.4G  172K  3.4G   1% /dev/shm
tmpfs           1.4G  5.7M  1.4G   1% /run
tmpfs           5.0M     0  5.0M   0% /run/lock
/dev/sda15      105M  6.1M   99M   6% /boot/efi
/dev/sdb1        14G  4.1G  9.0G  31% /mnt
tmpfs           693M   12K  693M   1% /run/user/1001
```