### PR TITLE
Replace the curl e2e in exit node for tshooting

### DIFF
--- a/integration-tests/routing_test.go
+++ b/integration-tests/routing_test.go
@@ -64,6 +64,7 @@ func TestExitNode(t *testing.T) {
 		"--exit-node-client")
 
 	nexExitNodeServerHostname, err := helper.getNodeHostname(ctx, nexExitNodeServer)
+	require.NoError(err)
 
 	err = helper.startPortListener(ctx, nexExitNodeServer, webserver, protoTCP, "8000")
 	require.NoError(err)
@@ -82,7 +83,7 @@ func TestExitNode(t *testing.T) {
 	// Negative test since the exit node client is no longer in exit mode, the connection should fail since the exit node is no longer available
 	err = helper.startPortListener(ctx, nexExitNodeServer, webserver, protoTCP, "8080")
 	require.NoError(err)
-	connectResults, err = helper.connectToPort(ctx, nexExitNodeClient, webserver, protoTCP, "8080")
+	_, err = helper.connectToPort(ctx, nexExitNodeClient, webserver, protoTCP, "8080")
 	require.Error(err)
 }
 


### PR DESCRIPTION
- Replacing the exit node e2e curl to cflare and replacing it with pings to 8.8.8.8 since we're occasionally seeing resets from the cflare target. This will help determine if the error is due to code or e2e with the external curl target (likely the later with the error code being returned).