### PR TITLE
ui: Don’t show the Users menu item.

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -6,8 +6,8 @@ import { goOidcAgentAuthProvider } from "./providers/AuthProvider";
 
 // icons
 import DeviceIcon from "@mui/icons-material/Devices";
-import OrganizationIcon from "@mui/icons-material/VpnLock";
-import UserIcon from "@mui/icons-material/People";
+import OrganizationIcon from "@mui/icons-material/People";
+import UserIcon from "@mui/icons-material/Person";
 import InvitationIcon from "@mui/icons-material/Rsvp";
 import RegKeyIcon from "@mui/icons-material/Key";
 import VPCIcon from "@mui/icons-material/Cloud";

--- a/ui/src/layout/Menus.tsx
+++ b/ui/src/layout/Menus.tsx
@@ -1,8 +1,7 @@
 import { DashboardMenuItem, MenuItemLink, Menu } from "react-admin";
 import SecurityIcon from "@mui/icons-material/Security";
-import UserIcon from "@mui/icons-material/People";
 import DeviceIcon from "@mui/icons-material/Devices";
-import OrganizationIcon from "@mui/icons-material/VpnLock";
+import OrganizationIcon from "@mui/icons-material/People";
 import InvitationIcon from "@mui/icons-material/Rsvp";
 import { MenuProps } from "react-admin";
 import RegKeyIcon from "@mui/icons-material/Key";
@@ -12,7 +11,6 @@ export const CustomMenu = (props: MenuProps) => {
   return (
     <Menu {...props}>
       <DashboardMenuItem />
-      <MenuItemLink to="/users" primaryText="Users" leftIcon={<UserIcon />} />
       <MenuItemLink
         to="/organizations"
         primaryText="Organizations"


### PR DESCRIPTION
Since users don’t have access to view list other users, it does not make sense to show the Users resource page in the UI, it’s only going to list the currently logged in user.  Maybe we bring it back if we have a Super Admin type role that can view users across different tennants.