### PR TITLE
docs: Use paths for root user in help text

### DIFF
--- a/cmd/nexctl/local_unix.go
+++ b/cmd/nexctl/local_unix.go
@@ -22,7 +22,7 @@ func init() {
 				Usage:       "Path to the unix socket nexd is listening against",
 				Value:       api.UnixSocketPath,
 				Destination: &api.UnixSocketPath,
-				DefaultText: "$HOME/.nexodus/nexd.sock",
+				DefaultText: api.UnixSocketPath,
 				Required:    false,
 			},
 		},

--- a/cmd/nexd/flags_unix.go
+++ b/cmd/nexd/flags_unix.go
@@ -3,10 +3,11 @@
 package main
 
 import (
-	"github.com/nexodus-io/nexodus/internal/api"
-	"github.com/urfave/cli/v2"
 	"os/user"
 	"path/filepath"
+
+	"github.com/nexodus-io/nexodus/internal/api"
+	"github.com/urfave/cli/v2"
 )
 
 var stateDirDefault = "/var/lib/nexd"
@@ -19,7 +20,6 @@ func init() {
 		stateDirDefault = filepath.Join(currentUser.HomeDir, ".nexodus")
 		stateDirDefaultExpression = "$HOME/.nexodus"
 		api.UnixSocketPath = filepath.Join(stateDirDefault, "nexd.sock")
-		api.UnixSocketPathExpression = "$HOME/.nexodus/nexd.sock"
 	}
 
 	additionalPlatformFlags = append(additionalPlatformFlags,

--- a/docs/user-guide/nexctl.md
+++ b/docs/user-guide/nexctl.md
@@ -117,7 +117,7 @@ COMMANDS:
    help, h    Shows a list of commands or help for one command
 
 OPTIONS:
-   --unix-socket value  Path to the unix socket nexd is listening against (default: $HOME/.nexodus/nexd.sock)
+   --unix-socket value  Path to the unix socket nexd is listening against (default: /run/nexd.sock)
    --help, -h           Show help
 ```
 

--- a/docs/user-guide/nexd.md
+++ b/docs/user-guide/nexd.md
@@ -24,7 +24,7 @@ COMMANDS:
 GLOBAL OPTIONS:
    --exit-node-client   Enable this node to use an available exit node (default: false) [$NEXD_EXIT_NODE_CLIENT]
    --help, -h           Show help
-   --unix-socket value  Path to the unix socket nexd is listening against (default: $HOME/.nexodus/nexd.sock)
+   --unix-socket value  Path to the unix socket nexd is listening against (default: /run/nexd.sock)
 
    Agent Options
 


### PR DESCRIPTION
When displaying the default unix socket path, use the privileged mode
default, as that is the common case.

Signed-off-by: Russell Bryant <rbryant@redhat.com>
