### PR TITLE
apiserver: add tests and #1582 for security groups.

### DIFF
--- a/integration-tests/features/security-group-api.feature
+++ b/integration-tests/features/security-group-api.feature
@@ -1,52 +1,99 @@
 Feature: Security Group API
+
   Background:
     Given a user named "Oscar" with password "testpass"
+    Given a user named "EvilBob" with password "testpass"
 
   Scenario: Show basic security group api in action
-
-    #
-    # Get the user and default org ids for a user...
-    #
 
     Given I am logged in as "Oscar"
     When I GET path "/api/users/me"
     Then the response code should be 200
     Given I store the ".id" selection from the response as ${oscar_user_id}
-    Given I store the ".username" selection from the response as ${oscar_username}
 
-    When I GET path "/api/organizations"
-    Then the response code should be 200
-    Given I store the ${response[0].id} as ${oscar_organization_id}
-
-    When I GET path "/api/organizations"
-    Then the response code should be 200
-    Given I store the ${response[0].security_group_id} as ${oscar_security_group_id}
-
-    When I GET path "/api/organizations"
+    # get the default security group.. it's ID should match the user's ID
+    When I GET path "/api/security-groups/${oscar_user_id}"
     Then the response code should be 200
     And the response should match json:
       """
-      [
-        {
-          "description": "${oscar_username}'s organization",
-          "id": "${oscar_organization_id}",
-          "name": "${oscar_username}",
-          "owner_id": "${oscar_user_id}",
-          "security_group_id": "${oscar_security_group_id}"
-        }
-      ]
-      """
-
-    When I GET path "/api/security-groups/${oscar_security_group_id}"
-    Then the response code should be 200
-    Given I store the ".revision" selection from the response as ${current_revision}
-    And the response should match json:
-  """
       {
         "group_description": "default organization security group",
         "group_name": "default",
-        "id": "${oscar_security_group_id}",
-        "organization_id": "${oscar_organization_id}",
-        "revision": ${current_revision}
+        "id": "${oscar_user_id}",
+        "organization_id": "${oscar_user_id}",
+        "revision": ${response.revision}
       }
-  """
+      """
+    Given I store the ${response} as ${default_security_group}
+
+    # Oscar should only have one security group at this point.
+    When I GET path "/api/security-groups"
+    Then the response code should be 200
+    And the response should match json:
+        """
+        [ ${default_security_group} ]
+        """
+
+    # Oscar should not be able to delete the default security group.
+    When I DELETE path "/api/security-groups/${oscar_user_id}"
+    Then the response code should be 400
+    And the response should match json:
+      """
+      {
+        "error": "operation not allowed",
+        "reason": "default security group cannot be deleted"
+      }
+      """
+
+    # But we can create additional security groups
+    When I POST path "/api/security-groups" with json body:
+      """
+      {
+        "organization_id": "${oscar_user_id}",
+        "group_description": "extra security group",
+        "group_name": "extra"
+      }
+      """
+    Then the response code should be 201
+    Given I store the ".id" selection from the response as ${extra_security_group_id}
+    And the response should match json:
+      """
+      {
+        "id": "${extra_security_group_id}",
+        "organization_id": "${oscar_user_id}",
+        "group_description": "extra security group",
+        "group_name": "extra",
+        "revision": ${response.revision}
+      }
+      """
+    Given I store the ${response} as ${extra_security_group}
+
+    # Oscar should now have two security groups.
+    When I GET path "/api/security-groups"
+    Then the response code should be 200
+    And the response should match json:
+      """
+      [ ${default_security_group}, ${extra_security_group} ]
+      """
+
+    # let's verify another user cannot access any of Oscar's resources
+    Given I am logged in as "EvilBob"
+    When I GET path "/api/security-groups/${oscar_user_id}"
+    Then the response code should be 404
+    When I GET path "/api/security-groups/${extra_security_group_id}"
+    Then the response code should be 404
+    When I DELETE path "/api/security-groups/${oscar_user_id}"
+    Then the response code should be 404
+    When I DELETE path "/api/security-groups/${extra_security_group_id}"
+    Then the response code should be 404
+
+    # Switch back to Oscar
+    Given I am logged in as "Oscar"
+
+    # We should be able to delete non default security groups.
+    When I DELETE path "/api/security-groups/${extra_security_group_id}"
+    Then the response code should be 200
+    And the response should match json:
+      """
+      ${extra_security_group}
+      """

--- a/internal/handlers/security_group.go
+++ b/internal/handlers/security_group.go
@@ -95,7 +95,7 @@ func (api *API) ListSecurityGroups(c *gin.Context) {
 	api.sendList(c, ctx, func(db *gorm.DB) (fetchmgr.ResourceList, error) {
 		var items securityGroupList
 		db = api.SecurityGroupIsReadableByCurrentUser(c, db)
-		db = FilterAndPaginateWithQuery(db, &models.SecurityGroup{}, c, query, "id")
+		db = FilterAndPaginateWithQuery(db, &models.SecurityGroup{}, c, query, "group_name")
 		result := db.Find(&items)
 		if result.Error != nil && !errors.Is(result.Error, gorm.ErrRecordNotFound) {
 			return nil, result.Error
@@ -290,13 +290,9 @@ func (api *API) CreateSecurityGroup(c *gin.Context) {
 			OutboundRules:    request.OutboundRules,
 			GroupDescription: request.GroupDescription,
 		}
-		if res := tx.Create(&sg); res.Error != nil {
-			return res.Error
-		}
-
-		// Replace the organization's SecurityGroupId field
-		org.SecurityGroupId = sg.ID
-		if res := tx.Save(&org); res.Error != nil {
+		if res := tx.
+			Clauses(clause.Returning{Columns: []clause.Column{{Name: "revision"}}}).
+			Create(&sg); res.Error != nil {
 			return res.Error
 		}
 
@@ -367,12 +363,15 @@ func (api *API) DeleteSecurityGroup(c *gin.Context) {
 	}
 
 	sg := models.SecurityGroup{}
-
 	err = api.transaction(ctx, func(tx *gorm.DB) error {
 
 		if res := api.SecurityGroupIsWriteableByCurrentUser(c, tx).
 			First(&sg, "id = ?", secGroupID); res.Error != nil {
 			return NewApiResponseError(http.StatusNotFound, models.NewNotFoundError("vpc"))
+		}
+
+		if sg.ID == sg.OrganizationId {
+			return NewApiResponseError(http.StatusBadRequest, models.NewNotAllowedError("default security group cannot be deleted"))
 		}
 
 		if res := tx.Delete(&sg, "id = ?", sg.ID); res.Error != nil {


### PR DESCRIPTION
Implements #1582 for security groups.
We now sort by the group name instead of by id.