### PR TITLE
Exit node fixes

### DIFF
--- a/internal/nexodus/ctlexit.go
+++ b/internal/nexodus/ctlexit.go
@@ -31,13 +31,42 @@ func (ac *NexdCtl) DisableExitNodeClient(_ string, result *string) error {
 	return nil
 }
 
+// ListExitNodes lists all exit node origins
 func (ac *NexdCtl) ListExitNodes(_ string, result *string) error {
-	exitNodeOrigins, err := json.Marshal(ac.nx.exitNode.exitNodeOrigins)
-	if err != nil {
-		return fmt.Errorf("error marshalling disable exit node results %w", err)
+	var allExitNodeOrigins []wgPeerConfig
+	isExitNode := false
+
+	// Check if the local node is an exit node
+	for _, prefix := range ac.nx.childPrefix {
+		if prefix == "0.0.0.0/0" {
+			isExitNode = true
+			break
+		}
 	}
 
-	*result = string(exitNodeOrigins)
+	// If the local node is an exit node, create a copy and append the new instance
+	if isExitNode {
+		// Make a copy of exitNodeOrigins to a new slice
+		allExitNodeOrigins = make([]wgPeerConfig, len(ac.nx.exitNode.exitNodeOrigins))
+		copy(allExitNodeOrigins, ac.nx.exitNode.exitNodeOrigins)
+
+		// Create a new instance of wgPeerConfig
+		newPeerConfig := wgPeerConfig{
+			PublicKey: ac.nx.wireguardPubKey,
+			Endpoint:  ac.nx.nodeReflexiveAddressIPv4.String(),
+		}
+		// Append the local node if it is an exit node
+		allExitNodeOrigins = append(allExitNodeOrigins, newPeerConfig)
+	} else {
+		allExitNodeOrigins = ac.nx.exitNode.exitNodeOrigins
+	}
+
+	exitNodeOriginsJSON, err := json.Marshal(allExitNodeOrigins)
+	if err != nil {
+		return fmt.Errorf("error marshalling exit node list results: %w", err)
+	}
+
+	*result = string(exitNodeOriginsJSON)
 
 	return nil
 }

--- a/internal/nexodus/exit_origin.go
+++ b/internal/nexodus/exit_origin.go
@@ -61,3 +61,21 @@ func addExitOriginForwardRule(logger *zap.SugaredLogger) error {
 
 	return nil
 }
+
+func (nx *Nexodus) updateExitNodeOrigins(newPeer wgPeerConfig) {
+	nx.exitNode.exitNodeExists = true
+	// check if the exit node already exists and update its details
+	found := false
+	for i, existingPeerConfig := range nx.exitNode.exitNodeOrigins {
+		if existingPeerConfig.PublicKey == newPeer.PublicKey {
+			nx.exitNode.exitNodeOrigins[i].Endpoint = newPeer.Endpoint
+			found = true
+			break
+		}
+	}
+
+	// If no existing entry with the same public key was found, append the new exit node
+	if !found {
+		nx.exitNode.exitNodeOrigins = append(nx.exitNode.exitNodeOrigins, newPeer)
+	}
+}

--- a/internal/nexodus/route_darwin.go
+++ b/internal/nexodus/route_darwin.go
@@ -22,8 +22,7 @@ func (nx *Nexodus) handlePeerRouteOS(wgPeerConfig wgPeerConfig) error {
 	for _, allowedIP := range wgPeerConfig.AllowedIPs {
 		// if the peer is advertising a default route, append it as an exit origin node, but don't add the route
 		if util.IsDefaultIPv4Route(allowedIP) || util.IsDefaultIPv6Route(allowedIP) {
-			nx.exitNode.exitNodeExists = true
-			nx.exitNode.exitNodeOrigins = append(nx.exitNode.exitNodeOrigins, wgPeerConfig)
+			nx.updateExitNodeOrigins(wgPeerConfig)
 			continue
 		}
 

--- a/internal/nexodus/route_linux.go
+++ b/internal/nexodus/route_linux.go
@@ -16,8 +16,7 @@ func (nx *Nexodus) handlePeerRouteOS(wgPeerConfig wgPeerConfig) error {
 	for _, allowedIP := range wgPeerConfig.AllowedIPs {
 		// if the peer is advertising a default route, append it as an exit origin node, but don't add the route
 		if util.IsDefaultIPv4Route(allowedIP) || util.IsDefaultIPv6Route(allowedIP) {
-			nx.exitNode.exitNodeExists = true
-			nx.exitNode.exitNodeOrigins = append(nx.exitNode.exitNodeOrigins, wgPeerConfig)
+			nx.updateExitNodeOrigins(wgPeerConfig)
 			continue
 		}
 

--- a/internal/nexodus/route_windows.go
+++ b/internal/nexodus/route_windows.go
@@ -16,8 +16,7 @@ func (nx *Nexodus) handlePeerRouteOS(wgPeerConfig wgPeerConfig) error {
 	for _, allowedIP := range wgPeerConfig.AllowedIPs {
 		// if the peer is advertising a default route, append it as an exit origin node, but don't add the route
 		if util.IsDefaultIPv4Route(allowedIP) || util.IsDefaultIPv6Route(allowedIP) {
-			nx.exitNode.exitNodeExists = true
-			nx.exitNode.exitNodeOrigins = append(nx.exitNode.exitNodeOrigins, wgPeerConfig)
+			nx.updateExitNodeOrigins(wgPeerConfig)
 			continue
 		}
 


### PR DESCRIPTION
- Fixes an issue where exit nodes were being duplicated in `exitNodeOrigins` if the endpoint address changed. It now keys off the public key to avoid duplication.
```
# Resolves this:
nexctl nexd exit-node list
ENDPOINT ADDRESS        PUBLIC KEY
192.168.64.2:56997      Wneb+xx6481iaWB2eohZmEttZzar+G7R6A0hoBYkJBQ=
192.168.64.2:55374      Wneb+xx6481iaWB2eohZmEttZzar+G7R6A0hoBYkJBQ=
```
- Adjust nexctl to display the local node if it is an exit node. Currently, if the local node is an exit node it is omitted from the nexctl output of `nexctl nexd exit-node list`. It only adjusts the nexctl output since it is operating as intended since it is using peer data from the api-server.
