### PR TITLE
fixes: #1605 Error responses have the wrong content type set

### DIFF
--- a/cmd/nexctl/device.go
+++ b/cmd/nexctl/device.go
@@ -104,10 +104,7 @@ func createDeviceCommand() *cli.Command {
 }
 
 func listVpcDevices(cCtx *cli.Context, c *public.APIClient, vpcId uuid.UUID) error {
-	devices, _, err := c.VPCApi.ListDevicesInVPC(context.Background(), vpcId.String()).Execute()
-	if err != nil {
-		log.Fatal(err)
-	}
+	devices := processApiResponse(c.VPCApi.ListDevicesInVPC(context.Background(), vpcId.String()).Execute())
 	showOutput(cCtx, deviceTableFields(cCtx), devices)
 	return nil
 }
@@ -175,10 +172,7 @@ func deviceTableFields(cCtx *cli.Context) []TableField {
 }
 
 func listAllDevices(cCtx *cli.Context, c *public.APIClient) error {
-	devices, _, err := c.DevicesApi.ListDevices(context.Background()).Execute()
-	if err != nil {
-		log.Fatal(err)
-	}
+	devices := processApiResponse(c.DevicesApi.ListDevices(context.Background()).Execute())
 
 	// Only modify the time to a user-friendly value if the nexctl output is in column form
 	if cCtx.String("output") == encodeColumn || cCtx.String("output") == encodeNoHeader {
@@ -197,10 +191,7 @@ func deleteDevice(c *public.APIClient, encodeOut, devID string) error {
 		log.Fatalf("failed to parse a valid UUID from %s %v", devUUID, err)
 	}
 
-	res, _, err := c.DevicesApi.DeleteDevice(context.Background(), devUUID.String()).Execute()
-	if err != nil {
-		log.Fatalf("device delete failed: %v\n", err)
-	}
+	res := processApiResponse(c.DevicesApi.DeleteDevice(context.Background(), devUUID.String()).Execute())
 
 	if encodeOut == encodeColumn || encodeOut == encodeNoHeader {
 		fmt.Printf("successfully deleted device %s\n", res.Id)
@@ -221,13 +212,10 @@ func updateDevice(c *public.APIClient, encodeOut, devID string, update public.Mo
 		log.Fatalf("failed to parse a valid UUID from %s %v", devUUID, err)
 	}
 
-	res, _, err := c.DevicesApi.
+	res := processApiResponse(c.DevicesApi.
 		UpdateDevice(context.Background(), devUUID.String()).
 		Update(update).
-		Execute()
-	if err != nil {
-		log.Fatalf("device update failed: %v\n", err)
-	}
+		Execute())
 
 	if encodeOut == encodeColumn || encodeOut == encodeNoHeader {
 		fmt.Printf("successfully update device %s\n", res.Id)

--- a/cmd/nexctl/device_metadata.go
+++ b/cmd/nexctl/device_metadata.go
@@ -185,27 +185,20 @@ func metadataTableFields(cCtx *cli.Context, includeDeviceId bool) []TableField {
 func getDeviceMetadata(c *cli.Context, deviceID uuid.UUID) error {
 	client := mustCreateAPIClient(c)
 
-	metadata, _, err := client.DevicesApi.
+	metadata := processApiResponse(client.DevicesApi.
 		ListDeviceMetadata(context.Background(), deviceID.String()).
-		Execute()
-	if err != nil {
-		return err
-	}
+		Execute())
 
 	showOutput(c, metadataTableFields(c, false), metadata)
-
 	return nil
 }
 
 func getDeviceMetadataKey(c *cli.Context, deviceID uuid.UUID, key string) error {
 	client := mustCreateAPIClient(c)
 
-	metadata, _, err := client.DevicesApi.
+	metadata := processApiResponse(client.DevicesApi.
 		GetDeviceMetadataKey(context.Background(), deviceID.String(), key).
-		Execute()
-	if err != nil {
-		return err
-	}
+		Execute())
 
 	showOutput(c, metadataTableFields(c, false), metadata)
 	return nil
@@ -215,12 +208,9 @@ func getVpcMetadata(c *cli.Context, vpcID uuid.UUID) error {
 	client := mustCreateAPIClient(c)
 
 	prefixes := []string{}
-	metadata, _, err := client.VPCApi.
+	metadata := processApiResponse(client.VPCApi.
 		ListMetadataInVPC(context.Background(), vpcID.String(), prefixes).
-		Execute()
-	if err != nil {
-		return err
-	}
+		Execute())
 
 	showOutput(c, metadataTableFields(c, true), metadata)
 
@@ -237,13 +227,10 @@ func updateDeviceMetadata(c *cli.Context, deviceID uuid.UUID, key, value string)
 
 	client := mustCreateAPIClient(c)
 
-	metadata, _, err := client.DevicesApi.
+	metadata := processApiResponse(client.DevicesApi.
 		UpdateDeviceMetadataKey(context.Background(), deviceID.String(), key).
 		Value(valueMap).
-		Execute()
-	if err != nil {
-		return err
-	}
+		Execute())
 
 	showOutput(c, metadataTableFields(c, false), metadata)
 	return nil

--- a/cmd/nexctl/organization.go
+++ b/cmd/nexctl/organization.go
@@ -36,9 +36,9 @@ func createOrganizationCommand() *cli.Command {
 					},
 				},
 				Action: func(cCtx *cli.Context) error {
-					organizationName := cCtx.String("name")
-					organizationDescrip := cCtx.String("description")
-					return createOrganization(cCtx, mustCreateAPIClient(cCtx), organizationName, organizationDescrip)
+					name := cCtx.String("name")
+					description := cCtx.String("description")
+					return createOrganization(cCtx, mustCreateAPIClient(cCtx), name, description)
 				},
 			},
 			{
@@ -69,24 +69,16 @@ func orgTableFields() []TableField {
 	return fields
 }
 func listOrganizations(cCtx *cli.Context, c *client.APIClient) error {
-	orgs, _, err := c.OrganizationsApi.ListOrganizations(context.Background()).Execute()
-	if err != nil {
-		log.Fatal(err)
-	}
-
+	orgs := processApiResponse(c.OrganizationsApi.ListOrganizations(context.Background()).Execute())
 	showOutput(cCtx, orgTableFields(), orgs)
 	return nil
 }
 
 func createOrganization(cCtx *cli.Context, c *client.APIClient, name, description string) error {
-	res, _, err := c.OrganizationsApi.CreateOrganization(context.Background()).Organization(public.ModelsAddOrganization{
+	res := processApiResponse(c.OrganizationsApi.CreateOrganization(context.Background()).Organization(public.ModelsAddOrganization{
 		Name:        name,
 		Description: description,
-	}).Execute()
-	if err != nil {
-		log.Fatal(err)
-	}
-
+	}).Execute())
 	showOutput(cCtx, orgTableFields(), res)
 	return nil
 }
@@ -123,11 +115,7 @@ func deleteOrganization(cCtx *cli.Context, c *client.APIClient, encodeOut, Organ
 		log.Fatalf("failed to parse a valid UUID from %s %v", OrganizationUUID, err)
 	}
 
-	res, _, err := c.OrganizationsApi.DeleteOrganization(context.Background(), OrganizationUUID.String()).Execute()
-	if err != nil {
-		log.Fatalf("Organization delete failed: %v\n", err)
-	}
-
+	res := processApiResponse(c.OrganizationsApi.DeleteOrganization(context.Background(), OrganizationUUID.String()).Execute())
 	showOutput(cCtx, orgTableFields(), res)
 	if encodeOut == encodeColumn || encodeOut == encodeNoHeader {
 		fmt.Println("\nsuccessfully deleted")

--- a/cmd/nexctl/reg_key.go
+++ b/cmd/nexctl/reg_key.go
@@ -89,11 +89,7 @@ func regTokenTableFields() []TableField {
 }
 
 func listRegKeys(cCtx *cli.Context, c *client.APIClient) error {
-	rows, _, err := c.RegKeyApi.ListRegKeys(cCtx.Context).Execute()
-	if err != nil {
-		log.Fatal(err)
-	}
-
+	rows := processApiResponse(c.RegKeyApi.ListRegKeys(cCtx.Context).Execute())
 	showOutput(cCtx, regTokenTableFields(), rows)
 	return nil
 }
@@ -104,27 +100,18 @@ func createRegKey(cCtx *cli.Context, c *client.APIClient, token public.ModelsAdd
 		token.VpcId = getDefaultVpcId(cCtx.Context, c)
 	}
 
-	res, _, err := c.RegKeyApi.CreateRegKey(cCtx.Context).RegKey(token).Execute()
-	if err != nil {
-		log.Fatal(err)
-	}
+	res := processApiResponse(c.RegKeyApi.CreateRegKey(cCtx.Context).RegKey(token).Execute())
 	showOutput(cCtx, regTokenTableFields(), res)
 	return nil
 }
 
 func getDefaultOrgId(ctx context.Context, c *client.APIClient) string {
-	user, _, err := c.UsersApi.GetUser(ctx, "me").Execute()
-	if err != nil {
-		log.Fatal(err)
-	}
+	user := processApiResponse(c.UsersApi.GetUser(ctx, "me").Execute())
 	return user.Id
 }
 
 func getDefaultVpcId(ctx context.Context, c *client.APIClient) string {
-	user, _, err := c.UsersApi.GetUser(ctx, "me").Execute()
-	if err != nil {
-		log.Fatal(err)
-	}
+	user := processApiResponse(c.UsersApi.GetUser(ctx, "me").Execute())
 	return user.Id
 }
 
@@ -134,10 +121,7 @@ func deleteRegKey(cCtx *cli.Context, c *client.APIClient, encodeOut, id string) 
 		log.Fatalf("failed to parse a valid UUID from %s: %v", id, err)
 	}
 
-	res, _, err := c.RegKeyApi.DeleteRegKey(cCtx.Context, tokenId.String()).Execute()
-	if err != nil {
-		log.Fatalf("Registration token delete failed: %v\n", err)
-	}
+	res := processApiResponse(c.RegKeyApi.DeleteRegKey(cCtx.Context, tokenId.String()).Execute())
 
 	showOutput(cCtx, regTokenTableFields(), res)
 	if encodeOut == encodeColumn || encodeOut == encodeNoHeader {

--- a/cmd/nexctl/security_group.go
+++ b/cmd/nexctl/security_group.go
@@ -215,22 +215,14 @@ func updateSecurityGroup(cCtx *cli.Context, c *client.APIClient, secGroupID stri
 
 // listSecurityGroups lists all security groups.
 func listSecurityGroups(cCtx *cli.Context, c *client.APIClient) error {
-	securityGroups, _, err := c.SecurityGroupApi.ListSecurityGroups(context.Background()).Execute()
-	if err != nil {
-		return fmt.Errorf("list security groups failed: %w", err)
-	}
-
+	securityGroups := processApiResponse(c.SecurityGroupApi.ListSecurityGroups(context.Background()).Execute())
 	showOutput(cCtx, securityGroupTableFields(cCtx), securityGroups)
 	return nil
 }
 
 // deleteSecurityGroup deletes an existing security group.
 func deleteSecurityGroup(cCtx *cli.Context, c *client.APIClient, encodeOut, secGroupID string) error {
-	res, _, err := c.SecurityGroupApi.DeleteSecurityGroup(context.Background(), secGroupID).Execute()
-	if err != nil {
-		return fmt.Errorf("security group delete failed: %w", err)
-	}
-
+	res := processApiResponse(c.SecurityGroupApi.DeleteSecurityGroup(context.Background(), secGroupID).Execute())
 	showOutput(cCtx, securityGroupTableFields(cCtx), res)
 	if encodeOut == encodeColumn || encodeOut == encodeNoHeader {
 		fmt.Println("\nsuccessfully deleted")

--- a/cmd/nexctl/user.go
+++ b/cmd/nexctl/user.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"github.com/nexodus-io/nexodus/internal/client"
 	"github.com/urfave/cli/v2"
-	"log"
 )
 
 func createUserSubCommand() *cli.Command {
@@ -74,20 +73,13 @@ func userTableFields() []TableField {
 	return fields
 }
 func listUsers(cCtx *cli.Context, c *client.APIClient) error {
-	users, _, err := c.UsersApi.ListUsers(context.Background()).Execute()
-	if err != nil {
-		log.Fatal(err)
-	}
+	users := processApiResponse(c.UsersApi.ListUsers(context.Background()).Execute())
 	showOutput(cCtx, userTableFields(), users)
 	return nil
 }
 
 func deleteUser(cCtx *cli.Context, c *client.APIClient, encodeOut, userID string) error {
-	res, _, err := c.UsersApi.DeleteUser(context.Background(), userID).Execute()
-	if err != nil {
-		log.Fatalf("user delete failed: %v\n", err)
-	}
-
+	res := processApiResponse(c.UsersApi.DeleteUser(context.Background(), userID).Execute())
 	showOutput(cCtx, userTableFields(), res)
 	if encodeOut == encodeColumn || encodeOut == encodeNoHeader {
 		fmt.Println("\nsuccessfully deleted")
@@ -97,11 +89,7 @@ func deleteUser(cCtx *cli.Context, c *client.APIClient, encodeOut, userID string
 }
 
 func deleteUserFromOrg(cCtx *cli.Context, c *client.APIClient, encodeOut, userID, orgID string) error {
-	res, _, err := c.UsersApi.DeleteUserFromOrganization(context.Background(), userID, orgID).Execute()
-	if err != nil {
-		log.Fatalf("user removal failed: %v\n", err)
-	}
-
+	res := processApiResponse(c.UsersApi.DeleteUserFromOrganization(context.Background(), userID, orgID).Execute())
 	showOutput(cCtx, userTableFields(), res)
 	if encodeOut == encodeColumn || encodeOut == encodeNoHeader {
 		fmt.Printf("successfully removed user %s from organization %s\n", userID, orgID)
@@ -110,10 +98,7 @@ func deleteUserFromOrg(cCtx *cli.Context, c *client.APIClient, encodeOut, userID
 }
 
 func getCurrent(cCtx *cli.Context, c *client.APIClient) error {
-	user, _, err := c.UsersApi.GetUser(context.Background(), "me").Execute()
-	if err != nil {
-		log.Fatal(err)
-	}
+	user := processApiResponse(c.UsersApi.GetUser(context.Background(), "me").Execute())
 	showOutput(cCtx, userTableFields(), user)
 	return nil
 }

--- a/cmd/nexctl/vpc.go
+++ b/cmd/nexctl/vpc.go
@@ -87,11 +87,7 @@ func vpcTableFields() []TableField {
 	return fields
 }
 func listVPCs(cCtx *cli.Context, c *client.APIClient) error {
-	vpcs, _, err := c.VPCApi.ListVPCs(context.Background()).Execute()
-	if err != nil {
-		log.Fatal(err)
-	}
-
+	vpcs := processApiResponse(c.VPCApi.ListVPCs(context.Background()).Execute())
 	showOutput(cCtx, vpcTableFields(), vpcs)
 	return nil
 }
@@ -115,11 +111,7 @@ func deleteVPC(cCtx *cli.Context, c *client.APIClient, encodeOut, VPCID string) 
 		log.Fatalf("failed to parse a valid UUID from %s %v", id, err)
 	}
 
-	res, _, err := c.VPCApi.DeleteVPC(context.Background(), id.String()).Execute()
-	if err != nil {
-		log.Fatalf("VPC delete failed: %v\n", err)
-	}
-
+	res := processApiResponse(c.VPCApi.DeleteVPC(context.Background(), id.String()).Execute())
 	showOutput(cCtx, vpcTableFields(), res)
 	if encodeOut == encodeColumn || encodeOut == encodeNoHeader {
 		fmt.Println("\nsuccessfully deleted")

--- a/integration-tests/features/reg-key-api.feature
+++ b/integration-tests/features/reg-key-api.feature
@@ -248,3 +248,25 @@ Feature: Device API
       }
       """
 
+  Scenario: Negative Tests
+
+    Given I am logged in as "Bob"
+
+    When I GET path "/api/users/me"
+    Then the response code should be 200
+    Given I store the ".id" selection from the response as ${user_id}
+
+    When I POST path "/api/reg-keys" with json body:
+      """
+      {
+        "owner_id": "${user_id}",
+        "vpc_id": "test"
+      }
+      """
+    Then the response code should be 400
+    And the response should match json:
+      """
+      {
+          "error": "request json is invalid: invalid UUID length: 4"
+      }
+      """

--- a/internal/cucumber/http_response.go
+++ b/internal/cucumber/http_response.go
@@ -55,6 +55,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"strings"
 
 	"github.com/cucumber/godog"
 	"github.com/itchyny/gojq"
@@ -106,6 +107,10 @@ func (s *TestScenario) TheResponseShouldMatchJsonDoc(expected *godog.DocString) 
 }
 func (s *TestScenario) theResponseShouldMatchJson(expected string) error {
 	session := s.Session()
+	ct := session.Resp.Header.Get("Content-Type")
+	if !strings.HasPrefix(ct, "application/json") {
+		return fmt.Errorf("Content-Type is not application/json, but: %s", ct)
+	}
 
 	if len(session.RespBytes) == 0 {
 		return fmt.Errorf("got an empty response from server, expected a json body")

--- a/internal/handlers/device.go
+++ b/internal/handlers/device.go
@@ -178,8 +178,8 @@ func (api *API) UpdateDevice(c *gin.Context) {
 	}
 	var request models.UpdateDevice
 
-	if err := c.BindJSON(&request); err != nil {
-		c.JSON(http.StatusBadRequest, models.NewBadPayloadError())
+	if err := c.ShouldBindJSON(&request); err != nil {
+		c.JSON(http.StatusBadRequest, models.NewBadPayloadError(err))
 		return
 	}
 
@@ -419,8 +419,8 @@ func (api *API) CreateDevice(c *gin.Context) {
 	defer span.End()
 	var request models.AddDevice
 	// Call BindJSON to bind the received JSON
-	if err := c.BindJSON(&request); err != nil {
-		c.JSON(http.StatusBadRequest, models.NewBadPayloadError())
+	if err := c.ShouldBindJSON(&request); err != nil {
+		c.JSON(http.StatusBadRequest, models.NewBadPayloadError(err))
 		return
 	}
 

--- a/internal/handlers/device_metadata.go
+++ b/internal/handlers/device_metadata.go
@@ -42,7 +42,7 @@ func (api *API) ListDeviceMetadata(c *gin.Context) {
 		Query
 		Prefixes []string `form:"prefix"`
 	}{}
-	if err := c.BindQuery(&query); err != nil {
+	if err := c.ShouldBindQuery(&query); err != nil {
 		c.JSON(http.StatusBadRequest, models.NewApiError(err))
 		return
 	}
@@ -122,7 +122,7 @@ func (api *API) ListMetadataInVPC(c *gin.Context) {
 		Query
 		Prefixes []string `form:"prefix"`
 	}{}
-	if err := c.BindQuery(&query); err != nil {
+	if err := c.ShouldBindQuery(&query); err != nil {
 		c.JSON(http.StatusBadRequest, models.NewApiError(err))
 		return
 	}
@@ -268,8 +268,8 @@ func (api *API) UpdateDeviceMetadataKey(c *gin.Context) {
 	key := c.Param("key")
 
 	var request json.RawMessage
-	if err := c.BindJSON(&request); err != nil {
-		c.JSON(http.StatusBadRequest, models.NewBadPayloadError())
+	if err := c.ShouldBindJSON(&request); err != nil {
+		c.JSON(http.StatusBadRequest, models.NewBadPayloadError(err))
 		return
 	}
 

--- a/internal/handlers/envoy_authz.go
+++ b/internal/handlers/envoy_authz.go
@@ -226,6 +226,15 @@ func denyCheckResponse(statusCode int, baseError models.BaseError) (*auth.CheckR
 		Status: &status.Status{Code: int32(codes.PermissionDenied)},
 		HttpResponse: &auth.CheckResponse_DeniedResponse{
 			DeniedResponse: &auth.DeniedHttpResponse{
+				Headers: []*core.HeaderValueOption{
+					{
+						AppendAction: core.HeaderValueOption_OVERWRITE_IF_EXISTS_OR_ADD,
+						Header: &core.HeaderValue{
+							Key:   "Content-Type",
+							Value: "application/json",
+						},
+					},
+				},
 				Status: &v3.HttpStatus{Code: v3.StatusCode(statusCode)},
 				Body:   string(data),
 			},

--- a/internal/handlers/events.go
+++ b/internal/handlers/events.go
@@ -65,14 +65,14 @@ func (api *API) WatchEvents(c *gin.Context) {
 		PublicKey string `form:"public_key"`
 	}
 
-	if err := c.BindQuery(&query); err != nil {
+	if err := c.ShouldBindQuery(&query); err != nil {
 		c.JSON(http.StatusBadRequest, models.NewApiError(err))
 		return
 	}
 
 	var request []models.Watch
-	if err := c.BindJSON(&request); err != nil {
-		c.JSON(http.StatusBadRequest, models.NewBadPayloadError())
+	if err := c.ShouldBindJSON(&request); err != nil {
+		c.JSON(http.StatusBadRequest, models.NewBadPayloadError(err))
 		return
 	}
 

--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -55,7 +55,7 @@ func (q *Query) GetFilter() (map[string]interface{}, error) {
 
 func FilterAndPaginate(db *gorm.DB, model interface{}, c *gin.Context, orderBy string) *gorm.DB {
 	var query Query
-	if err := c.BindQuery(&query); err != nil {
+	if err := c.ShouldBindQuery(&query); err != nil {
 		db.Error = err
 		return db
 	}

--- a/internal/handlers/invitations.go
+++ b/internal/handlers/invitations.go
@@ -33,8 +33,8 @@ func (api *API) CreateInvitation(c *gin.Context) {
 	defer span.End()
 
 	var request models.AddInvitation
-	if err := c.BindJSON(&request); err != nil {
-		c.JSON(http.StatusBadRequest, models.NewBadPayloadError())
+	if err := c.ShouldBindJSON(&request); err != nil {
+		c.JSON(http.StatusBadRequest, models.NewBadPayloadError(err))
 		return
 	}
 

--- a/internal/handlers/organization.go
+++ b/internal/handlers/organization.go
@@ -55,8 +55,8 @@ func (api *API) CreateOrganization(c *gin.Context) {
 
 	var request models.AddOrganization
 	// Call BindJSON to bind the received JSON
-	if err := c.BindJSON(&request); err != nil {
-		c.JSON(http.StatusBadRequest, models.NewBadPayloadError())
+	if err := c.ShouldBindJSON(&request); err != nil {
+		c.JSON(http.StatusBadRequest, models.NewBadPayloadError(err))
 		return
 	}
 

--- a/internal/handlers/reg_key.go
+++ b/internal/handlers/reg_key.go
@@ -37,8 +37,8 @@ func (api *API) CreateRegKey(c *gin.Context) {
 	defer span.End()
 
 	var request models.AddRegKey
-	if err := c.BindJSON(&request); err != nil {
-		c.JSON(http.StatusBadRequest, models.NewBadPayloadError())
+	if err := c.ShouldBindJSON(&request); err != nil {
+		c.JSON(http.StatusBadRequest, models.NewBadPayloadError(err))
 		return
 	}
 

--- a/internal/handlers/security_group.go
+++ b/internal/handlers/security_group.go
@@ -87,7 +87,7 @@ func (api *API) ListSecurityGroups(c *gin.Context) {
 	defer span.End()
 
 	var query Query
-	if err := c.BindQuery(&query); err != nil {
+	if err := c.ShouldBindQuery(&query); err != nil {
 		c.JSON(http.StatusBadRequest, models.NewApiError(err))
 		return
 	}
@@ -144,7 +144,7 @@ func (api *API) ListSecurityGroupsInVPC(c *gin.Context) {
 	}
 
 	var query Query
-	if err := c.BindQuery(&query); err != nil {
+	if err := c.ShouldBindQuery(&query); err != nil {
 		c.JSON(http.StatusBadRequest, models.NewApiError(err))
 		return
 	}
@@ -245,8 +245,8 @@ func (api *API) CreateSecurityGroup(c *gin.Context) {
 
 	var request models.AddSecurityGroup
 	// Call BindJSON to bind the received JSON
-	if err := c.BindJSON(&request); err != nil {
-		c.JSON(http.StatusBadRequest, models.NewBadPayloadError())
+	if err := c.ShouldBindJSON(&request); err != nil {
+		c.JSON(http.StatusBadRequest, models.NewBadPayloadError(err))
 		return
 	}
 
@@ -434,8 +434,8 @@ func (api *API) UpdateSecurityGroup(c *gin.Context) {
 	}
 
 	var request models.UpdateSecurityGroup
-	if err := c.BindJSON(&request); err != nil {
-		c.JSON(http.StatusBadRequest, models.NewBadPayloadError())
+	if err := c.ShouldBindJSON(&request); err != nil {
+		c.JSON(http.StatusBadRequest, models.NewBadPayloadError(err))
 		return
 	}
 

--- a/internal/handlers/vpc.go
+++ b/internal/handlers/vpc.go
@@ -52,8 +52,8 @@ func (api *API) CreateVPC(c *gin.Context) {
 
 	var request models.AddVPC
 	// Call BindJSON to bind the received JSON
-	if err := c.BindJSON(&request); err != nil {
-		c.JSON(http.StatusBadRequest, models.NewBadPayloadError())
+	if err := c.ShouldBindJSON(&request); err != nil {
+		c.JSON(http.StatusBadRequest, models.NewBadPayloadError(err))
 		return
 	}
 
@@ -290,7 +290,7 @@ func (api *API) ListDevicesInVPC(c *gin.Context) {
 	}
 
 	var query Query
-	if err := c.BindQuery(&query); err != nil {
+	if err := c.ShouldBindQuery(&query); err != nil {
 		c.JSON(http.StatusBadRequest, models.NewApiError(err))
 		return
 	}
@@ -444,8 +444,8 @@ func (api *API) UpdateVPC(c *gin.Context) {
 	}
 
 	var request models.UpdateVPC
-	if err := c.BindJSON(&request); err != nil {
-		c.JSON(http.StatusBadRequest, models.NewBadPayloadError())
+	if err := c.ShouldBindJSON(&request); err != nil {
+		c.JSON(http.StatusBadRequest, models.NewBadPayloadError(err))
 		return
 	}
 

--- a/internal/models/error.go
+++ b/internal/models/error.go
@@ -1,5 +1,7 @@
 package models
 
+import "fmt"
+
 // BaseError is the base type for API errors
 type BaseError struct {
 	Error string `json:"error" example:"something bad"`
@@ -29,10 +31,10 @@ type InternalServerError struct {
 	TraceId string `json:"trace_id,omitempty"`
 }
 
-func NewBadPayloadError() ValidationError {
+func NewBadPayloadError(err error) ValidationError {
 	return ValidationError{
 		BaseError: BaseError{
-			Error: "request json is invalid",
+			Error: fmt.Sprintf("request json is invalid: %s", err),
 		},
 	}
 }


### PR DESCRIPTION
* Switch from using Bind*() calls to ShouldBind*() so that we can set the json content type.
* `nexctl` displays improved error messages when API errors occur.