### PR TITLE
nexd: Add unit tests for peering method fallback and fix some bugs

### DIFF
--- a/internal/nexodus/nexodus.go
+++ b/internal/nexodus/nexodus.go
@@ -82,8 +82,6 @@ type userspaceWG struct {
 const ()
 
 type peerHealth struct {
-	// the time we started tracking this data
-	startTime time.Time
 	// the last tx bytes value for this peer
 	lastTxBytes int64
 	// the time of the last tx bytes update
@@ -1010,7 +1008,7 @@ func (nx *Nexodus) reconcileDeviceCache() error {
 		existing.endpoint = curStats.Endpoint
 		existing.peerHealthy = nx.peerIsHealthy(existing)
 		if existing.peerHealthy {
-			existing.startTime = now
+			existing.peerHealthyTime = now
 		}
 		nx.deviceCache[p.PublicKey] = existing
 	}
@@ -1024,7 +1022,6 @@ func (nx *Nexodus) reconcileDeviceCache() error {
 			if !ok {
 				continue
 			}
-			existing.startTime = now
 			if peerConfig, ok := nx.wgConfig.Peers[peer.PublicKey]; ok {
 				existing.endpoint = peerConfig.Endpoint
 			}

--- a/internal/nexodus/nexodus.go
+++ b/internal/nexodus/nexodus.go
@@ -933,12 +933,12 @@ func (nx *Nexodus) peerIsHealthy(d deviceCacheEntry) bool {
 }
 
 // assumes deviceCacheLock is held with a write-lock
-func (nx *Nexodus) addToDeviceCache(p public.ModelsDevice, reset bool) {
+func (nx *Nexodus) addToDeviceCache(p public.ModelsDevice) {
 	d := deviceCacheEntry{
 		device:      p,
 		lastUpdated: time.Now(),
 	}
-	nx.peeringReset(&d, reset)
+	nx.peeringReset(&d)
 	nx.deviceCache[p.PublicKey] = d
 }
 
@@ -975,7 +975,7 @@ func (nx *Nexodus) reconcileDeviceCache() error {
 			if p.PublicKey == nx.wireguardPubKey {
 				newLocalConfig = true
 			}
-			nx.addToDeviceCache(p, ok)
+			nx.addToDeviceCache(p)
 			existing = nx.deviceCache[p.PublicKey]
 			delete(peerStats, p.PublicKey)
 		}

--- a/internal/nexodus/wg_peers.go
+++ b/internal/nexodus/wg_peers.go
@@ -147,9 +147,9 @@ func (nx *Nexodus) rebuildPeerConfig(d *deviceCacheEntry, healthyRelay bool) (wg
 		nx.org.CidrV6,
 	}
 
-	peer := wgPeerConfig{}
-	chosenMethod := ""
-	chosenMethodIndex := -1
+	peer := nx.wgConfig.Peers[d.device.PublicKey]
+	chosenMethod := d.peeringMethod
+	chosenMethodIndex := d.peeringMethodIndex
 	for i, method := range wgPeerMethods {
 		if i < d.peeringMethodIndex {
 			// A peering method was previously chosen and we haven't reached it yet
@@ -210,9 +210,8 @@ func (nx *Nexodus) buildPeersConfig() map[string]public.ModelsDevice {
 
 		peerConfig, chosenMethod, chosenMethodIndex := nx.rebuildPeerConfig(&d, healthyRelay)
 
-		if chosenMethodIndex < 0 || !nx.peerConfigUpdated(d.device, peerConfig) {
-			// We either didn't choose a peering method at all,
-			// or the resulting peer configuration hasn't changed.
+		if !nx.peerConfigUpdated(d.device, peerConfig) {
+			// The resulting peer configuration hasn't changed.
 			continue
 		}
 

--- a/internal/nexodus/wg_peers.go
+++ b/internal/nexodus/wg_peers.go
@@ -256,7 +256,7 @@ func (nx *Nexodus) peeringFailed(d deviceCacheEntry, healthyRelay bool) bool {
 		return false
 	}
 
-	if !d.peerHealthyTime.IsZero() && time.Since(d.peeringTime) < peeringRestoreTimeout {
+	if !d.peerHealthyTime.IsZero() && time.Since(d.peerHealthyTime) < peeringRestoreTimeout {
 		// Peering worked, but went down, so give it a few minutes to come back up.
 		return false
 	}

--- a/internal/nexodus/wg_peers_test.go
+++ b/internal/nexodus/wg_peers_test.go
@@ -3,29 +3,36 @@ package nexodus
 import (
 	"net/netip"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 
 	"github.com/nexodus-io/nexodus/internal/api/public"
 )
 
 func TestRebuildPeerConfig(t *testing.T) {
+	zLogger, _ := zap.NewDevelopment()
+	testLogger := zLogger.Sugar()
 	nxBase := &Nexodus{
 		org: &public.ModelsOrganization{
 			Cidr:   "100.64.0.0/10",
 			CidrV6: "200::/64",
 		},
 		nodeReflexiveAddressIPv4: netip.MustParseAddrPort("1.1.1.1:1234"),
+		logger:                   testLogger,
 	}
 	nxRelay := &Nexodus{
 		org:                      nxBase.org,
 		relay:                    true,
 		nodeReflexiveAddressIPv4: netip.MustParseAddrPort("1.1.1.1:1234"),
+		logger:                   testLogger,
 	}
 	nxSymmetricNAT := &Nexodus{
 		org:                      nxBase.org,
 		symmetricNat:             true,
 		nodeReflexiveAddressIPv4: netip.MustParseAddrPort("1.1.1.1:1234"),
+		logger:                   testLogger,
 	}
 
 	testCases := []struct {
@@ -41,6 +48,8 @@ func TestRebuildPeerConfig(t *testing.T) {
 		healthyRelay bool
 		// the peering method expected to be chosen based on the local and remote peer parameters
 		expectedMethod string
+		// the second choices peering method
+		secondMethod string
 	}{
 		{
 			// Ensure we choose direct peering when the reflexive IPs are the same
@@ -49,6 +58,7 @@ func TestRebuildPeerConfig(t *testing.T) {
 			peerLocalIP:    "192.168.10.50:5678",
 			peerStunIP:     "1.1.1.1:4321",
 			expectedMethod: peeringMethodDirectLocal,
+			secondMethod:   peeringMethodReflexive,
 		},
 		{
 			// Ensure we choose reflexive peering when the reflexive IPs are different
@@ -57,6 +67,7 @@ func TestRebuildPeerConfig(t *testing.T) {
 			peerLocalIP:    "192.168.10.50:5678",
 			peerStunIP:     "2.2.2.2:4321",
 			expectedMethod: peeringMethodReflexive,
+			secondMethod:   peeringMethodReflexive, // our only choice
 		},
 		{
 			// Peer directly with a relay that is behind the same reflexive IP
@@ -66,6 +77,7 @@ func TestRebuildPeerConfig(t *testing.T) {
 			peerStunIP:     "1.1.1.1:4321",
 			peerIsRelay:    true,
 			expectedMethod: peeringMethodRelayPeerDirectLocal,
+			secondMethod:   peeringMethodRelayPeer,
 		},
 		{
 			// Peer via the reflexive IP of a relay when not behind the same reflexive IP
@@ -75,6 +87,7 @@ func TestRebuildPeerConfig(t *testing.T) {
 			peerStunIP:     "2.2.2.2:4321",
 			peerIsRelay:    true,
 			expectedMethod: peeringMethodRelayPeer,
+			secondMethod:   peeringMethodRelayPeer, // our only choice
 		},
 		{
 			// We are the relay on the same network as a peer
@@ -83,6 +96,7 @@ func TestRebuildPeerConfig(t *testing.T) {
 			peerLocalIP:    "192.168.10.50:5678",
 			peerStunIP:     "1.1.1.1:4321",
 			expectedMethod: peeringMethodRelaySelfDirectLocal,
+			secondMethod:   peeringMethodRelaySelf,
 		},
 		{
 			// Ensure we choose reflexive peering when the reflexive IPs are different
@@ -91,6 +105,7 @@ func TestRebuildPeerConfig(t *testing.T) {
 			peerLocalIP:    "192.168.10.50:5678",
 			peerStunIP:     "2.2.2.2:4321",
 			expectedMethod: peeringMethodRelaySelf,
+			secondMethod:   peeringMethodRelaySelf, // our only choice
 		},
 		{
 			// Use direct peering when behind the same reflexive IP, even if we are also
@@ -100,6 +115,7 @@ func TestRebuildPeerConfig(t *testing.T) {
 			peerLocalIP:    "192.168.10.50:5678",
 			peerStunIP:     "1.1.1.1:4321",
 			expectedMethod: peeringMethodDirectLocal,
+			secondMethod:   peeringMethodDirectLocal, // our only choice without a relay
 		},
 		{
 			// No peering method available when we are behind symmetric NAT and we
@@ -109,6 +125,7 @@ func TestRebuildPeerConfig(t *testing.T) {
 			peerLocalIP:    "192.168.10.50:5678",
 			peerStunIP:     "2.2.2.2:4321",
 			expectedMethod: "",
+			secondMethod:   "",
 		},
 		{
 			// Use the relay when we are behind symmetric NAT and we have a relay available
@@ -118,6 +135,7 @@ func TestRebuildPeerConfig(t *testing.T) {
 			peerStunIP:     "2.2.2.2:4321",
 			healthyRelay:   true,
 			expectedMethod: peeringMethodViaRelay,
+			secondMethod:   peeringMethodViaRelay, // our only choice
 		},
 		{
 			// Use the relay when the peer is behind symmetric NAT, even if we are not
@@ -128,6 +146,7 @@ func TestRebuildPeerConfig(t *testing.T) {
 			peerSymmetricNAT: true,
 			healthyRelay:     true,
 			expectedMethod:   peeringMethodViaRelay,
+			secondMethod:     peeringMethodViaRelay, // our only choice
 		},
 	}
 
@@ -136,7 +155,6 @@ func TestRebuildPeerConfig(t *testing.T) {
 	for _, tcIter := range testCases {
 		tc := tcIter
 		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
 			d := deviceCacheEntry{
 				device: public.ModelsDevice{
 					Endpoints: []public.ModelsEndpoint{
@@ -149,12 +167,39 @@ func TestRebuildPeerConfig(t *testing.T) {
 							Source:  "stun",
 						},
 					},
+					PublicKey:    "bacon",
 					Relay:        tc.peerIsRelay,
 					SymmetricNat: tc.peerSymmetricNAT,
 				},
 			}
-			_, chosenMethod, _ := tc.nx.rebuildPeerConfig(&d, tc.healthyRelay)
+			_, chosenMethod, chosenIndex := tc.nx.rebuildPeerConfig(&d, tc.healthyRelay)
 			require.Equal(tc.expectedMethod, chosenMethod)
+
+			now := time.Now()
+
+			// Ensure we stick with the chosen method while the peer is healthy.
+			// Set that we peered 15 minutes ago and it was healthy 5 seconds later.
+			d.peerHealthy = true
+			d.peeringMethod = chosenMethod
+			d.peeringMethodIndex = chosenIndex
+			d.peeringTime = now.Add(-15 * time.Minute)
+			d.peerHealthyTime = now.Add(-15*time.Minute + 5*time.Second)
+			_, chosenMethod, _ = tc.nx.rebuildPeerConfig(&d, tc.healthyRelay)
+			require.Equal(tc.expectedMethod, chosenMethod)
+
+			// Switch to unhealthy, but since this was previously a successful
+			// peer configuration, it should keep trying for 3 minutes. We
+			// have 1 minute until the deadline to work again.
+			d.peerHealthy = false
+			d.peerHealthyTime = now.Add(-1*peeringRestoreTimeout + time.Minute)
+			_, chosenMethod, _ = tc.nx.rebuildPeerConfig(&d, tc.healthyRelay)
+			require.Equal(tc.expectedMethod, chosenMethod)
+
+			// After 3 minutes, we should switch to the next best method.
+			// We were last healthy 3 minutes and 5 seconds ago.
+			d.peerHealthyTime = now.Add(-1*peeringRestoreTimeout - 5*time.Second)
+			_, chosenMethod, _ = tc.nx.rebuildPeerConfig(&d, tc.healthyRelay)
+			require.Equal(tc.secondMethod, chosenMethod)
 		})
 	}
 }


### PR DESCRIPTION
- nexd: Fix delay of peering fallback
- nexd: adjust rebuildPeerConfig() return values
- nexd: Expand peering unit tests
- nexd: Fix peering reset when no relays are present
- nexd: Add 3rd level peering fallback unit tests


commit 8de00491a5b700bc5da9074cafa365b9817a11d0
Author: Russell Bryant <russell.bryant@gmail.com>
Date:   Mon Oct 23 16:50:16 2023 -0400

    nexd: Add 3rd level peering fallback unit tests
    
    This change introduces tests for a 3rd level of peering fallback. It
    covers cases like:
    
        direct -> reflexive -> relay
    
    or if no relay was present:
    
        direct -> reflexive -> direct
    
    It also ensures that peering doesn't change once we fall back to a
    healthy relay.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>

commit e2cebf9f618173b14268e7b847bcc84f9d4b18a7
Author: Russell Bryant <russell.bryant@gmail.com>
Date:   Tue Oct 24 10:49:21 2023 -0400

    nexd: Fix peering reset when no relays are present
    
    The code that intended to make peering start over at the beginning
    would only work after connecting with a relay and then that relay goes
    away. If no relay was available, we would never go back to the
    beginning of the peering method list.
    
    This change also introduces a "none" peering method to be more
    explicit when we do not think it is currently possible to reach a
    peer via any means. Previously, "via-relay" was used for both
    "reachable by a relay" and "reachable IF a relay was present".
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>

commit 8e8711df7f04c54441f7fde52ef47b978e303f12
Author: Russell Bryant <russell.bryant@gmail.com>
Date:   Mon Oct 23 13:15:08 2023 -0400

    nexd: Expand peering unit tests
    
    Expand the peering method selection unit tests to cover the first
    level of fallback. It ensures that enough time is given before the
    fallback and that the expected second choice occurs.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>

commit a707e681be56db5cb4a3314fbb1eacf6a818cb56
Author: Russell Bryant <russell.bryant@gmail.com>
Date:   Mon Oct 23 13:35:58 2023 -0400

    nexd: adjust rebuildPeerConfig() return values
    
    When no new method is chosen, just return the current settings instead
    of blank. This doesn't change any behavior, but makes it a bit easier
    to write some tests.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>

commit 5b0c4c2b1b5f827f69829381319001a9d28528e3
Author: Russell Bryant <russell.bryant@gmail.com>
Date:   Mon Oct 23 13:13:09 2023 -0400

    nexd: Fix delay of peering fallback
    
    The code intended to delay dropping back to the next preferred peering
    method if a given method was previously working and then stopped. The
    intent was to wait 3 minutes in that case, instead of waiting much
    less time for a method that had not yet worked at all.
    
    The code was checking the wrong timestamp for this. The problem was
    discovered while writing unit tests for this code.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>
