### PR TITLE
Add qa-dev to promote for promotion validation

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -7,6 +7,62 @@ on:
   workflow_dispatch:
 
 jobs:
+  run-qa-dev:
+    # Dispatch the qa-dev workflow to validate main prior to promotion
+    runs-on: ubuntu-latest
+
+    env:
+      WAIT_INTERVAL: "60"
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Capture current timestamp
+        run: |
+          current_time=$(date --utc +%Y-%m-%dT%H:%M:%S+00:00)
+          echo "current_time=${current_time}" >> "$GITHUB_ENV"
+
+      - name: Dispatch the qa-dev workflow
+        run: |
+          curl -X POST \
+          -H "Authorization: token ${{secrets.GITHUB_TOKEN}}" \
+          -H "Accept: application/vnd.github.v3+json" \
+          "https://api.github.com/repos/${{github.repository}}/actions/workflows/qa-dev.yml/dispatches" \
+          -d '{"ref": "main", "inputs": {"deployment_size": "small", "pr_or_branch": "main"}}'
+          echo "Triggered qa-dev Workflow."
+
+      - name: Wait for qa-dev workflow to complete
+        timeout-minutes: 30
+        run: |
+          check_status() {
+            runs=$(curl -s -H "Authorization: token ${{secrets.GITHUB_TOKEN}}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            "https://api.github.com/repos/${{github.repository}}/actions/workflows/deploy-qa-test.yml/runs?per_page=10")
+
+            latest_run=$(echo "$runs" | jq -r --arg timestamp "$current_time" \
+            '.workflow_runs[] | select(.created_at >= $timestamp) | .')
+          
+            status=$(echo "$latest_run" | jq -r '.status')
+            conclusion=$(echo "$latest_run" | jq -r '.conclusion')
+
+            echo "Workflow status: $status, conclusion: $conclusion"
+
+            if [[ "$status" == "completed" && "$conclusion" == "success" ]]; then
+              return 0
+            elif [[ "$status" == "completed" && "$conclusion" != "success" ]]; then
+              echo "qa-dev workflow failed. For details, see https://github.com/nerdalert/apex-qa/actions/workflows/deploy-qa-test.yml"
+              exit 1
+            else
+              return 1
+            fi
+          }
+
+          while ! check_status; do
+            echo "Waiting for qa-dev workflow to complete..."
+            sleep "$WAIT_INTERVAL"
+          done
+
   update-prod:
     # Sync prod with the QA ref
     name: Update Production Deployment


### PR DESCRIPTION
Closes #1554

GH doesn't return a job ID from a dispatch so this timestamps and queries qa-dev for runs after the timestamp. This should work in all scenarios since qa-dev is in a concurrency group and shouldn't conflict with other dispatches. More on the API limitation [here](https://github.com/orgs/community/discussions/9752).

I validated the API calls in a fork and they are functional. Going to draft this until Monday when we promote next.
