### PR TITLE
chore: Use ShouldBindJSON everywhere

### DIFF
--- a/internal/handlers/device.go
+++ b/internal/handlers/device.go
@@ -178,7 +178,7 @@ func (api *API) UpdateDevice(c *gin.Context) {
 	}
 	var request models.UpdateDevice
 
-	if err := c.BindJSON(&request); err != nil {
+	if err := c.ShouldBindJSON(&request); err != nil {
 		c.JSON(http.StatusBadRequest, models.NewBadPayloadError())
 		return
 	}
@@ -418,8 +418,8 @@ func (api *API) CreateDevice(c *gin.Context) {
 	ctx, span := tracer.Start(c.Request.Context(), "AddDevice")
 	defer span.End()
 	var request models.AddDevice
-	// Call BindJSON to bind the received JSON
-	if err := c.BindJSON(&request); err != nil {
+	// Call ShouldBindJSON to bind the received JSON
+	if err := c.ShouldBindJSON(&request); err != nil {
 		c.JSON(http.StatusBadRequest, models.NewBadPayloadError())
 		return
 	}

--- a/internal/handlers/device_metadata.go
+++ b/internal/handlers/device_metadata.go
@@ -268,7 +268,7 @@ func (api *API) UpdateDeviceMetadataKey(c *gin.Context) {
 	key := c.Param("key")
 
 	var request json.RawMessage
-	if err := c.BindJSON(&request); err != nil {
+	if err := c.ShouldBindJSON(&request); err != nil {
 		c.JSON(http.StatusBadRequest, models.NewBadPayloadError())
 		return
 	}

--- a/internal/handlers/events.go
+++ b/internal/handlers/events.go
@@ -71,7 +71,7 @@ func (api *API) WatchEvents(c *gin.Context) {
 	}
 
 	var request []models.Watch
-	if err := c.BindJSON(&request); err != nil {
+	if err := c.ShouldBindJSON(&request); err != nil {
 		c.JSON(http.StatusBadRequest, models.NewBadPayloadError())
 		return
 	}

--- a/internal/handlers/invitations.go
+++ b/internal/handlers/invitations.go
@@ -2,11 +2,12 @@ package handlers
 
 import (
 	"errors"
+	"net/http"
+	"time"
+
 	"github.com/nexodus-io/nexodus/internal/database"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
-	"net/http"
-	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
@@ -33,7 +34,7 @@ func (api *API) CreateInvitation(c *gin.Context) {
 	defer span.End()
 
 	var request models.AddInvitation
-	if err := c.BindJSON(&request); err != nil {
+	if err := c.ShouldBindJSON(&request); err != nil {
 		c.JSON(http.StatusBadRequest, models.NewBadPayloadError())
 		return
 	}

--- a/internal/handlers/organization.go
+++ b/internal/handlers/organization.go
@@ -3,6 +3,8 @@ package handlers
 import (
 	"errors"
 	"fmt"
+	"net/http"
+
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"github.com/nexodus-io/nexodus/internal/database"
@@ -11,7 +13,6 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
-	"net/http"
 )
 
 type errDuplicateOrganization struct {
@@ -54,8 +55,8 @@ func (api *API) CreateOrganization(c *gin.Context) {
 	userId := api.GetCurrentUserID(c)
 
 	var request models.AddOrganization
-	// Call BindJSON to bind the received JSON
-	if err := c.BindJSON(&request); err != nil {
+	// Call ShouldBindJSON to bind the received JSON
+	if err := c.ShouldBindJSON(&request); err != nil {
 		c.JSON(http.StatusBadRequest, models.NewBadPayloadError())
 		return
 	}

--- a/internal/handlers/reg_key.go
+++ b/internal/handlers/reg_key.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
+
 	"github.com/gin-gonic/gin"
 	"github.com/go-jose/go-jose/v3"
 	"github.com/google/uuid"
@@ -15,7 +17,6 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	"golang.zx2c4.com/wireguard/wgctrl/wgtypes"
 	"gorm.io/gorm"
-	"net/http"
 )
 
 // CreateRegKey creates a RegKey
@@ -37,7 +38,7 @@ func (api *API) CreateRegKey(c *gin.Context) {
 	defer span.End()
 
 	var request models.AddRegKey
-	if err := c.BindJSON(&request); err != nil {
+	if err := c.ShouldBindJSON(&request); err != nil {
 		c.JSON(http.StatusBadRequest, models.NewBadPayloadError())
 		return
 	}

--- a/internal/handlers/security_group.go
+++ b/internal/handlers/security_group.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
+	"strings"
+
 	"github.com/nexodus-io/nexodus/internal/database"
 	"github.com/nexodus-io/nexodus/internal/handlers/fetchmgr"
 	"github.com/nexodus-io/nexodus/internal/util"
 	"gorm.io/gorm/clause"
-	"net/http"
-	"strings"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
@@ -245,7 +246,7 @@ func (api *API) CreateSecurityGroup(c *gin.Context) {
 
 	var request models.AddSecurityGroup
 	// Call BindJSON to bind the received JSON
-	if err := c.BindJSON(&request); err != nil {
+	if err := c.ShouldBindJSON(&request); err != nil {
 		c.JSON(http.StatusBadRequest, models.NewBadPayloadError())
 		return
 	}
@@ -434,7 +435,7 @@ func (api *API) UpdateSecurityGroup(c *gin.Context) {
 	}
 
 	var request models.UpdateSecurityGroup
-	if err := c.BindJSON(&request); err != nil {
+	if err := c.ShouldBindJSON(&request); err != nil {
 		c.JSON(http.StatusBadRequest, models.NewBadPayloadError())
 		return
 	}

--- a/internal/handlers/vpc.go
+++ b/internal/handlers/vpc.go
@@ -52,7 +52,7 @@ func (api *API) CreateVPC(c *gin.Context) {
 
 	var request models.AddVPC
 	// Call BindJSON to bind the received JSON
-	if err := c.BindJSON(&request); err != nil {
+	if err := c.ShouldBindJSON(&request); err != nil {
 		c.JSON(http.StatusBadRequest, models.NewBadPayloadError())
 		return
 	}
@@ -444,7 +444,7 @@ func (api *API) UpdateVPC(c *gin.Context) {
 	}
 
 	var request models.UpdateVPC
-	if err := c.BindJSON(&request); err != nil {
+	if err := c.ShouldBindJSON(&request); err != nil {
 		c.JSON(http.StatusBadRequest, models.NewBadPayloadError())
 		return
 	}

--- a/pkg/oidcagent/handlers.go
+++ b/pkg/oidcagent/handlers.go
@@ -97,7 +97,7 @@ func (o *OidcAgent) LoginEnd(c *gin.Context) {
 	var data models.LoginEndRequest
 	var accessToken, refreshToken, rawIDToken string
 
-	err := c.BindJSON(&data)
+	err := c.ShouldBindJSON(&data)
 	if err != nil {
 		c.AbortWithStatus(http.StatusBadRequest)
 		return
@@ -342,7 +342,7 @@ func (o *OidcAgent) Refresh(c *gin.Context) {
 
 	var data models.RefreshTokenRequest
 
-	err := c.BindJSON(&data)
+	err := c.ShouldBindJSON(&data)
 	if err != nil {
 		c.AbortWithStatus(http.StatusBadRequest)
 		return


### PR DESCRIPTION
BindJSON is infallible. It sets the status to 400 and aborts. We need ShouldBindJSON since in all cases we are doing our own error handling.