### PR TITLE
nexd: reuse the wireguard listen port on restart

### DIFF
--- a/internal/nexodus/dump.go
+++ b/internal/nexodus/dump.go
@@ -137,3 +137,19 @@ func (nx *Nexodus) DumpPeersOS(iface string) (map[string]WgSessions, error) {
 	}
 	return peers, nil
 }
+
+func (nx *Nexodus) currentWgPort() int {
+	if nx.userspaceMode {
+		return nx.listenPort
+	}
+
+	c, err := wgctrl.New()
+	if err != nil {
+		return 0
+	}
+	device, err := c.Device(nx.defaultTunnelDev())
+	if err != nil {
+		return 0
+	}
+	return device.ListenPort
+}

--- a/internal/nexodus/wg.go
+++ b/internal/nexodus/wg.go
@@ -245,6 +245,16 @@ func (nx *Nexodus) deletePeerOS(publicKey, dev string) error {
 	return nil
 }
 
+func testWgListenPort(port int) error {
+	l, err := net.ListenUDP("udp", &net.UDPAddr{Port: port})
+	if err != nil {
+		return err
+	}
+	l.Close()
+	return nil
+}
+
+// getWgListenPort() will allocate a random UDP port to use as our wireguard listen port
 func getWgListenPort() (int, error) {
 	l, err := net.ListenUDP("udp", &net.UDPAddr{})
 	if err != nil {

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -2,8 +2,9 @@ package state
 
 import (
 	"fmt"
-	"golang.org/x/oauth2"
 	"io"
+
+	"golang.org/x/oauth2"
 )
 
 type State struct {
@@ -11,6 +12,7 @@ type State struct {
 	PublicKey        string           `json:"public-key"`
 	PrivateKey       string           `json:"private-key"`
 	ProxyRulesConfig ProxyRulesConfig `json:"proxy-rules-config"`
+	Port             int              `json:"port"`
 }
 
 type ProxyRulesConfig struct {


### PR DESCRIPTION
This issue reported that when a device is restarted, it triggered
upates to be sent to all peers. The reason updates were being sent is
that the Endpoints changed on every restart. When nexd started, it
would allocate a new random UDP listen port. This is bad, because it
means the data plane is interrupted at every restart until peering is
re-established using the new endpoint details.

This change uses the state store to save off the random UDP port so it
can be used on a restart.

There is one other behavior change included here. Previously, for a
relay, the default wireguard port was always used for a relay. Now if
a port is specified via a command line argument, it will be used for
regular devices and relays.

Closes #958

Signed-off-by: Russell Bryant <rbryant@redhat.com>
