### PR TITLE
Ensure CLI docs stay up to date

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -360,7 +360,15 @@ dist/.ui-fmt: $(wildcard ui/*) $(wildcard ui/src/**) | dist
 .PHONY: generate
 generate: dist/.generate ## Run all code generators and formatters
 
-dist/.generate: $(SWAGGER_YAML) dist/.ui-fmt | dist
+docs/user-guide/nexd.md: dist/nexd hack/nexd-docs.sh
+	$(ECHO_PREFIX) printf "  %-12s nexd\n" "[DOCS]"
+	$(CMD_PREFIX) hack/nexd-docs.sh
+
+docs/user-guide/nexctl.md: dist/nexctl hack/nexctl-docs.sh
+	$(ECHO_PREFIX) printf "  %-12s nexctl\n" "[DOCS]"
+	$(CMD_PREFIX) hack/nexctl-docs.sh
+
+dist/.generate: $(SWAGGER_YAML) dist/.ui-fmt docs/user-guide/nexd.md docs/user-guide/nexctl.md | dist
 	$(ECHO_PREFIX) printf "  %-12s \n" "[MOD TIDY]"
 	$(CMD_PREFIX) go mod tidy
 

--- a/docs/user-guide/nexctl.md
+++ b/docs/user-guide/nexctl.md
@@ -69,6 +69,7 @@ USAGE:
 COMMANDS:
    list      List all devices
    delete    Delete a device
+   update    Update a device
    metadata  Commands relating to device metadata
    help, h   Shows a list of commands or help for one command
 

--- a/docs/user-guide/nexd.md
+++ b/docs/user-guide/nexd.md
@@ -24,7 +24,7 @@ COMMANDS:
 GLOBAL OPTIONS:
    --exit-node-client   Enable this node to use an available exit node (default: false) [$NEXD_EXIT_NODE_CLIENT]
    --help, -h           Show help
-   --unix-socket value  Path to the unix socket nexd is listening against (default: "/home/rbryant/.nexodus/nexd.sock")
+   --unix-socket value  Path to the unix socket nexd is listening against (default: "$HOME/nexd.sock")
 
    Agent Options
 
@@ -35,7 +35,7 @@ GLOBAL OPTIONS:
    --insecure-skip-tls-verify                   If true, server certificates will not be checked for validity. This will make your HTTPS connections insecure (default: false) [$NEXD_INSECURE_SKIP_TLS_VERIFY]
    --password string                            Password string for accessing the nexodus service [$NEXD_PASSWORD]
    --service-url value                          URL to the Nexodus service (default: "https://try.nexodus.127.0.0.1.nip.io") [$NEXD_SERVICE_URL]
-   --state-dir value                            Directory to store state in, such as api tokens to reuse after interactive login. Defaults to'/home/rbryant/.nexodus' (default: "/home/rbryant/.nexodus") [$NEXD_STATE_DIR]
+   --state-dir value                            Directory to store state in, such as api tokens to reuse after interactive login. Defaults to'$HOME/.nexodus") [$NEXD_STATE_DIR]
    --stun-server value [ --stun-server value ]  stun server to use discover our endpoint address.  At least two are required. [$NEXD_STUN_SERVER]
    --username string                            Username string for accessing the nexodus service [$NEXD_USERNAME]
    --vpc-id value                               VPC ID to use when registering with the nexodus service [$NEXD_ORG_ID]

--- a/hack/nexctl-docs.sh
+++ b/hack/nexctl-docs.sh
@@ -8,7 +8,6 @@ cat docs/user-guide/nexctl.md | sed -n '/## Usage/q;p' > docs/user-guide/nexctl.
 printf "### Usage\n\n" >> docs/user-guide/nexctl.md.tmp
 
 # generate the usage output
-make dist/nexctl
 echo '```text' >> docs/user-guide/nexctl.md.tmp
 dist/nexctl -h >> docs/user-guide/nexctl.md.tmp
 echo '```' >> docs/user-guide/nexctl.md.tmp

--- a/hack/nexd-docs.sh
+++ b/hack/nexd-docs.sh
@@ -9,13 +9,13 @@ printf "### Usage\n\n" >> docs/user-guide/nexd.md.tmp
 
 # generate the usage output
 echo '```text' >> docs/user-guide/nexd.md.tmp
-dist/nexd -h >> docs/user-guide/nexd.md.tmp
+dist/nexd -h | sed -e 's/\/home\/.*\//\$HOME\//g' >> docs/user-guide/nexd.md.tmp
 echo '```' >> docs/user-guide/nexd.md.tmp
 
 for subcmd in proxy router relay; do
     printf "\n#### nexd $subcmd\n\n" >> docs/user-guide/nexd.md.tmp
     echo '```text' >> docs/user-guide/nexd.md.tmp
-    dist/nexd ${subcmd} -h >> docs/user-guide/nexd.md.tmp
+    dist/nexd ${subcmd} -h | sed -e 's/\/home\/.*\//\$HOME\//g' >> docs/user-guide/nexd.md.tmp
     echo '```' >> docs/user-guide/nexd.md.tmp
 done
 

--- a/hack/nexd-docs.sh
+++ b/hack/nexd-docs.sh
@@ -8,7 +8,6 @@ cat docs/user-guide/nexd.md | sed -n '/## Usage/q;p' > docs/user-guide/nexd.md.t
 printf "### Usage\n\n" >> docs/user-guide/nexd.md.tmp
 
 # generate the usage output
-make dist/nexd
 echo '```text' >> docs/user-guide/nexd.md.tmp
 dist/nexd -h >> docs/user-guide/nexd.md.tmp
 echo '```' >> docs/user-guide/nexd.md.tmp


### PR DESCRIPTION
- Makefile: auto update nexd/nexctl CLI docs
- docs: Update nexctl docs to include device update


commit 2454d033acd5fe138da0ffb576c3efa8e2376586
Author: Russell Bryant <russell.bryant@gmail.com>
Date:   Mon Nov 6 16:01:08 2023 -0500

    docs: Update nexctl docs to include device update
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>

commit d607a95c64cb5674c0c4f26528e7af8271e5827c
Author: Russell Bryant <russell.bryant@gmail.com>
Date:   Mon Nov 6 15:58:09 2023 -0500

    Makefile: auto update nexd/nexctl CLI docs
    
    Make the build process automatically update the generated CLI docs for
    nexd and nexctl. CI will also fail if CLI options are changed but the
    docs are not updated. The `make generate` job will see uncommitted
    changes and fail.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>
