### PR TITLE
ci: store the previous prod tag as prod-previous so that we can 

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -77,8 +77,9 @@ jobs:
       - name: Promote to the prod Tag
         shell: bash
         run: |
+          git tag prod-previous prod --force
           git tag prod --force
-          git push origin prod --force 
+          git push origin prod prod-previous --force 
 
   build-packages:
     # Sync the agent binary in s3 /download with the prod promotion in the update-prod job


### PR DESCRIPTION
rollback to it easily if we need to.