### PR TITLE
ui: fix security groups after API changes

### DIFF
--- a/ui/src/pages/SecurityGroups/SecurityGroupEditRules.tsx
+++ b/ui/src/pages/SecurityGroups/SecurityGroupEditRules.tsx
@@ -43,15 +43,11 @@ interface EditRulesProps {
   type: "inbound_rules" | "outbound_rules";
 }
 
-const updateSecurityGroup = (
-  organizationId: string,
-  securityGroupId: string,
-  data: any,
-) => {
+const updateSecurityGroup = (securityGroupId: string, data: any) => {
   console.log("Update SecGroup data being sent to the endpoint:", data);
   console.log(
     "Sending PATCH request to:",
-    `${backend}/api/organizations/${organizationId}/security_groups/${securityGroupId}`,
+    `${backend}/api/security-groups/${securityGroupId}`,
   );
   console.log("Data being sent:", JSON.stringify(data, null, 2));
 
@@ -63,7 +59,7 @@ const updateSecurityGroup = (
   };
 
   return fetchJson(
-    `${backend}/api/organizations/${organizationId}/security_groups/${securityGroupId}`,
+    `${backend}/api/security-groups/${securityGroupId}`,
     requestOptions,
   );
 };
@@ -157,7 +153,7 @@ const EditRules: React.FC<EditRulesProps> = ({
           outbound_rules: outboundRules,
         };
 
-        updateSecurityGroup(organizationId, securityGroupId, updateData)
+        updateSecurityGroup(securityGroupId, updateData)
           .then(() => {
             // Handle the response
             setNotificationType("success");

--- a/ui/src/pages/SecurityGroups/SecurityGroups.tsx
+++ b/ui/src/pages/SecurityGroups/SecurityGroups.tsx
@@ -45,10 +45,8 @@ export const SecurityGroups = () => {
     "success" | "error" | "info" | null
   >(null);
 
-  const fetchSecurityGroup = async (orgId: string, securityGroupId: string) => {
-    return await fetchJson(
-      `${backend}/api/organizations/${orgId}/security_group/${securityGroupId}`,
-    );
+  const fetchSecurityGroup = async (securityGroupId: string) => {
+    return await fetchJson(`${backend}/api/security-groups/${securityGroupId}`);
   };
 
   const fetchData = async () => {
@@ -65,7 +63,7 @@ export const SecurityGroups = () => {
       }
       // Fetch security groups data
       const securityGroupPromises = orgs.map((org) =>
-        fetchSecurityGroup(org.id, org.security_group_id),
+        fetchSecurityGroup(org.security_group_id),
       );
 
       const securityGroupsData = await Promise.all(securityGroupPromises);
@@ -95,7 +93,6 @@ export const SecurityGroups = () => {
     if (selectedOrg) {
       try {
         const updatedSecurityGroupData = await fetchSecurityGroup(
-          selectedOrg.id,
           selectedOrg.security_group_id,
         );
         setSelectedSecurityGroup(updatedSecurityGroupData);


### PR DESCRIPTION
The paths for the security-groups API changed in our recent round of
API updates. This change adjusts the security-groups page ti use the
new APIs.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
