### PR TITLE
nextctl: make all fields of the sg update optional.

### DIFF
--- a/integration-tests/features/security-group-api.feature
+++ b/integration-tests/features/security-group-api.feature
@@ -1,52 +1,124 @@
 Feature: Security Group API
+
   Background:
     Given a user named "Oscar" with password "testpass"
+    Given a user named "EvilBob" with password "testpass"
 
   Scenario: Show basic security group api in action
-
-    #
-    # Get the user and default org ids for a user...
-    #
 
     Given I am logged in as "Oscar"
     When I GET path "/api/users/me"
     Then the response code should be 200
     Given I store the ".id" selection from the response as ${oscar_user_id}
-    Given I store the ".username" selection from the response as ${oscar_username}
 
-    When I GET path "/api/organizations"
-    Then the response code should be 200
-    Given I store the ${response[0].id} as ${oscar_organization_id}
-
-    When I GET path "/api/organizations"
-    Then the response code should be 200
-    Given I store the ${response[0].security_group_id} as ${oscar_security_group_id}
-
-    When I GET path "/api/organizations"
+    # get the default security group.. it's ID should match the user's ID
+    When I GET path "/api/security-groups/${oscar_user_id}"
     Then the response code should be 200
     And the response should match json:
       """
-      [
-        {
-          "description": "${oscar_username}'s organization",
-          "id": "${oscar_organization_id}",
-          "name": "${oscar_username}",
-          "owner_id": "${oscar_user_id}",
-          "security_group_id": "${oscar_security_group_id}"
-        }
-      ]
-      """
-
-    When I GET path "/api/security-groups/${oscar_security_group_id}"
-    Then the response code should be 200
-    Given I store the ".revision" selection from the response as ${current_revision}
-    And the response should match json:
-  """
       {
         "group_description": "default organization security group",
         "group_name": "default",
-        "id": "${oscar_security_group_id}",
-        "organization_id": "${oscar_organization_id}",
-        "revision": ${current_revision}
+        "id": "${oscar_user_id}",
+        "organization_id": "${oscar_user_id}",
+        "revision": ${response.revision}
       }
-  """
+      """
+    Given I store the ${response} as ${default_security_group}
+
+    # Oscar should only have one security group at this point.
+    When I GET path "/api/security-groups"
+    Then the response code should be 200
+    And the response should match json:
+        """
+        [ ${default_security_group} ]
+        """
+
+    # He can create additional security groups
+    When I POST path "/api/security-groups" with json body:
+      """
+      {
+        "organization_id": "${oscar_user_id}",
+        "group_description": "extra security group",
+        "group_name": "extra"
+      }
+      """
+    Then the response code should be 201
+    Given I store the ".id" selection from the response as ${extra_security_group_id}
+    And the response should match json:
+      """
+      {
+        "id": "${extra_security_group_id}",
+        "organization_id": "${oscar_user_id}",
+        "group_description": "extra security group",
+        "group_name": "extra",
+        "revision": ${response.revision}
+      }
+      """
+    Given I store the ${response} as ${extra_security_group}
+
+    # Oscar should now have two security groups.
+    When I GET path "/api/security-groups"
+    Then the response code should be 200
+    And the response should match json:
+      """
+      [ ${default_security_group}, ${extra_security_group} ]
+      """
+
+    # let's verify another user cannot access any of Oscar's resources
+    Given I am logged in as "EvilBob"
+    When I GET path "/api/security-groups/${oscar_user_id}"
+    Then the response code should be 404
+    When I GET path "/api/security-groups/${extra_security_group_id}"
+    Then the response code should be 404
+    When I DELETE path "/api/security-groups/${oscar_user_id}"
+    Then the response code should be 404
+    When I DELETE path "/api/security-groups/${extra_security_group_id}"
+    Then the response code should be 404
+
+    # Switch back to Oscar
+    Given I am logged in as "Oscar"
+
+    # We should be able to delete non default security groups.
+    When I DELETE path "/api/security-groups/${extra_security_group_id}"
+    Then the response code should be 200
+    And the response should match json:
+      """
+      ${extra_security_group}
+      """
+
+    # The organization's security-group should be the default security group....
+    When I GET path "/api/organizations/${oscar_user_id}"
+    Then the response code should be 200
+    And the response should match json:
+      """
+      {
+        "id": "${oscar_user_id}",
+        "name": "${response.name}",
+        "description": "${response.description}",
+        "owner_id": "${oscar_user_id}",
+        "security_group_id": "${oscar_user_id}"
+      }
+      """
+
+    # If we delete the default security group, it should removed from the organization.
+    When I DELETE path "/api/security-groups/${oscar_user_id}"
+    Then the response code should be 200
+    And the response should match json:
+      """
+      ${default_security_group}
+      """
+
+    # verify it gets removed...
+    When I GET path "/api/organizations/${oscar_user_id}"
+    Then the response code should be 200
+    And the response should match json:
+      """
+      {
+        "id": "${oscar_user_id}",
+        "name": "${response.name}",
+        "description": "${response.description}",
+        "owner_id": "${oscar_user_id}",
+        "security_group_id": "00000000-0000-0000-0000-000000000000"
+      }
+      """

--- a/integration-tests/helper_test.go
+++ b/integration-tests/helper_test.go
@@ -562,11 +562,9 @@ func (helper *Helper) securityGroupRulesUpdate(username, password string, inboun
 		"--username", username,
 		"--password", password,
 		"security-group", "update",
-		"--name=default",
-		"--description=security group e2e",
+		"--security-group-id", secGroupID,
 		"--inbound-rules", string(inboundJSON),
 		"--outbound-rules", string(outboundJSON),
-		"--security-group-id", secGroupID,
 	}
 
 	out, err := helper.runCommand(command...)

--- a/internal/handlers/security_group_test.go
+++ b/internal/handlers/security_group_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"github.com/nexodus-io/nexodus/internal/util"
 	"io"
 	"net/http"
 
@@ -260,8 +261,8 @@ func (suite *HandlerTestSuite) TestUpdateSecurityGroup() {
 
 	// Update the security group
 	updateGroup := models.UpdateSecurityGroup{
-		GroupName:        "updatedTestGroup",
-		GroupDescription: "This is an updated test group",
+		GroupName:        util.PtrString("updatedTestGroup"),
+		GroupDescription: util.PtrString("This is an updated test group"),
 		InboundRules:     []models.SecurityRule{{IpProtocol: "tcp", FromPort: 22, ToPort: 22, IpRanges: []string{"10.130.0.1-10.130.0.5", "192.168.64.10-192.168.64.50", "100.100.0.128/25"}}},
 		OutboundRules:    []models.SecurityRule{{IpProtocol: "", FromPort: 0, ToPort: 0, IpRanges: []string{"200::/64", "201::1-201::8"}}},
 	}
@@ -289,8 +290,8 @@ func (suite *HandlerTestSuite) TestUpdateSecurityGroup() {
 	require.NoError(err)
 
 	// Check the updated fields
-	assert.Equal(updateGroup.GroupName, updatedGroup.GroupName)
-	assert.Equal(updateGroup.GroupDescription, updatedGroup.GroupDescription)
+	assert.Equal(*updateGroup.GroupName, updatedGroup.GroupName)
+	assert.Equal(*updateGroup.GroupDescription, updatedGroup.GroupDescription)
 	assert.Equal(updateGroup.InboundRules, updatedGroup.InboundRules)
 	assert.Equal(updateGroup.OutboundRules, updatedGroup.OutboundRules)
 }
@@ -332,8 +333,8 @@ func (suite *HandlerTestSuite) TestInvalidUpdateSecurityGroup() {
 
 	// Update the security group with an invalid rule (FromPort > ToPort)
 	updateGroup := models.UpdateSecurityGroup{
-		GroupName:        "updatedTestGroup",
-		GroupDescription: "This is an updated test group",
+		GroupName:        util.PtrString("updatedTestGroup"),
+		GroupDescription: util.PtrString("This is an updated test group"),
 		InboundRules: []models.SecurityRule{
 			{IpProtocol: "tcp", FromPort: 8081, ToPort: 8080, IpRanges: []string{"200::/64"}},
 		},
@@ -359,8 +360,8 @@ func (suite *HandlerTestSuite) TestInvalidUpdateSecurityGroup() {
 
 	// Update the security group with an invalid port range with a from_port of 0
 	updateGroup = models.UpdateSecurityGroup{
-		GroupName:        "updatedTestGroup",
-		GroupDescription: "This is an updated test group",
+		GroupName:        util.PtrString("updatedTestGroup"),
+		GroupDescription: util.PtrString("This is an updated test group"),
 		InboundRules: []models.SecurityRule{
 			{IpProtocol: "tcp", FromPort: 0, ToPort: 8080, IpRanges: []string{"10.130.0.1-10.130.0.5,10.20.0.0/28"}},
 		},
@@ -386,8 +387,8 @@ func (suite *HandlerTestSuite) TestInvalidUpdateSecurityGroup() {
 
 	// Update the security group with an invalid ip range
 	updateGroup = models.UpdateSecurityGroup{
-		GroupName:        "updatedTestGroup",
-		GroupDescription: "This is an updated test group",
+		GroupName:        util.PtrString("updatedTestGroup"),
+		GroupDescription: util.PtrString("This is an updated test group"),
 		InboundRules: []models.SecurityRule{
 			{IpProtocol: "tcp", FromPort: 8080, ToPort: 8080, IpRanges: []string{"200::/64¯\\_(ツ)_/¯"}},
 		},
@@ -413,8 +414,8 @@ func (suite *HandlerTestSuite) TestInvalidUpdateSecurityGroup() {
 
 	// Update the security group with an invalid ip range
 	updateGroup = models.UpdateSecurityGroup{
-		GroupName:        "updatedTestGroup",
-		GroupDescription: "This is an updated test group",
+		GroupName:        util.PtrString("updatedTestGroup"),
+		GroupDescription: util.PtrString("This is an updated test group"),
 		InboundRules: []models.SecurityRule{
 			{IpProtocol: "tcp", FromPort: 8080, ToPort: 8080, IpRanges: []string{""}},
 		},

--- a/internal/models/security_group.go
+++ b/internal/models/security_group.go
@@ -26,8 +26,8 @@ type AddSecurityGroup struct {
 
 // UpdateSecurityGroup is the information needed to update an existing Security Group.
 type UpdateSecurityGroup struct {
-	GroupName        string         `json:"group_name,omitempty"`
-	GroupDescription string         `json:"group_description,omitempty"`
+	GroupName        *string        `json:"group_name,omitempty"`
+	GroupDescription *string        `json:"group_description,omitempty"`
 	InboundRules     []SecurityRule `json:"inbound_rules,omitempty" gorm:"type:JSONB; serializer:json"`
 	OutboundRules    []SecurityRule `json:"outbound_rules,omitempty" gorm:"type:JSONB; serializer:json"`
 }

--- a/internal/util/string.go
+++ b/internal/util/string.go
@@ -1,0 +1,3 @@
+package util
+
+func PtrString(v string) *string { return &v }


### PR DESCRIPTION
This allows a user to update individual fields of a security group. We now sort by the group name instead of by id.
Add more api feature tests around security-groups.