### PR TITLE
Fix for gosec G601 error

### DIFF
--- a/internal/handlers/invitations_test.go
+++ b/internal/handlers/invitations_test.go
@@ -85,6 +85,7 @@ func (suite *HandlerTestSuite) TestCreateAcceptRefuseInvitation() {
 		var res *httptest.ResponseRecorder
 		switch c.action {
 		case "invite":
+			c := c
 			request := models.AddInvitation{
 				UserID:         &c.userID,
 				OrganizationID: c.orgID,


### PR DESCRIPTION
go-lint is throwing gosec G601 error on main branch.

```
nexodus git:(main) go version
go version go1.21.3 linux/amd64
➜  nexodus git:(main) make clean
➜  nexodus git:(main) make go-lint
  [GO LINT]    GOOS=linux
internal/handlers/invitations_test.go:89:21: G601: Implicit memory aliasing in for loop. (gosec)
                                UserID:         &c.userID,
                                                ^
make: *** [Makefile:185: dist/.go-lint-linux] Error 1
```