### PR TITLE
e2e: Allow for some packet drops in udp tests

### DIFF
--- a/integration-tests/proxy_test.go
+++ b/integration-tests/proxy_test.go
@@ -6,13 +6,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/nexodus-io/nexodus/internal/state"
-	"github.com/testcontainers/testcontainers-go"
 	"net"
 	"strings"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/nexodus-io/nexodus/internal/state"
+	"github.com/testcontainers/testcontainers-go"
 
 	"github.com/nexodus-io/nexodus/internal/util"
 )
@@ -902,10 +903,13 @@ func testProxyLoadBalancer(t *testing.T, opts testProxyLoadBalancerOpts) {
 				potato += 1
 			}
 		}
+		helper.Logf("TCP responses: apples=%d, bananas=%d", apples, bananas)
+		helper.Logf("UDP responses: carrot=%d, potato=%d", carrot, potato)
 		require.Equal(5, apples)
 		require.Equal(5, bananas)
-		require.Equal(5, carrot)
-		require.Equal(5, potato)
+		// Allow some drops for UDP
+		require.GreaterOrEqual(carrot, 3)
+		require.GreaterOrEqual(potato, 3)
 		return true, nil
 	}
 


### PR DESCRIPTION
This e2e test is one that we commonly see some failures from. For
example, the  last one I saw showed 4 responses received via UDP
instead of 5. Since it's UDP, and we're running these tests in
parallel so load could be an issue at times, allow for some drops as
long as we receive the majority of responses we expected.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
