### PR TITLE
e2e: Add more flexibility to the proxy LB test

### DIFF
--- a/integration-tests/proxy_test.go
+++ b/integration-tests/proxy_test.go
@@ -905,11 +905,15 @@ func testProxyLoadBalancer(t *testing.T, opts testProxyLoadBalancerOpts) {
 		}
 		helper.Logf("TCP responses: apples=%d, bananas=%d", apples, bananas)
 		helper.Logf("UDP responses: carrot=%d, potato=%d", carrot, potato)
-		require.Equal(5, apples)
-		require.Equal(5, bananas)
+		// Allow for some failures/retries for TCP
+		require.GreaterOrEqual(apples, 3)
+		require.GreaterOrEqual(bananas, 3)
 		// Allow some drops for UDP
 		require.GreaterOrEqual(carrot, 3)
 		require.GreaterOrEqual(potato, 3)
+		// In both cases the total should be 10
+		require.Equal(10, apples+bananas)
+		require.Equal(10, carrot+potato)
 		return true, nil
 	}
 


### PR DESCRIPTION
I've seen cases where this test fails because the counters are not 5
and 5. This was the last one:

    proxy_test.go:906: TCP responses: apples=4, bananas=6
    proxy_test.go:907: UDP responses: carrot=5, potato=5

I can see that curl failed once and had to retry. In that case, we'll
hit the other endpoint.

Make the test more flexible for when this happens. Make sure we hit
each endpoint at least 3 times and that the sum is still 10.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
