### PR TITLE
nexd: Add child prefix routing through relays

### DIFF
--- a/integration-tests/integration_test.go
+++ b/integration-tests/integration_test.go
@@ -409,8 +409,8 @@ func TestHubVPC(t *testing.T) {
 	err := helper.nexdStatus(ctx, node1)
 	require.NoError(err)
 
-	helper.runNexd(ctx, node2, "--username", username, "--password", password, "--vpc-id", vpcID)
-	helper.runNexd(ctx, node3, "--username", username, "--password", password, "--vpc-id", vpcID)
+	helper.runNexd(ctx, node2, "--username", username, "--password", password, "--vpc-id", vpcID, "--relay-only")
+	helper.runNexd(ctx, node3, "--username", username, "--password", password, "--vpc-id", vpcID, "--relay-only")
 
 	node1IP, err := getContainerIfaceIP(ctx, inetV4, "wg0", node1)
 	require.NoError(err)
@@ -449,7 +449,7 @@ func TestHubVPC(t *testing.T) {
 	require.NoError(err)
 
 	helper.runNexd(ctx, node2, "--username", username, "--password", password,
-		"--vpc-id", vpcID,
+		"--vpc-id", vpcID, "--relay-only",
 		"router", fmt.Sprintf("--advertise-cidr=%s", hubVPCAdvertiseCidr),
 	)
 
@@ -469,7 +469,7 @@ func TestHubVPC(t *testing.T) {
 	node2LoopbackIP, _, _ := net.ParseCIDR(node2AdvertiseCidrLoopbackNet)
 
 	t.Logf("Pinging loopback on node2 %s from node3 wg0", node2LoopbackIP.String())
-	err = ping(ctx, node2, inetV4, node2LoopbackIP.String())
+	err = ping(ctx, node3, inetV4, node2LoopbackIP.String())
 	require.NoError(err)
 
 	helper.Logf("Pinging %s from node1", node3IP)

--- a/internal/nexodus/nexodus.go
+++ b/internal/nexodus/nexodus.go
@@ -190,6 +190,7 @@ type wgPeerConfig struct {
 	Endpoint            string
 	AllowedIPs          []string
 	PersistentKeepAlive string
+	AllowedIPsForRelay  []string
 }
 
 type wgLocalConfig struct {

--- a/internal/nexodus/wg_peers.go
+++ b/internal/nexodus/wg_peers.go
@@ -94,7 +94,7 @@ var wgPeerMethods = []wgPeerMethod{
 		},
 		buildPeerConfig: func(nx *Nexodus, device public.ModelsDevice, _ []string, _, _, _ string) wgPeerConfig {
 			return wgPeerConfig{
-				AllowedIPsForRelay: device.ChildPrefix,
+				AllowedIPsForRelay: device.AdvertiseCidrs,
 			}
 		},
 	},
@@ -257,7 +257,7 @@ func (nx *Nexodus) buildPeersConfig() map[string]public.ModelsDevice {
 	if healthyRelay && len(allowedIPsForRelay) > 0 {
 		// Add child prefix CIDRs to the relay for peers that we can only reach via the relay
 		relayConfig := nx.wgConfig.Peers[relayDevice.PublicKey]
-		relayConfig.AllowedIPs = append([]string{nx.org.Cidr, nx.org.CidrV6}, allowedIPsForRelay...)
+		relayConfig.AllowedIPs = append([]string{nx.vpc.Ipv4Cidr, nx.vpc.Ipv4Cidr}, allowedIPsForRelay...)
 		nx.wgConfig.Peers[relayDevice.PublicKey] = relayConfig
 	}
 


### PR DESCRIPTION
Prior to this change, the only way to reach a child-prefix CIDR was by
peering directly with the device exposing that prefix.

This change updates relay peer configuration to include child-prefix
CIDRs for peers that are reachable via the relay instead of directly.

Closes #1536
