### PR TITLE
rpm: Rename russellb/nexodus to nexodus/nexodus

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -162,7 +162,14 @@ jobs:
           MOCK_ROOT="${{ matrix.mock_root }}" SRPM_MOCK_ROOT="${{ matrix.srpm_mock_root }}" SRPM_DISTRO="${{ matrix.srpm_distro }}" make srpm
           find dist
 
-      - name: Submit srpm to copr
+      - name: Submit srpm to copr (nexodus repo)
+        run: |
+            echo "${{ secrets.NEXODUS_COPR_CONFIG }}" > ~/.config/copr
+            docker run --name copr-cli -v "$(pwd):/nexodus" -v ~/.config:/root/.config quay.io/nexodus/mock:latest \
+                copr-cli build nexodus -r "$(echo ${{ matrix.mock_root }} | cut -f2 -d'+')" --nowait \
+                "/nexodus/dist/rpm/mock/nexodus-0-0.1.$(date +%Y%m%d)git$(git describe --always --abbrev=6).${{ matrix.srpm_distro }}.src.rpm"
+
+      - name: Submit srpm to copr (deprecated repo)
         run: |
           echo "${{ secrets.COPR_CONFIG }}" > ~/.config/copr
           docker run --name copr-cli -v "$(pwd):/nexodus" -v ~/.config:/root/.config quay.io/nexodus/mock:latest \

--- a/Makefile
+++ b/Makefile
@@ -279,7 +279,7 @@ dist/.opa-lint: $(policies) | dist
 
 .PHONY: action-lint
 action-lint: dist/.action-lint ## Lint GitHub Action workflows
-dist/.action-lint: $(find -type f .github) | dist
+dist/.action-lint: $(shell find .github -type f) | dist
 	$(ECHO_PREFIX) printf "  %-12s .github/...\n" "[ACTION LINT]"
 	$(CMD_PREFIX) if ! which actionlint $(PIPE_DEV_NULL) ; then \
 		echo "Please install actionlint." ; \

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -16,7 +16,7 @@ Supported versions:
 
 ```sh
 # Enable the COPR repository and install the nexodus package
-sudo dnf copr enable russellb/nexodus
+sudo dnf copr enable nexodus/nexodus
 sudo dnf install nexodus
 
 # Start the nexodus service and set it to automatically start on boot

--- a/docs/user-guide/agent.md
+++ b/docs/user-guide/agent.md
@@ -13,12 +13,12 @@ Supported versions:
 - Fedora 38 (x86_64, aarch64)
 - CentOS Stream 9 (x86_64, aarch64)
 
-A Fedora [Copr repository](https://copr.fedorainfracloud.org/coprs/russellb/nexodus/) is updated with new rpms after each new commit to the `main` branch that passes CI. The rpm will include `nexctl`, `nexd`, and integration with systemd.
+A Fedora [Copr repository](https://copr.fedorainfracloud.org/coprs/nexodus/nexodus/) is updated with new rpms after each new commit to the `main` branch that passes CI. The rpm will include `nexctl`, `nexd`, and integration with systemd.
 
 You can add this repository to your Fedora host with the following command:
 
 ```sh
-sudo dnf copr enable russellb/nexodus
+sudo dnf copr enable nexodus/nexodus
 ```
 
 Then you should be able to install Nexodus with:


### PR DESCRIPTION
- rpm: Enable new repo
- Makefile: Fix action-lint dependencies

Part of #1139


commit 1bc13bdf8e3434bef3e0ed573371fddbaecb7509
Author: Russell Bryant <russell.bryant@gmail.com>
Date:   Wed Nov 15 17:00:21 2023 -0500

    Makefile: Fix action-lint dependencies
    
    I noticed that the action-lint target didn't run after I made a change
    to a github workflow. This fixes it.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>

commit 7a0172ff3926cb79c2b833508eb28df1cbc36405
Author: Russell Bryant <russell.bryant@gmail.com>
Date:   Wed Nov 15 16:53:48 2023 -0500

    rpm: Enable new repo
    
    The original rpm repo was russellb/nexodus. This turns on the config
    to publish rpms to nexodus/nexodus. For now it will publish to both to
    allow some transition. Eventually I'll delete the one under my name.
    
    Signed-off-by: Russell Bryant <rbryant@redhat.com>
