### PR TITLE
Add PacketFilter policy support for macOS

### DIFF
--- a/docs/user-guide/security-groups.md
+++ b/docs/user-guide/security-groups.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Nexodus Security Groups are virtual firewalls for your Nexodus instances to control inbound and outbound traffic. They act as a white list, only allowing through the traffic that you specify is allowed. Each security group includes a set of rules that filter traffic coming into and out of the instance.
+Nexodus Security Groups are virtual firewalls for your Nexodus instances to control inbound and outbound traffic. They act as a white list, only allowing through the traffic that you specify is allowed. Each security group includes a set of rules that filter traffic coming into and out of the instance. Current OS support is Linux via NetFilter and macOS via PacketFilter.
 
 ![no-alt-text](../images/security-groups-multi-cloud-1.png)
 

--- a/internal/nexodus/exit_client.go
+++ b/internal/nexodus/exit_client.go
@@ -46,7 +46,7 @@ func addExitSrcDefaultRouteTable() error {
 
 // nfAddExitSrcMangleTable create a nftables table for mangle
 func nfAddExitSrcMangleTable(logger *zap.SugaredLogger) error {
-	if _, err := runNftCmd(logger, []string{"add", "table", "inet", nfOobMangleTable}); err != nil {
+	if _, err := policyCmd(logger, []string{"add", "table", "inet", nfOobMangleTable}); err != nil {
 		return fmt.Errorf("failed to add nftables table nexodus-stun-mangle: %w", err)
 	}
 
@@ -55,7 +55,7 @@ func nfAddExitSrcMangleTable(logger *zap.SugaredLogger) error {
 
 // nfAddExitSrcMangleOutputChain creates a nftables chain OUTPUT within the nftables mangle (alter) table.
 func nfAddExitSrcMangleOutputChain(logger *zap.SugaredLogger) error {
-	if _, err := runNftCmd(logger, []string{"add", "chain", "inet", nfOobMangleTable,
+	if _, err := policyCmd(logger, []string{"add", "chain", "inet", nfOobMangleTable,
 		"OUTPUT", "{", "type", "route", "hook", "output", "priority", "mangle", ";", "policy", "accept", ";", "}"}); err != nil {
 		return fmt.Errorf("failed to add nftables OUTPUT chain: %w", err)
 	}
@@ -66,7 +66,7 @@ func nfAddExitSrcMangleOutputChain(logger *zap.SugaredLogger) error {
 // nfAddExitSrcDestPortMangleRule adds a rule to the nftables mangle (alter) table that
 // sets the mark 0x4B66 for OOB (out of band) packets sent to a specific port.
 func nfAddExitSrcDestPortMangleRule(logger *zap.SugaredLogger, proto string, port int) error {
-	if _, err := runNftCmd(logger, []string{"add", "rule", "inet", nfOobMangleTable, "OUTPUT", "meta", "l4proto", proto,
+	if _, err := policyCmd(logger, []string{"add", "rule", "inet", nfOobMangleTable, "OUTPUT", "meta", "l4proto", proto,
 		proto, "dport", fmt.Sprintf("%d", port), "counter", "mark", "set", oobFwdMarkHex}); err != nil {
 		return fmt.Errorf("failed to add nftables OUTPUT rule: %w", err)
 	}
@@ -77,7 +77,7 @@ func nfAddExitSrcDestPortMangleRule(logger *zap.SugaredLogger, proto string, por
 // nfAddExitSrcDestPortMangleRule adds a rule to the nftables mangle (alter) table that
 // sets the mark 0x4B66 for OOB (out of band) packets sent to a specific port.
 func nfAddExitSrcApiServerOOBMangleRule(logger *zap.SugaredLogger, proto, apiServer string, port int) error {
-	if _, err := runNftCmd(logger, []string{"add", "rule", "inet", nfOobMangleTable, "OUTPUT", "ip", "daddr", apiServer,
+	if _, err := policyCmd(logger, []string{"add", "rule", "inet", nfOobMangleTable, "OUTPUT", "ip", "daddr", apiServer,
 		proto, "dport", fmt.Sprintf("%d", port), "counter", "mark", "set", oobFwdMarkHex}); err != nil {
 		return fmt.Errorf("failed to add nftables OUTPUT rule: %w", err)
 	}
@@ -87,7 +87,7 @@ func nfAddExitSrcApiServerOOBMangleRule(logger *zap.SugaredLogger, proto, apiSer
 
 // nfAddExitSrcSnatTable create a nftables table for OOB SNAT
 func nfAddExitSrcSnatTable(logger *zap.SugaredLogger) error {
-	if _, err := runNftCmd(logger, []string{"add", "table", "inet", nfOobSnatTable}); err != nil {
+	if _, err := policyCmd(logger, []string{"add", "table", "inet", nfOobSnatTable}); err != nil {
 		return fmt.Errorf("failed to add nftables table nexodus-stun-mangle: %w", err)
 
 	}
@@ -97,7 +97,7 @@ func nfAddExitSrcSnatTable(logger *zap.SugaredLogger) error {
 
 // nfAddExitSrcSnatOutputChain the purpose of this chain is to perform source NAT (SNAT) for outgoing packets
 func nfAddExitSrcSnatOutputChain(logger *zap.SugaredLogger) error {
-	if _, err := runNftCmd(logger, []string{"add", "chain", "inet", nfOobSnatTable, "POSTROUTING", "{", "type", "nat", "hook", "postrouting", "priority", "srcnat", ";", "policy", "accept", ";", "}"}); err != nil {
+	if _, err := policyCmd(logger, []string{"add", "chain", "inet", nfOobSnatTable, "POSTROUTING", "{", "type", "nat", "hook", "postrouting", "priority", "srcnat", ";", "policy", "accept", ";", "}"}); err != nil {
 		return fmt.Errorf("failed to add nftables snat chain POSTROUTING: %w", err)
 	}
 
@@ -106,7 +106,7 @@ func nfAddExitSrcSnatOutputChain(logger *zap.SugaredLogger) error {
 
 // nfAddExitSrcSnatRule adds a rule to the nexodus oob snat table that applies masquerading to postrouting
 func nfAddExitSrcSnatRule(logger *zap.SugaredLogger, phyIface string) error {
-	if _, err := runNftCmd(logger, []string{"add", "rule", "inet", nfOobSnatTable, "POSTROUTING", "oifname", phyIface, "counter", "masquerade"}); err != nil {
+	if _, err := policyCmd(logger, []string{"add", "rule", "inet", nfOobSnatTable, "POSTROUTING", "oifname", phyIface, "counter", "masquerade"}); err != nil {
 		return fmt.Errorf("failed to add nftables rule SNAT POSTROUTING: %w", err)
 	}
 

--- a/internal/nexodus/exit_node.go
+++ b/internal/nexodus/exit_node.go
@@ -202,7 +202,7 @@ func (nx *Nexodus) exitNodeClientTeardown() error {
 
 	exitNodeNFTables := []string{nfOobMangleTable, nfOobSnatTable}
 	for _, nfTable := range exitNodeNFTables {
-		if err2 = nx.nfTableDrop(nfTable); err2 != nil {
+		if err2 = nx.policyTableDrop(nfTable); err2 != nil {
 			nx.logger.Debug(err2)
 		}
 	}
@@ -227,7 +227,7 @@ func (nx *Nexodus) exitNodeClientTeardown() error {
 
 // exitNodeOriginTeardown removes the exit node origin where traffic is originated when it exits the wireguard network
 func (nx *Nexodus) exitNodeOriginTeardown() error {
-	if err := nx.nfTableDrop(nfExitNodeTable); err != nil {
+	if err := nx.policyTableDrop(nfExitNodeTable); err != nil {
 		return err
 	}
 

--- a/internal/nexodus/exit_origin.go
+++ b/internal/nexodus/exit_origin.go
@@ -15,7 +15,7 @@ import (
 // nft add rule inet nexodus-exit-node forward iifname "wg0" counter accept
 
 func addExitDestinationTable(logger *zap.SugaredLogger) error {
-	if _, err := runNftCmd(logger, []string{"add", "table", "inet", nfExitNodeTable}); err != nil {
+	if _, err := policyCmd(logger, []string{"add", "table", "inet", nfExitNodeTable}); err != nil {
 		return fmt.Errorf("failed to add nftables table %s: %w", nfExitNodeTable, err)
 	}
 
@@ -23,7 +23,7 @@ func addExitDestinationTable(logger *zap.SugaredLogger) error {
 }
 
 func addExitOriginPreroutingChain(logger *zap.SugaredLogger) error {
-	if _, err := runNftCmd(logger, []string{"add", "chain", "inet", nfExitNodeTable, "prerouting", "{", "type", "nat", "hook", "prerouting", "priority", "dstnat", ";", "}"}); err != nil {
+	if _, err := policyCmd(logger, []string{"add", "chain", "inet", nfExitNodeTable, "prerouting", "{", "type", "nat", "hook", "prerouting", "priority", "dstnat", ";", "}"}); err != nil {
 		return fmt.Errorf("failed to add nftables chain nexodus-exit-node: %w", err)
 	}
 
@@ -31,7 +31,7 @@ func addExitOriginPreroutingChain(logger *zap.SugaredLogger) error {
 }
 
 func addExitOriginPostroutingChain(logger *zap.SugaredLogger) error {
-	if _, err := runNftCmd(logger, []string{"add", "chain", "inet", nfExitNodeTable, "postrouting", "{", "type", "nat", "hook", "postrouting", "priority", "srcnat", ";", "}"}); err != nil {
+	if _, err := policyCmd(logger, []string{"add", "chain", "inet", nfExitNodeTable, "postrouting", "{", "type", "nat", "hook", "postrouting", "priority", "srcnat", ";", "}"}); err != nil {
 		return fmt.Errorf("failed to add nftables chain nexodus-exit-node: %w", err)
 	}
 
@@ -39,7 +39,7 @@ func addExitOriginPostroutingChain(logger *zap.SugaredLogger) error {
 }
 
 func addExitOriginForwardChain(logger *zap.SugaredLogger) error {
-	if _, err := runNftCmd(logger, []string{"add", "chain", "inet", nfExitNodeTable, "forward", "{", "type", "filter", "hook", "forward", "priority", "filter", ";", "}"}); err != nil {
+	if _, err := policyCmd(logger, []string{"add", "chain", "inet", nfExitNodeTable, "forward", "{", "type", "filter", "hook", "forward", "priority", "filter", ";", "}"}); err != nil {
 		return fmt.Errorf("failed to add nftables chain nexodus-exit-node: %w", err)
 	}
 
@@ -47,7 +47,7 @@ func addExitOriginForwardChain(logger *zap.SugaredLogger) error {
 }
 
 func addExitOriginPostroutingRule(logger *zap.SugaredLogger, phyIface string) error {
-	if _, err := runNftCmd(logger, []string{"add", "rule", "inet", nfExitNodeTable, "postrouting", "oifname", phyIface, "masquerade"}); err != nil {
+	if _, err := policyCmd(logger, []string{"add", "rule", "inet", nfExitNodeTable, "postrouting", "oifname", phyIface, "masquerade"}); err != nil {
 		return fmt.Errorf("failed to add nftables rule nexodus-exit-node: %w", err)
 	}
 
@@ -55,7 +55,7 @@ func addExitOriginPostroutingRule(logger *zap.SugaredLogger, phyIface string) er
 }
 
 func addExitOriginForwardRule(logger *zap.SugaredLogger) error {
-	if _, err := runNftCmd(logger, []string{"add", "rule", "inet", nfExitNodeTable, "forward", "iifname", wgIface, "accept"}); err != nil {
+	if _, err := policyCmd(logger, []string{"add", "rule", "inet", nfExitNodeTable, "forward", "iifname", wgIface, "accept"}); err != nil {
 		return fmt.Errorf("failed to add nftables rule nexodus-exit-node: %w", err)
 	}
 

--- a/internal/nexodus/net_router.go
+++ b/internal/nexodus/net_router.go
@@ -42,7 +42,7 @@ func (nx *Nexodus) setupNetworkRouterNode() error {
 	if err := nx.enableForwardingIP(); err != nil {
 		return err
 	}
-	if err := nx.nfNetworkRouterSetup(); err != nil {
+	if err := nx.networkRouterSetup(); err != nil {
 		return err
 	}
 

--- a/internal/nexodus/nexodus.go
+++ b/internal/nexodus/nexodus.go
@@ -387,8 +387,8 @@ func (nx *Nexodus) Start(ctx context.Context, wg *sync.WaitGroup) error {
 		return fmt.Errorf("CtlServerStart(): %w", err)
 	}
 
-	if runtime.GOOS != Linux.String() {
-		nx.logger.Info("Security Groups are currently only supported on Linux")
+	if runtime.GOOS != Linux.String() && runtime.GOOS != Darwin.String() {
+		nx.logger.Info("Security Groups are currently only supported on Linux and macOS")
 	} else if nx.userspaceMode {
 		nx.logger.Info("Security Groups are not supported in userspace proxy mode")
 	}
@@ -663,7 +663,7 @@ func (nx *Nexodus) Stop() {
 
 // reconcileSecurityGroups will check the security group and update it if necessary.
 func (nx *Nexodus) reconcileSecurityGroups(ctx context.Context) {
-	if runtime.GOOS != Linux.String() || nx.userspaceMode {
+	if runtime.GOOS != Linux.String() && runtime.GOOS != Darwin.String() || nx.userspaceMode {
 		return
 	}
 

--- a/internal/nexodus/nexodus.go
+++ b/internal/nexodus/nexodus.go
@@ -165,6 +165,7 @@ type Nexodus struct {
 	password      string
 	skipTlsVerify bool
 	stateStore    state.Store
+	stateDir      string
 	userspaceWG
 	securityGroupsInformer *public.Informer[public.ModelsSecurityGroup]
 	devicesInformer        *public.Informer[public.ModelsDevice]
@@ -253,6 +254,7 @@ func NewNexodus(
 		password:                password,
 		skipTlsVerify:           insecureSkipTlsVerify,
 		stateStore:              stateStore,
+		stateDir:                stateDir,
 		orgId:                   orgId,
 		userspaceWG: userspaceWG{
 			proxies: map[ProxyKey]*UsProxy{},

--- a/internal/nexodus/policy_darwin.go
+++ b/internal/nexodus/policy_darwin.go
@@ -4,25 +4,403 @@ package nexodus
 
 import (
 	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/nexodus-io/nexodus/internal/api/public"
+	"github.com/nexodus-io/nexodus/internal/util"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
 
-// ProcessSecurityGroup for darwin build purposes, policy currently unsupported on darwin
+const (
+	basePFFile         = "/etc/pf.conf"
+	pfAnchorFile       = "/etc/pf.anchors/io.nexodus"
+	tempPFFile         = "/tmp/pf_temp.conf"
+	appleSharingAnchor = "com.apple.internet-sharing"
+)
+
+type pfRuleBuilder struct {
+	sb    strings.Builder
+	iface string
+}
+
 func (nx *Nexodus) processSecurityGroupRules() error {
+	// Check if SecurityGroup is nil or has no rules, if any of the conditionals match, create an empty anchor
+	// file permitting all traffic and return. The goal is to not interrupt any existing PF rules. If pfctl
+	// is already running, we leave it alone and simply write an empty file permitting all traffic.
+	// If pfctl is disabled on the host and there are no rules we leave it disabled.
+	if nx.securityGroup == nil || (len(nx.securityGroup.InboundRules) == 0 && len(nx.securityGroup.OutboundRules) == 0) {
+		if _, err := os.Stat(pfAnchorFile); os.IsNotExist(err) {
+			// Create the file if it does not exist
+			_, err := os.Create(pfAnchorFile)
+			if err != nil {
+				return fmt.Errorf("failed to create anchor file: %w", err)
+			}
+		}
+		if err := writeEmptyRuleSet(pfAnchorFile); err != nil {
+			return err
+		}
+
+		return nil
+	}
+
+	// Check and enable pfctl if not enabled
+	if err := checkAndEnablePfctl(nx.logger); err != nil {
+		return fmt.Errorf("failed to ensure pfctl is enabled: %w", err)
+	}
+
+	// Copy the main PacketForwarding configuration file /etc/pf.conf to tmp. Nexodus does
+	// not alter the original system file to avoid any issues with OS upgrades etc.
+	if err := copyFile(basePFFile, tempPFFile); err != nil {
+		return fmt.Errorf("failed to copy pf.conf: %w", err)
+	}
+
+	// Check for com.apple.internet-sharing anchor. UTM (qemu) and possibly others are enabling
+	// bridge mode sharing outside of anchor files. This checks if that anchor is loaded and if it
+	// is it adds it to the copy of the main pf entry.
+	if isAppleSharingEnabled, err := checkAppleInternetSharing(); err == nil && isAppleSharingEnabled {
+		if err := appendAppleSharingAnchor(tempPFFile); err != nil {
+			return fmt.Errorf("failed to append Apple Internet Sharing anchor: %w", err)
+		}
+	}
+
+	// Add io.nexodus anchor entry to the copy of pf.conf
+	if err := appendNexodusAnchor(tempPFFile); err != nil {
+		return fmt.Errorf("failed to append io.nexodus anchor: %w", err)
+	}
+
+	prb := &pfRuleBuilder{}
+	prb.iface = nx.tunnelIface
+
+	// Explicit drop if rules are defined
+	if len(nx.securityGroup.InboundRules) > 0 {
+		prb.pfBlockAll("in")
+	}
+
+	// Process inbound rules
+	for _, rule := range nx.securityGroup.InboundRules {
+		if len(rule.IpRanges) == 0 || containsEmptyRange(rule.IpRanges) {
+			if err := prb.pfPermitProtoPortAnyAddr(rule, "inbound"); err != nil {
+				nx.logger.Errorf("pfctl setup error, failed to process inbound rule with 'any': %v", err)
+				return fmt.Errorf("pfctl setup error, failed to process inbound rule with 'any': %w", err)
+			}
+		} else if util.ContainsValidCustomIPv4Ranges(rule.IpRanges) || util.ContainsValidCustomIPv6Ranges(rule.IpRanges) {
+			if err := prb.pfPermitProtoPortAddr(rule, "inbound"); err != nil {
+				nx.logger.Errorf("pfctl setup error, failed to process inbound rule: %v", err)
+				return fmt.Errorf("pfctl setup error, failed to process inbound rule: %w", err)
+			}
+		} else {
+			if err := prb.pfPermitProtoPortAnyAddr(rule, "inbound"); err != nil {
+				nx.logger.Errorf("pfctl setup error, failed to process inbound rule with 'any': %v", err)
+				return fmt.Errorf("pfctl setup error, failed to process inbound rule with 'any': %w", err)
+			}
+		}
+	}
+
+	// Explicit drop if rules are defined
+	if len(nx.securityGroup.OutboundRules) > 0 {
+		prb.pfBlockAll("out")
+	}
+
+	// Process outbound rules
+	for _, rule := range nx.securityGroup.OutboundRules {
+		if len(rule.IpRanges) == 0 || containsEmptyRange(rule.IpRanges) {
+			if err := prb.pfPermitProtoPortAnyAddr(rule, "outbound"); err != nil {
+				nx.logger.Errorf("pfctl setup error, failed to process outbound rule with 'any': %v", err)
+				return fmt.Errorf("pfctl setup error, failed to process outbound rule with 'any': %w", err)
+			}
+		} else if util.ContainsValidCustomIPv4Ranges(rule.IpRanges) || util.ContainsValidCustomIPv6Ranges(rule.IpRanges) {
+			if err := prb.pfPermitProtoPortAddr(rule, "outbound"); err != nil {
+				nx.logger.Errorf("pfctl setup error, failed to process outbound rule: %v", err)
+				return fmt.Errorf("pfctl setup error, failed to process outbound rule: %w", err)
+			}
+		} else {
+			if err := prb.pfPermitProtoPortAnyAddr(rule, "outbound"); err != nil {
+				nx.logger.Errorf("pfctl setup error, failed to process outbound rule with 'any': %v", err)
+				return fmt.Errorf("pfctl setup error, failed to process outbound rule with 'any': %w", err)
+			}
+		}
+	}
+
+	// Open the anchor file to write pf rules
+	f, err := os.OpenFile(pfAnchorFile, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
+	if err != nil {
+		return fmt.Errorf("failed to open pf anchor file: %w", err)
+	}
+	defer f.Close()
+
+	// If debugging is enabled print the rules in a readable block
+	if nx.logger.Level().Enabled(zapcore.InfoLevel) {
+		fmt.Println("Generated pfctl Rules:")
+		fmt.Println(prb.sb.String())
+	}
+
+	_, err = f.WriteString(prb.sb.String())
+	if err != nil {
+		return fmt.Errorf("failed to write to build the PF rules: %w", err)
+	}
+
+	// Overwrite the contents of /etc/pf.anchors/io.nexodus
+	if err := os.WriteFile(pfAnchorFile, []byte(prb.sb.String()+"\n"), 0600); err != nil {
+		return fmt.Errorf("failed to write to /etc/pf.anchors/io.nexodus: %w", err)
+	}
+
+	// Load the pf rules from anchor file
+	if _, err := policyCmd(nx.logger, []string{"-f", tempPFFile}); err != nil {
+		return fmt.Errorf("failed to load pf rules: %w", err)
+	}
+
 	return nil
 }
 
-// nfNetworkRouterSetup for darwin build purposes, network router currently unsupported on darwin
-func (nx *Nexodus) nfNetworkRouterSetup() error {
+func (prb *pfRuleBuilder) pfPermitProtoPortAddr(rule public.ModelsSecurityRule, direction string) error {
+	var portOption string
+	var directionToken string
+
+	if direction == "inbound" {
+		directionToken = "pass in"
+	} else if direction == "outbound" {
+		directionToken = "pass out"
+	}
+
+	if rule.FromPort == 0 && rule.ToPort == 0 {
+		portOption = ""
+	} else {
+		portOption = fmt.Sprintf("port %d:%d", rule.FromPort, rule.ToPort)
+	}
+
+	ipRangesStr := strings.Join(rule.IpRanges, ", ")
+	// Ensure there are spaces around any dashes
+	ipRangesStr = strings.ReplaceAll(ipRangesStr, "-", " - ")
+
+	ipDirection := "to any"
+	if direction == "inbound" {
+		ipDirection = fmt.Sprintf("from { %s } to any", ipRangesStr)
+	} else if direction == "outbound" {
+		ipDirection = fmt.Sprintf("to { %s }", ipRangesStr)
+	}
+
+	protocol := rule.IpProtocol
+	inetType := "inet"
+	if protocol == "ipv6" || protocol == "icmp6" || protocol == "icmpv6" {
+		inetType = "inet6"
+	}
+
+	switch protocol {
+	case "ipv4", "ipv6":
+		if portOption != "" {
+			prb.sb.WriteString(fmt.Sprintf("%s quick on %s %s proto tcp %s %s\n", directionToken, prb.iface, inetType, ipDirection, portOption))
+			prb.sb.WriteString(fmt.Sprintf("%s quick on %s %s proto udp %s %s\n", directionToken, prb.iface, inetType, ipDirection, portOption))
+		} else {
+			prb.sb.WriteString(fmt.Sprintf("%s quick on %s %s %s %s\n", directionToken, prb.iface, inetType, ipDirection, portOption))
+		}
+	case "tcp", "udp":
+		prb.sb.WriteString(fmt.Sprintf("%s quick on %s %s proto %s %s %s\n", directionToken, prb.iface, inetType, protocol, ipDirection, portOption))
+	case "icmp4", "icmpv4":
+		prb.sb.WriteString(fmt.Sprintf("%s quick on %s inet proto icmp %s\n", directionToken, prb.iface, ipDirection))
+	case "icmp6", "icmpv6":
+		prb.sb.WriteString(fmt.Sprintf("%s quick on %s inet6 proto icmp6 %s\n", directionToken, prb.iface, ipDirection))
+	case "icmp":
+		prb.sb.WriteString(fmt.Sprintf("%s quick on %s inet proto icmp to any\n", directionToken, prb.iface))
+		prb.sb.WriteString(fmt.Sprintf("%s quick on %s inet6 proto icmp6 to any\n", directionToken, prb.iface))
+	default:
+		return fmt.Errorf("no match for permit proto port/port/address rule: %v", rule)
+	}
+
 	return nil
 }
 
-// runNftCmd for Darwin build purposes
-func runNftCmd(logger *zap.SugaredLogger, cmd []string) (string, error) {
-	return "", nil
+func (prb *pfRuleBuilder) pfPermitProtoPortAnyAddr(rule public.ModelsSecurityRule, direction string) error {
+	var portOption string
+	var directionToken string
+
+	if direction == "inbound" {
+		directionToken = "pass in"
+	} else if direction == "outbound" {
+		directionToken = "pass out"
+	}
+
+	if rule.FromPort == 0 && rule.ToPort == 0 {
+		portOption = ""
+	} else {
+		portOption = fmt.Sprintf("port %d:%d", rule.FromPort, rule.ToPort)
+	}
+
+	ipDirection := "to any"
+	if direction == "inbound" {
+		ipDirection = "from any to any"
+	} else if direction == "outbound" {
+		ipDirection = "to any"
+	}
+
+	protocol := rule.IpProtocol
+	inetType := "inet"
+	if protocol == "ipv6" || protocol == "icmp6" || protocol == "icmpv6" {
+		inetType = "inet6"
+	}
+
+	switch protocol {
+	case "tcp", "udp":
+		prb.sb.WriteString(fmt.Sprintf("%s quick on %s %s proto %s %s %s\n", directionToken, prb.iface, inetType, protocol, ipDirection, portOption))
+	case "ipv4", "ipv6":
+		if portOption != "" {
+			prb.sb.WriteString(fmt.Sprintf("%s quick on %s %s proto tcp %s %s\n", directionToken, prb.iface, inetType, ipDirection, portOption))
+			prb.sb.WriteString(fmt.Sprintf("%s quick on %s %s proto udp %s %s\n", directionToken, prb.iface, inetType, ipDirection, portOption))
+		} else {
+			prb.sb.WriteString(fmt.Sprintf("%s quick on %s %s %s %s\n", directionToken, "utun8", inetType, ipDirection, portOption))
+		}
+	case "icmp4", "icmpv4":
+		prb.sb.WriteString(fmt.Sprintf("%s quick on %s %s proto icmp %s\n", directionToken, prb.iface, inetType, ipDirection))
+	case "icmp6", "icmpv6":
+		prb.sb.WriteString(fmt.Sprintf("%s quick on %s %s proto icmp6 %s\n", directionToken, prb.iface, inetType, ipDirection))
+	case "icmp":
+		prb.sb.WriteString(fmt.Sprintf("%s quick on %s %s proto icmp %s\n", directionToken, prb.iface, inetType, ipDirection))
+		prb.sb.WriteString(fmt.Sprintf("%s quick on %s %s proto icmp6 %s\n", directionToken, prb.iface, inetType, ipDirection))
+	default:
+		return fmt.Errorf("no policy PF match for permit proto port any address rule: %v", rule)
+	}
+
+	return nil
 }
 
-// nfTableDrop for Darwin build purposes
-func (nx *Nexodus) nfTableDrop(table string) error {
-	return fmt.Errorf("nft table drop method currently unsupported for darwin")
+// copyFile Copy file from src to dst
+func copyFile(src, dst string) error {
+	input, err := os.ReadFile(src)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(dst, input, 0600)
+}
+
+// checkAppleInternetSharing Check if com.apple.internet-sharing anchor is loaded.
+// This is used by various macOS hypervisors and not loaded via the main PF config.
+func checkAppleInternetSharing() (bool, error) {
+	output, err := exec.Command("pfctl", "-sA").CombinedOutput()
+	if err != nil {
+		return false, err
+	}
+	return strings.Contains(string(output), appleSharingAnchor), nil
+}
+
+// appendToFileAfterLastOccurrence Appends the given lines to the file after the last
+// occurrence of the specified keyword. PF anchors have to be loaded in specific order
+func appendToFileAfterLastOccurrence(filename string, keyword string, linesToAppend string) error {
+	fileContent, err := os.ReadFile(filename)
+	if err != nil {
+		return err
+	}
+
+	lines := strings.Split(string(fileContent), "\n")
+
+	insertIndex := -1
+
+	// Find the last occurrence of the keyword
+	for i, line := range lines {
+		if strings.Contains(line, keyword) {
+			insertIndex = i + 1
+		}
+	}
+
+	if insertIndex == -1 {
+		return fmt.Errorf("keyword '%s' not found in file", keyword)
+	}
+
+	// Insert the linesToAppend after the last occurrence of the keyword
+	lines = append(lines[:insertIndex], append([]string{linesToAppend}, lines[insertIndex:]...)...)
+
+	// Write the updated lines back to the file
+	return os.WriteFile(filename, []byte(strings.Join(lines, "\n")), 0600)
+}
+
+// appendAppleSharingAnchor Append Apple Internet Sharing anchor to tempPFFile
+func appendAppleSharingAnchor(tempPFFile string) error {
+	anchorLines := fmt.Sprintf("nat-anchor \"%s/*\"\nrdr-anchor \"%s/*\"\n", appleSharingAnchor, appleSharingAnchor)
+	return appendToFileAfterLastOccurrence(tempPFFile, "rdr-anchor", anchorLines)
+}
+
+// appendNexodusAnchor Append io.nexodus anchor to tempPFFile
+func appendNexodusAnchor(tempPFFile string) error {
+	anchorLines := "anchor \"io.nexodus\"\nload anchor \"io.nexodus\" from \"/etc/pf.anchors/io.nexodus\"\n"
+	return appendToFile(tempPFFile, anchorLines)
+}
+
+// appendToFile Append lines to file
+func appendToFile(filename, lines string) error {
+	f, err := os.OpenFile(filename, os.O_APPEND|os.O_WRONLY, 0600)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	if _, err = f.WriteString(lines); err != nil {
+		return err
+	}
+	return nil
+}
+
+// pfBlockAll adds an implicit drop once an explicit allow is added
+func (prb *pfRuleBuilder) pfBlockAll(direction string) {
+	prb.sb.WriteString(fmt.Sprintf("block %s on %s all\n", direction, prb.iface))
+}
+
+// containsEmptyString checks if the slice contains an empty string
+func containsEmptyRange(ranges []string) bool {
+	for _, ipRange := range ranges {
+		if ipRange == "" {
+			return true
+		}
+	}
+	return false
+}
+
+// checkAndEnablePfctl checks if pf is running and if it isn't, enable it.
+func checkAndEnablePfctl(logger *zap.SugaredLogger) error {
+	cmd := exec.Command("pfctl", "-s", "info")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to run pfctl info: %w", err)
+	}
+
+	if !strings.Contains(string(output), "Status: Enabled") {
+		if _, err := policyCmd(logger, []string{"-e"}); err != nil {
+			return fmt.Errorf("failed to enable pfctl: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// writeEmptyRuleSet write the PF rules to the anchorFile
+func writeEmptyRuleSet(filePath string) error {
+	content := []byte("pass quick on utun8 all")
+	if err := os.WriteFile(filePath, content, 0600); err != nil {
+		return fmt.Errorf("failed to write to anchor file: %w", err)
+	}
+
+	return nil
+}
+
+// policyCmd is used to execute pfctl commands
+func policyCmd(logger *zap.SugaredLogger, cmdArgs []string) (string, error) {
+	pfctl := exec.Command("pfctl", cmdArgs...)
+
+	output, err := pfctl.CombinedOutput()
+	if err != nil {
+		logger.Errorw("pfctl command failed", "error", err, "output", string(output))
+		return "", fmt.Errorf("pfctl command: pfctl %q failed: %w", strings.Join(cmdArgs, " "), err)
+	}
+	logger.Debugf("pfctl command: pfctl %s", strings.Join(cmdArgs, " "))
+
+	return string(output), nil
+}
+
+// networkRouterSetup network router currently unsupported on darwin
+func (nx *Nexodus) networkRouterSetup() error {
+	return nil
+}
+
+// policyTableDrop for Darwin build purposes
+func (nx *Nexodus) policyTableDrop(table string) error {
+	return nil
 }

--- a/internal/nexodus/policy_darwin_test.go
+++ b/internal/nexodus/policy_darwin_test.go
@@ -1,0 +1,162 @@
+//go:build darwin
+
+package nexodus
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/nexodus-io/nexodus/internal/api/public"
+	"github.com/nexodus-io/nexodus/internal/util"
+	"github.com/stretchr/testify/assert"
+)
+
+func runTestPacketFilterRuleBuilder(t *testing.T, securityGroupJSON string, expectedRules []string) {
+	var secGroup public.ModelsSecurityGroup
+	err := json.Unmarshal([]byte(securityGroupJSON), &secGroup)
+	if err != nil {
+		t.Fatalf("Error unmarshaling JSON: %v", err)
+	}
+
+	// Initialize pfRuleBuilder
+	prb := &pfRuleBuilder{iface: "utun8"}
+
+	// Explicit drop if inbound rules are defined
+	if len(secGroup.InboundRules) > 0 {
+		prb.pfBlockAll("in")
+	}
+	// Process inbound rules
+	for _, rule := range secGroup.InboundRules {
+		if len(rule.IpRanges) == 0 || containsEmptyRange(rule.IpRanges) {
+			if err := prb.pfPermitProtoPortAnyAddr(rule, "inbound"); err != nil {
+				t.Errorf("pfctl setup error, failed to process inbound rule with 'any': %v", err)
+			}
+		} else if util.ContainsValidCustomIPv4Ranges(rule.IpRanges) || util.ContainsValidCustomIPv6Ranges(rule.IpRanges) {
+			if err := prb.pfPermitProtoPortAddr(rule, "inbound"); err != nil {
+				t.Errorf("pfctl setup error, failed to process inbound rule: %v", err)
+			}
+		} else {
+			if err := prb.pfPermitProtoPortAnyAddr(rule, "inbound"); err != nil {
+				t.Errorf("pfctl setup error, failed to process inbound rule with 'any': %v", err)
+			}
+		}
+	}
+	// Explicit drop if outbound rules are defined
+	if len(secGroup.OutboundRules) > 0 {
+		prb.pfBlockAll("out")
+	}
+	// Process outbound rules
+	for _, rule := range secGroup.OutboundRules {
+		if len(rule.IpRanges) == 0 || containsEmptyRange(rule.IpRanges) {
+			if err := prb.pfPermitProtoPortAnyAddr(rule, "outbound"); err != nil {
+				t.Errorf("pfctl setup error, failed to process outbound rule with 'any': %v", err)
+			}
+		} else if util.ContainsValidCustomIPv4Ranges(rule.IpRanges) || util.ContainsValidCustomIPv6Ranges(rule.IpRanges) {
+			if err := prb.pfPermitProtoPortAddr(rule, "outbound"); err != nil {
+				t.Errorf("pfctl setup error, failed to process outbound rule: %v", err)
+			}
+		} else {
+			if err := prb.pfPermitProtoPortAnyAddr(rule, "outbound"); err != nil {
+				t.Errorf("pfctl setup error, failed to process outbound rule with 'any': %v", err)
+			}
+		}
+	}
+
+	// Assert and output the generated rules for debugging
+	t.Logf("Generated pf rules:\n%s\n", prb.sb.String())
+
+	for _, rule := range expectedRules {
+		assert.Contains(t, prb.sb.String(), rule, "Generated rules should include: "+rule)
+	}
+}
+
+func TestDarwinRuleBuilder(t *testing.T) {
+	mockSecurityGroup1 := `
+{
+	"group_name": "Test",
+	"inbound_rules": [
+		{"ip_protocol": "ipv4", "ip_ranges": ["10.0.0.1/24", "192.168.1.1/32"]},
+		{"ip_protocol": "ipv4", "ip_ranges": ["0.0.0.0/0"]},
+		{"ip_protocol": "tcp"},
+		{"ip_protocol": "ipv6", "ip_ranges": ["::1/128", "2001:db8::/64"]},
+		{"from_port": 22, "to_port": 22, "ip_protocol": "tcp", "ip_ranges": ["10.0.0.1", "192.168.0.1"]},
+		{"from_port": 80, "to_port": 80, "ip_protocol": "tcp", "ip_ranges": ["10.0.0.2", "10.0.0.3"]},
+		{"ip_protocol": "icmpv4", "ip_ranges": ["10.0.0.1"]},
+		{"ip_protocol": "icmpv4"},
+		{"ip_protocol": "tcp", "from_port": 9001, "to_port": 9005, "ip_ranges": ["100.64.0.1 - 100.64.0.45"]},
+		{"ip_protocol": "icmpv6", "ip_ranges": ["::1"]},
+		{"ip_protocol": "icmp", "ip_ranges": ["::1"]},
+		{"ip_protocol": "udp"},
+		{"ip_protocol": "tcp", "from_port": 22, "to_port": 22},
+		{"ip_protocol": "icmp6"},
+		{"ip_protocol": "icmp4"},
+		{"ip_protocol": "ipv4"},
+		{"ip_protocol": "udp", "from_port": 54, "to_port": 54, "ip_ranges": ["100.64.0.1 - 100.64.0.45", "100.64.100.0/24", "100.64.0.120"]},
+		{"ip_protocol": "ipv4", "from_port": 9000, "to_port": 9001},
+		{"ip_protocol": "ipv6", "from_port": 43333, "to_port": 53333},
+		{"ip_protocol": "ipv6", "from_port": 0, "to_port": 0},
+		{"ip_protocol": "ipv4", "from_port": 0, "to_port": 0, "ip_ranges": [""]}
+	],
+	"outbound_rules": [
+		{"ip_protocol": "tcp", "from_port": 80, "to_port": 80, "ip_ranges": ["192.168.0.1", "10.120.0.2"]},
+		{"ip_protocol": "udp", "from_port": 53, "to_port": 53, "ip_ranges": ["8.8.8.8"]},
+		{"ip_protocol": "icmpv6", "ip_ranges": ["::1", "2001:db8:1234::/48"]},
+		{"ip_protocol": "icmp6"},
+		{"ip_protocol": "icmp"},
+		{"ip_protocol": "ipv4", "ip_ranges": ["", "10.0.0.3"]},
+		{"ip_protocol": "ipv4", "from_port": 123, "to_port": 456},
+		{"ip_protocol": "ipv6", "from_port": 41000, "to_port": 41500},
+		{"ip_protocol": "ipv4", "from_port": 52000, "to_port": 53000, "ip_ranges": ["192.168.0.1", "10.130.0.2"]},
+		{"ip_protocol": "ipv6", "from_port": 78, "to_port": 89, "ip_ranges": ["2001:db9::2/64", "3001:da9::2-3001:da9::6"]}
+	]
+}
+`
+
+	mockSecurityGroup1ExpectedRules := []string{
+		"block in on utun8 all",
+		"pass in quick on utun8 inet from { 10.0.0.1/24, 192.168.1.1/32 } to any",
+		"pass in quick on utun8 inet from { 0.0.0.0/0 } to any",
+		"pass in quick on utun8 inet proto tcp from any to any",
+		"pass in quick on utun8 inet6 from { ::1/128, 2001:db8::/64 } to any",
+		"pass in quick on utun8 inet proto tcp from { 10.0.0.1, 192.168.0.1 } to any port 22:22",
+		"pass in quick on utun8 inet proto tcp from { 10.0.0.2, 10.0.0.3 } to any port 80:80",
+		"pass in quick on utun8 inet proto icmp from { 10.0.0.1 } to any",
+		"pass in quick on utun8 inet proto icmp from any to any",
+		"pass in quick on utun8 inet proto tcp from { 100.64.0.1  -  100.64.0.45 } to any port 9001:9005",
+		"pass in quick on utun8 inet6 proto icmp6 from { ::1 } to any",
+		"pass in quick on utun8 inet proto icmp to any",
+		"pass in quick on utun8 inet6 proto icmp6 to any",
+		"pass in quick on utun8 inet proto udp from any to any",
+		"pass in quick on utun8 inet proto tcp from any to any port 22:22",
+		"pass in quick on utun8 inet6 proto icmp6 from any to any",
+		"pass in quick on utun8 inet proto icmp from any to any",
+		"pass in quick on utun8 inet from any to any",
+		"pass in quick on utun8 inet proto udp from { 100.64.0.1  -  100.64.0.45, 100.64.100.0/24, 100.64.0.120 } to any port 54:54",
+		"pass in quick on utun8 inet proto tcp from any to any port 9000:9001",
+		"pass in quick on utun8 inet proto udp from any to any port 9000:9001",
+		"pass in quick on utun8 inet6 proto tcp from any to any port 43333:53333",
+		"pass in quick on utun8 inet6 proto udp from any to any port 43333:53333",
+		"pass in quick on utun8 inet6 from any to any",
+		"pass in quick on utun8 inet from any to any",
+		"block out on utun8 all",
+		"pass out quick on utun8 inet proto tcp to { 192.168.0.1, 10.120.0.2 } port 80:80",
+		"pass out quick on utun8 inet proto udp to { 8.8.8.8 } port 53:53",
+		"pass out quick on utun8 inet6 proto icmp6 to { ::1, 2001:db8:1234::/48 }",
+		"pass out quick on utun8 inet6 proto icmp6 to any",
+		"pass out quick on utun8 inet proto icmp to any",
+		"pass out quick on utun8 inet6 proto icmp6 to any",
+		"pass out quick on utun8 inet to any",
+		"pass out quick on utun8 inet proto tcp to any port 123:456",
+		"pass out quick on utun8 inet proto udp to any port 123:456",
+		"pass out quick on utun8 inet6 proto tcp to any port 41000:41500",
+		"pass out quick on utun8 inet6 proto udp to any port 41000:41500",
+		"pass out quick on utun8 inet proto tcp to { 192.168.0.1, 10.130.0.2 } port 52000:53000",
+		"pass out quick on utun8 inet proto udp to { 192.168.0.1, 10.130.0.2 } port 52000:53000",
+		"pass out quick on utun8 inet6 proto tcp to { 2001:db9::2/64, 3001:da9::2 - 3001:da9::6 } port 78:89",
+		"pass out quick on utun8 inet6 proto udp to { 2001:db9::2/64, 3001:da9::2 - 3001:da9::6 } port 78:89",
+	}
+
+	t.Run("Test with mockSecurityGroup1", func(t *testing.T) {
+		runTestPacketFilterRuleBuilder(t, mockSecurityGroup1, mockSecurityGroup1ExpectedRules)
+	})
+}

--- a/internal/nexodus/policy_darwin_test.go
+++ b/internal/nexodus/policy_darwin_test.go
@@ -107,7 +107,8 @@ func TestDarwinRuleBuilder(t *testing.T) {
 		{"ip_protocol": "ipv4", "from_port": 123, "to_port": 456},
 		{"ip_protocol": "ipv6", "from_port": 41000, "to_port": 41500},
 		{"ip_protocol": "ipv4", "from_port": 52000, "to_port": 53000, "ip_ranges": ["192.168.0.1", "10.130.0.2"]},
-		{"ip_protocol": "ipv6", "from_port": 78, "to_port": 89, "ip_ranges": ["2001:db9::2/64", "3001:da9::2-3001:da9::6"]}
+		{"ip_protocol": "ipv6", "from_port": 78, "to_port": 89, "ip_ranges": ["2001:db9::2/64", "3001:da9::2-3001:da9::6"]},
+		{"ip_protocol": "icmp", "from_port": 0, "to_port": 0, "ip_ranges": [""]}
 	]
 }
 `
@@ -154,6 +155,8 @@ func TestDarwinRuleBuilder(t *testing.T) {
 		"pass out quick on utun8 inet proto udp to { 192.168.0.1, 10.130.0.2 } port 52000:53000",
 		"pass out quick on utun8 inet6 proto tcp to { 2001:db9::2/64, 3001:da9::2 - 3001:da9::6 } port 78:89",
 		"pass out quick on utun8 inet6 proto udp to { 2001:db9::2/64, 3001:da9::2 - 3001:da9::6 } port 78:89",
+		"pass in quick on utun8 inet proto icmp from any to any",
+		"pass in quick on utun8 inet6 proto icmp6 from any to any",
 	}
 
 	t.Run("Test with mockSecurityGroup1", func(t *testing.T) {

--- a/internal/nexodus/policy_windows.go
+++ b/internal/nexodus/policy_windows.go
@@ -3,26 +3,25 @@
 package nexodus
 
 import (
-	"fmt"
 	"go.uber.org/zap"
 )
 
-// ProcessSecurityGroup for windows build purposes, policy currently unsupported on windows
+// processSecurityGroupRules for windows build purposes, policy currently unsupported on windows
 func (nx *Nexodus) processSecurityGroupRules() error {
 	return nil
 }
 
-// nfNetworkRouterSetup for windows build purposes, network router currently unsupported on windows
-func (nx *Nexodus) nfNetworkRouterSetup() error {
+// networkRouterSetup for windows build purposes, network router currently unsupported on windows
+func (nx *Nexodus) networkRouterSetup() error {
 	return nil
 }
 
-// runNftCmd for windows build purposes
-func runNftCmd(logger *zap.SugaredLogger, cmd []string) (string, error) {
+// policyCmd for windows build purposes
+func policyCmd(logger *zap.SugaredLogger, cmd []string) (string, error) {
 	return "", nil
 }
 
-// nfTableDrop for windows build purposes
-func (nx *Nexodus) nfTableDrop(table string) error {
-	return fmt.Errorf("nft table drop method currently unsupported for windows")
+// policyTableDrop for windows build purposes
+func (nx *Nexodus) policyTableDrop(table string) error {
+	return nil
 }


### PR DESCRIPTION
- Adds v4/v6 policy support via PF for darwin.
- Creates a PF anchorfile in `/etc/pf.anchors/io.nexodus` and copies the main pf.conf for loading to avoid modifying a system file.