### PR TITLE
fixes #1514 - When a device is deleted it is marked deleted but still  has a unique key in the device table.

### DIFF
--- a/integration-tests/features/device-api.feature
+++ b/integration-tests/features/device-api.feature
@@ -259,6 +259,71 @@ Feature: Device API
         "id": "${device_id}",
         "vpc_id": "${vpc_id}",
         "os": "linux",
+        "public_key": "",
+        "relay": false,
+        "revision": ${response.revision},
+        "symmetric_nat": true,
+        "ipv4_tunnel_ips": [
+          {
+            "address": "${response.ipv4_tunnel_ips[0].address}",
+            "cidr": "${response.ipv4_tunnel_ips[0].cidr}"
+          }
+        ],
+        "ipv6_tunnel_ips": [
+          {
+            "address": "${response.ipv6_tunnel_ips[0].address}",
+            "cidr": "${response.ipv6_tunnel_ips[0].cidr}"
+          }
+        ],
+        "owner_id": "${user_id}",
+        "security_group_id": "${response.security_group_id}"
+      }
+      """
+
+      # We should be able to create a new device with the same public key again.
+    When I POST path "/api/devices" with json body:
+      """
+      {
+        "owner_id": "${user_id}",
+        "vpc_id": "${vpc_id}",
+        "public_key": "${public_key}",
+        "endpoints": [{
+          "source": "local",
+          "address": "172.17.0.3:58664"
+        }, {
+          "source": "stun:stun1.l.google.com:19302",
+          "address": "172.17.0.3:58664"
+        }],
+        "advertise_cidrs": null,
+        "relay": false,
+        "symmetric_nat": true,
+        "hostname": "bbac3081d5e8",
+        "os": "linux"
+      }
+      """
+    Then the response code should be 201
+    Given I store the ".id" selection from the response as ${device_id}
+    And the response should match json:
+      """
+      {
+        "allowed_ips": [
+          "${response.allowed_ips[0]}",
+          "${response.allowed_ips[1]}"
+        ],
+        "online": false,
+        "online_at": null,
+        "advertise_cidrs": null,
+        "endpoints": [{
+          "source": "local",
+          "address": "172.17.0.3:58664"
+        }, {
+          "source": "stun:stun1.l.google.com:19302",
+          "address": "172.17.0.3:58664"
+        }],
+        "hostname": "bbac3081d5e8",
+        "id": "${device_id}",
+        "vpc_id": "${vpc_id}",
+        "os": "linux",
         "public_key": "${public_key}",
         "relay": false,
         "revision": ${response.revision},

--- a/internal/api/public/api_vpc_devices_custom.go
+++ b/internal/api/public/api_vpc_devices_custom.go
@@ -23,7 +23,7 @@ func (d DeviceAdaptor) Revision(item ModelsDevice) int32 {
 }
 
 func (d DeviceAdaptor) Key(item ModelsDevice) string {
-	return item.PublicKey
+	return item.Id
 }
 
 func (d DeviceAdaptor) Kind() string {

--- a/internal/nexodus/wg.go
+++ b/internal/nexodus/wg.go
@@ -154,7 +154,7 @@ func (nx *Nexodus) addPeerOS(wgPeerConfig wgPeerConfig) error {
 func (nx *Nexodus) handlePeerDelete(peerMap map[string]public.ModelsDevice) error {
 	// if the canonical peer listing does not contain a peer from cache, delete the peer
 	for _, p := range nx.deviceCache {
-		if _, ok := peerMap[p.device.PublicKey]; ok {
+		if _, ok := peerMap[p.device.Id]; ok {
 			continue
 		}
 


### PR DESCRIPTION

We now null out unique fields of the device record when we delete it.