### PR TITLE
nexd: Don't assign tunnel IP if it conflicts with host

### DIFF
--- a/internal/nexodus/nexodus.go
+++ b/internal/nexodus/nexodus.go
@@ -1151,13 +1151,6 @@ func (nx *Nexodus) orgRelayCheck(peerMap map[string]public.ModelsDevice) (string
 	return "", nil
 }
 
-func (nx *Nexodus) setupInterface() error {
-	if nx.userspaceMode {
-		return nx.setupInterfaceUS()
-	}
-	return nx.setupInterfaceOS()
-}
-
 func (nx *Nexodus) defaultTunnelDev() string {
 	if nx.userspaceMode {
 		return nx.defaultTunnelDevUS()


### PR DESCRIPTION
If either the v4 or v6 tunnel IPs conflict with a CIDR found on an
existing host interface.

I also moved setupInterface() to wg_deploy.go because that was the
only place it was used and it seems like an appropriate enough place
for it.

Closes #24

Signed-off-by: Russell Bryant <rbryant@redhat.com>
