### PR TITLE
nexd: fixes #1482 add logging to notify user when nexodus agent successfully reconcile …

### DIFF
--- a/internal/nexodus/nexodus.go
+++ b/internal/nexodus/nexodus.go
@@ -154,6 +154,7 @@ type Nexodus struct {
 	securityGroup            *public.ModelsSecurityGroup
 	symmetricNat             bool
 	ipv6Supported            bool
+	deviceReconciled         bool
 	os                       string
 	exitNode                 exitNode
 	logger                   *zap.SugaredLogger
@@ -738,6 +739,10 @@ func (nx *Nexodus) reconcileSecurityGroups(ctx context.Context) {
 func (nx *Nexodus) reconcileDevices(ctx context.Context, options []client.Option) {
 	var err error
 	if err = nx.reconcileDeviceCache(); err == nil {
+		if !nx.deviceReconciled {
+			nx.deviceReconciled = true
+			nx.logger.Info("Nexodus agent has reconciled state with API server")
+		}
 		return
 	}
 
@@ -749,6 +754,7 @@ func (nx *Nexodus) reconcileDevices(ctx context.Context, options []client.Option
 	}
 
 	nx.logger.Errorf("Failed to reconcile state with the nexodus API server: %v", err)
+	nx.deviceReconciled = false
 
 	// if the token grant becomes invalid expires refresh or exit depending on the onboard method
 	if !strings.Contains(err.Error(), invalidTokenGrant.Error()) {


### PR DESCRIPTION
Added Info logging to notify user when reconciliation returns to being successful.

Logs when agent starts-up:
```
{"level":"info","ts":"2023-10-15T23:09:39.498-0700","caller":"nexd/main.go:108","msg":"Starting node agent with wireguard driver"}
{"level":"info","ts":"2023-10-15T23:09:39.614-0700","caller":"nexodus/nexodus.go:393","msg":"Security Groups are currently only supported on Linux"}
{"level":"info","ts":"2023-10-15T23:09:39.796-0700","caller":"nexodus/nexodus.go:587","msg":"Reconnected as device with UUID: [ 1f98b343-7b6c-44c5-aba3-9f2b3c90380b ] into organization: [ admin (8f8cbe13-b684-42b1-a691-c3a8c3d70436) ]"}
{"level":"info","ts":"2023-10-15T23:09:39.806-0700","caller":"nexodus/wg_peers.go:364","msg":"New local Wireguard interface addresses assigned IPv4 [ 100.64.0.1 ] IPv6 [ 200::1 ]"}
{"level":"info","ts":"2023-10-15T23:09:39.823-0700","caller":"nexodus/nexodus.go:744","msg":"Nexodus agent has reconciled state with API server"}
```
Logs when agent reconcile successfully after failed reconciliation. 
```
{"level":"error","ts":"2023-10-15T23:16:42.558-0700","caller":"nexodus/nexodus.go:756","msg":"Failed to reconcile state with the nexodus API server: error: 502 Bad Gateway header: map[Connection:[keep-alive] Content-Length:[150] Content-Type:[text/html] Date:[Mon, 16 Oct 2023 06:16:42 GMT] Strict-Transport-Security:[max-age=15724800; includeSubDomains]]"}
{"level":"error","ts":"2023-10-15T23:16:42.559-0700","caller":"nexodus/nexodus.go:756","msg":"Failed to reconcile state with the nexodus API server: error: 502 Bad Gateway header: map[Connection:[keep-alive] Content-Length:[150] Content-Type:[text/html] Date:[Mon, 16 Oct 2023 06:16:42 GMT] Strict-Transport-Security:[max-age=15724800; includeSubDomains]]"}
{"level":"info","ts":"2023-10-15T23:16:47.822-0700","caller":"nexodus/nexodus.go:744","msg":"Nexodus agent has reconciled state with API server"}

```