### PR TITLE
nexctl: clean up api access commands to be simpler and more consistent.

### DIFF
--- a/cmd/nexctl/exit_node.go
+++ b/cmd/nexctl/exit_node.go
@@ -3,8 +3,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"log"
-
 	"github.com/urfave/cli/v2"
 )
 
@@ -88,7 +86,7 @@ func listExitNodes(cCtx *cli.Context, encodeOut string) error {
 
 	err = FormatOutput(encodeOut, exitNodes)
 	if err != nil {
-		log.Fatalf("failed to print output: %v", err)
+		Fatalf("failed to print output: %v", err)
 	}
 
 	return nil

--- a/cmd/nexctl/peers.go
+++ b/cmd/nexctl/peers.go
@@ -3,7 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"log"
+	"os"
 	"strconv"
 	"time"
 
@@ -51,7 +51,7 @@ func cmdListPeers(cCtx *cli.Context, encodeOut string) error {
 			rx := strconv.FormatInt(peer.Rx, 10)
 			handshakeTime, err := util.ParseTime(peer.LatestHandshake)
 			if err != nil {
-				log.Printf("Unable to parse LatestHandshake to time: %v", err)
+				fmt.Fprintln(os.Stderr, "Unable to parse LatestHandshake to time:", err)
 			}
 			handshake := "None"
 			if !handshakeTime.IsZero() {
@@ -68,7 +68,7 @@ func cmdListPeers(cCtx *cli.Context, encodeOut string) error {
 
 	err = FormatOutput(encodeOut, peers)
 	if err != nil {
-		log.Fatalf("Failed to print output: %v", err)
+		Fatalf("Failed to print output: %v", err)
 	}
 
 	return nil


### PR DESCRIPTION
Also:
* don’t show output using log, since the timestamps are not needed for interactive commands.
* we more consistently validate all uuids before doing api calls.