### PR TITLE
apiserver: invitation improvements

### DIFF
--- a/cmd/nexctl/invitation.go
+++ b/cmd/nexctl/invitation.go
@@ -92,8 +92,14 @@ func createInvitationCommand() *cli.Command {
 func invitationsTableFields() []TableField {
 	var fields []TableField
 	fields = append(fields, TableField{Header: "INVITATION ID", Field: "Id"})
-	fields = append(fields, TableField{Header: "ORGANIZATION ID", Field: "OrganizationId"})
-	fields = append(fields, TableField{Header: "USER ID", Field: "UserId"})
+	fields = append(fields, TableField{Header: "ORGANIZATION", Formatter: func(item interface{}) string {
+		inv := item.(public.ModelsInvitation)
+		return inv.Organization.Name
+	}})
+	fields = append(fields, TableField{Header: "FROM", Formatter: func(item interface{}) string {
+		inv := item.(public.ModelsInvitation)
+		return fmt.Sprintf("%s <%s>", inv.From.FullName, inv.From.Username)
+	}})
 	fields = append(fields, TableField{Header: "EMAIL", Field: "Email"})
 	fields = append(fields, TableField{Header: "EXPIRES AT", Field: "ExpiresAt"})
 	return fields

--- a/deploy/nexodus/base/auth/files/nexodus.json
+++ b/deploy/nexodus/base/auth/files/nexodus.json
@@ -708,23 +708,7 @@
       "authenticationFlowBindingOverrides": {},
       "fullScopeAllowed": true,
       "nodeReRegistrationTimeout": -1,
-      "protocolMappers" : [ {
-        "id" : "6273d8b6-f6e8-42e5-bece-aba7835e94e2",
-        "name" : "from_google",
-        "protocol" : "openid-connect",
-        "protocolMapper" : "oidc-usermodel-attribute-mapper",
-        "consentRequired" : false,
-        "config" : {
-          "aggregate.attrs" : "false",
-          "userinfo.token.claim" : "false",
-          "multivalued" : "false",
-          "user.attribute" : "from_google",
-          "id.token.claim" : "false",
-          "access.token.claim" : "true",
-          "claim.name" : "from_google",
-          "jsonType.label" : "boolean"
-        }
-      } ],
+      "protocolMappers" : [],
       "defaultClientScopes": [
         "web-origins",
         "acr",
@@ -784,23 +768,7 @@
       "authenticationFlowBindingOverrides": {},
       "fullScopeAllowed": true,
       "nodeReRegistrationTimeout": -1,
-      "protocolMappers" : [ {
-        "id" : "6273d8b6-f6e8-42e5-bece-aba7835e94e1",
-        "name" : "from_google",
-        "protocol" : "openid-connect",
-        "protocolMapper" : "oidc-usermodel-attribute-mapper",
-        "consentRequired" : false,
-        "config" : {
-          "aggregate.attrs" : "false",
-          "userinfo.token.claim" : "false",
-          "multivalued" : "false",
-          "user.attribute" : "from_google",
-          "id.token.claim" : "false",
-          "access.token.claim" : "true",
-          "claim.name" : "from_google",
-          "jsonType.label" : "boolean"
-        }
-      } ],
+      "protocolMappers" : [],
       "defaultClientScopes": [
         "web-origins",
         "acr",
@@ -1621,17 +1589,17 @@
       "clientSecret" : "${GOOGLE_CLIENT_SECRET}"
     }
   } ],
-  "identityProviderMappers" : [ {
-    "id" : "870802b9-27fd-4cba-aabe-62d7051b075a",
-    "name" : "from_google",
-    "identityProviderAlias" : "google",
-    "identityProviderMapper" : "hardcoded-attribute-idp-mapper",
-    "config" : {
-      "syncMode" : "INHERIT",
-      "attribute.value" : "true",
-      "attribute" : "from_google"
-    }
-  } ],
+  "identityProviderMappers" : [{
+      "id": "dca33fa6-edb4-4d8b-aae6-392f2e43d3b0",
+      "name": "picture",
+      "identityProviderAlias": "google",
+      "identityProviderMapper": "google-user-attribute-mapper",
+      "config": {
+        "syncMode": "FORCE",
+        "jsonField": "picture",
+        "userAttribute": "picture"
+      }
+    }],
   "components": {
     "org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy": [
       {

--- a/integration-tests/features/device-api.feature
+++ b/integration-tests/features/device-api.feature
@@ -15,6 +15,8 @@ Feature: Device API
       """
       {
         "id": "${user_id}",
+        "full_name": "Test Bob",
+        "picture": "",
         "username": "${response.username}"
       }
       """

--- a/integration-tests/features/invitation-api.feature
+++ b/integration-tests/features/invitation-api.feature
@@ -15,6 +15,7 @@ Feature: Invitations API
     When I GET path "/api/users/me"
     Then the response code should be 200
     Given I store the ".id" selection from the response as ${thompson_user_id}
+    Given I store the ".username" selection from the response as ${thompson_username}
 
     # Workaround: we can't seem to create a test user with an email, so set the email with SQL
     When I run SQL "INSERT INTO user_identities (kind, value, user_id) VALUES ('email', '${johnson_user_id}@redhat.com', '${johnson_user_id}')" expect 1 row to be affected.
@@ -61,6 +62,7 @@ Feature: Invitations API
     When I GET path "/api/users/me"
     Then the response code should be 200
     Given I store the ".id" selection from the response as ${thompson_user_id}
+    Given I store the ".username" selection from the response as ${thompson_username}
 
     When I GET path "/api/organizations"
     Then the response code should be 200
@@ -115,6 +117,18 @@ Feature: Invitations API
           "expires_at": "${response[0].expires_at}",
           "id": "${invitation_id}",
           "organization_id": "${thompson_organization_id}",
+          "from": {
+            "full_name": "Test Thompson",
+            "id": "${thompson_user_id}",
+            "picture": "",
+            "username": "${thompson_username}"
+          },
+          "organization": {
+            "description": "${thompson_username}'s organization",
+            "id": "${thompson_organization_id}",
+            "name": "${thompson_username}",
+            "owner_id": "${thompson_user_id}"
+          },
           "user_id": "${johnson_user_id}"
         }
       ]
@@ -130,6 +144,18 @@ Feature: Invitations API
           "expires_at": "${response[0].expires_at}",
           "id": "${invitation_id}",
           "organization_id": "${thompson_organization_id}",
+          "from": {
+            "full_name": "Test Thompson",
+            "id": "${thompson_user_id}",
+            "picture": "",
+            "username": "${thompson_username}"
+          },
+          "organization": {
+            "description": "${thompson_username}'s organization",
+            "id": "${thompson_organization_id}",
+            "name": "${thompson_username}",
+            "owner_id": "${thompson_user_id}"
+          },
           "user_id": "${johnson_user_id}"
         }
       ]

--- a/integration-tests/features/reg-key-api.feature
+++ b/integration-tests/features/reg-key-api.feature
@@ -15,6 +15,8 @@ Feature: Device API
       """
       {
         "id": "${user_id}",
+        "full_name": "Test Bob",
+        "picture": "",
         "username": "${response.username}"
       }
       """

--- a/integration-tests/features/users-api.feature
+++ b/integration-tests/features/users-api.feature
@@ -20,6 +20,8 @@ Feature: Users API
       """
       {
         "id": "${ursala_id}",
+        "full_name": "Test EvilUrsala",
+        "picture": "",
         "username": "${response.username}"
       }
       """
@@ -36,6 +38,8 @@ Feature: Users API
       [
         {
           "id": "${ursala_id}",
+          "full_name": "Test EvilUrsala",
+          "picture": "",
           "username": "${response[0].username}"
         }
       ]
@@ -48,6 +52,8 @@ Feature: Users API
       """
       {
         "id": "${ursala_id}",
+        "full_name": "Test EvilUrsala",
+        "picture": "",
         "username": "${response.username}"
       }
       """
@@ -89,6 +95,8 @@ Feature: Users API
       """
       {
         "id": "${ursala_id}",
+        "full_name": "Test EvilUrsala",
+        "picture": "",
         "username": "${response.username}"
       }
       """
@@ -114,6 +122,8 @@ Feature: Users API
       """
       {
         "id": "${response.id}",
+        "full_name": "Test EvilUrsala",
+        "picture": "",
         "username": "${response.username}"
       }
       """

--- a/internal/api/public/model_models_invitation.go
+++ b/internal/api/public/model_models_invitation.go
@@ -13,9 +13,11 @@ package public
 // ModelsInvitation struct for ModelsInvitation
 type ModelsInvitation struct {
 	// The email address to invite
-	Email          string `json:"email,omitempty"`
-	ExpiresAt      string `json:"expires_at,omitempty"`
-	Id             string `json:"id,omitempty"`
-	OrganizationId string `json:"organization_id,omitempty"`
-	UserId         string `json:"user_id,omitempty"`
+	Email          string             `json:"email,omitempty"`
+	ExpiresAt      string             `json:"expires_at,omitempty"`
+	From           ModelsUser         `json:"from,omitempty"`
+	Id             string             `json:"id,omitempty"`
+	Organization   ModelsOrganization `json:"organization,omitempty"`
+	OrganizationId string             `json:"organization_id,omitempty"`
+	UserId         string             `json:"user_id,omitempty"`
 }

--- a/internal/api/public/model_models_user.go
+++ b/internal/api/public/model_models_user.go
@@ -12,6 +12,8 @@ package public
 
 // ModelsUser struct for ModelsUser
 type ModelsUser struct {
+	FullName string `json:"full_name,omitempty"`
 	Id       string `json:"id,omitempty"`
+	Picture  string `json:"picture,omitempty"`
 	Username string `json:"username,omitempty"`
 }

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -12,6 +12,7 @@ import (
 	_ "github.com/nexodus-io/nexodus/internal/database/migration_20231114_0000"
 	_ "github.com/nexodus-io/nexodus/internal/database/migration_20231120_0000"
 	_ "github.com/nexodus-io/nexodus/internal/database/migration_20231130_0000"
+	_ "github.com/nexodus-io/nexodus/internal/database/migration_20231206_0000"
 	"sort"
 
 	"github.com/cenkalti/backoff/v4"

--- a/internal/database/migration_20231206_0000/migration.go
+++ b/internal/database/migration_20231206_0000/migration.go
@@ -1,0 +1,55 @@
+package migration_20231206_0000
+
+import (
+	"errors"
+	"github.com/google/uuid"
+	"github.com/nexodus-io/nexodus/internal/database/migration_20231130_0000"
+	. "github.com/nexodus-io/nexodus/internal/database/migrations"
+	"gorm.io/gorm"
+)
+
+type User struct {
+	FullName string
+	Picture  string
+}
+
+type Invitation struct {
+	FromID uuid.UUID
+	From   migration_20231130_0000.User
+}
+
+func init() {
+	migrationId := "20231206-0000"
+	CreateMigrationFromActions(migrationId,
+		func(tx *gorm.DB, apply bool) error {
+			return AddTableColumnsAction(&User{})(tx, apply)
+		},
+		func(tx *gorm.DB, apply bool) error {
+			return AddTableColumnsAction(&Invitation{})(tx, apply)
+		},
+		// AddTableColumnsAction(&Invitation{}),
+		func(tx *gorm.DB, apply bool) error {
+			if !apply {
+				return nil
+			}
+
+			// try to add admin user email...
+			user := migration_20231130_0000.User{}
+			adminIdpId := "01578c9e-8e76-46a4-b2b2-50788cec2ccd"
+			if res := tx.First(&user, "idp_id = ?", adminIdpId); res.Error != nil {
+				if errors.Is(res.Error, gorm.ErrRecordNotFound) {
+					return nil // skip if the admin user does not exist
+				}
+				return res.Error
+			}
+
+			// ignore error if the email already exists
+			_ = tx.Create(&migration_20231130_0000.UserIdentity{
+				Kind:   "email",
+				Value:  "admin@example.com",
+				UserID: user.ID,
+			})
+			return nil
+		},
+	)
+}

--- a/internal/docs/docs.go
+++ b/internal/docs/docs.go
@@ -3050,9 +3050,15 @@ const docTemplate = `{
                 "expires_at": {
                     "type": "string"
                 },
+                "from": {
+                    "$ref": "#/definitions/models.User"
+                },
                 "id": {
                     "type": "string",
                     "example": "aa22666c-0f57-45cb-a449-16efecc04f2e"
+                },
+                "organization": {
+                    "$ref": "#/definitions/models.Organization"
                 },
                 "organization_id": {
                     "type": "string"
@@ -3353,9 +3359,15 @@ const docTemplate = `{
         "models.User": {
             "type": "object",
             "properties": {
+                "full_name": {
+                    "type": "string"
+                },
                 "id": {
                     "type": "string",
                     "example": "aa22666c-0f57-45cb-a449-16efecc04f2e"
+                },
+                "picture": {
+                    "type": "string"
                 },
                 "username": {
                     "type": "string"

--- a/internal/docs/swagger.json
+++ b/internal/docs/swagger.json
@@ -3043,9 +3043,15 @@
                 "expires_at": {
                     "type": "string"
                 },
+                "from": {
+                    "$ref": "#/definitions/models.User"
+                },
                 "id": {
                     "type": "string",
                     "example": "aa22666c-0f57-45cb-a449-16efecc04f2e"
+                },
+                "organization": {
+                    "$ref": "#/definitions/models.Organization"
                 },
                 "organization_id": {
                     "type": "string"
@@ -3346,9 +3352,15 @@
         "models.User": {
             "type": "object",
             "properties": {
+                "full_name": {
+                    "type": "string"
+                },
                 "id": {
                     "type": "string",
                     "example": "aa22666c-0f57-45cb-a449-16efecc04f2e"
+                },
+                "picture": {
+                    "type": "string"
                 },
                 "username": {
                     "type": "string"

--- a/internal/docs/swagger.yaml
+++ b/internal/docs/swagger.yaml
@@ -230,9 +230,13 @@ definitions:
         type: string
       expires_at:
         type: string
+      from:
+        $ref: '#/definitions/models.User'
       id:
         example: aa22666c-0f57-45cb-a449-16efecc04f2e
         type: string
+      organization:
+        $ref: '#/definitions/models.Organization'
       organization_id:
         type: string
       user_id:
@@ -441,8 +445,12 @@ definitions:
     type: object
   models.User:
     properties:
+      full_name:
+        type: string
       id:
         example: aa22666c-0f57-45cb-a449-16efecc04f2e
+        type: string
+      picture:
         type: string
       username:
         type: string

--- a/internal/models/invitation.go
+++ b/internal/models/invitation.go
@@ -9,10 +9,13 @@ import (
 // Invitation is a request for a user to join an organization
 type Invitation struct {
 	Base
-	UserID         *uuid.UUID `json:"user_id,omitempty"`
-	Email          *string    `json:"email,omitempty"` // The email address to invite
-	OrganizationID uuid.UUID  `json:"organization_id"`
-	ExpiresAt      time.Time  `json:"expires_at"`
+	UserID         *uuid.UUID    `json:"user_id,omitempty"`
+	Email          *string       `json:"email,omitempty"` // The email address to invite
+	OrganizationID uuid.UUID     `json:"organization_id"`
+	Organization   *Organization `json:"organization,omitempty"`
+	ExpiresAt      time.Time     `json:"expires_at"`
+	FromID         uuid.UUID     `json:"-"`
+	From           *User         `json:"from,omitempty"`
 }
 
 type AddInvitation struct {

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -9,6 +9,8 @@ type User struct {
 	Base
 	IdpID         string          `json:"-"` // Comes from the IDP
 	Organizations []*Organization `gorm:"many2many:user_organizations" json:"-"`
+	FullName      string          `json:"full_name"`
+	Picture       string          `json:"picture"`
 	UserName      string          `json:"username"`
 	Invitations   []*Invitation   `json:"-"`
 }

--- a/ui/src/pages/Invitations.tsx
+++ b/ui/src/pages/Invitations.tsx
@@ -22,6 +22,8 @@ import {
   UseRecordContextParams,
   RaRecord,
   Identifier,
+  DateTimeInput,
+  AutocompleteInput,
 } from "react-admin";
 
 import { backend, fetchJson as apiFetchJson } from "../common/Api";
@@ -80,10 +82,8 @@ export const AcceptInvitationField = (
 ) => {
   const record = useRecordContext(props);
   const { identity } = useGetIdentity();
-  console.log("identity", identity);
-  console.log("record", record);
   // only show the accept button for invitations that are for the current user
-  return record && identity && identity.email == record.email ? (
+  return record && identity && identity.id == record.user_id ? (
     <AcceptInvitationButton />
   ) : null;
 };
@@ -91,22 +91,10 @@ export const AcceptInvitationField = (
 export const InvitationList = () => (
   <List>
     <Datagrid rowClick="show" bulkActionButtons={<InvitationListBulkActions />}>
-      <TextField label="ID" source="id" />
-      <TextField label="Email Address" source="email" />
-      {/* Right now we can't look up other users, we don't have access */}
-      {/*<ReferenceField*/}
-      {/*  label="User"*/}
-      {/*  source="user_id"*/}
-      {/*  reference="users"*/}
-      {/*  link="show"*/}
-      {/*/>*/}
-      <ReferenceField
-        label="Organization"
-        source="organization_id"
-        reference="organizations"
-        link="show"
-      />
-      <TextField label="Expires" source="expiry" />
+      <TextField label="From" source="from.full_name" />
+      <TextField label="To" source="email" />
+      <TextField label="Organization" source="organization.name" />
+      <TextField label="Expires At" source="expires_at" />
       <AcceptInvitationField />
     </Datagrid>
   </List>
@@ -116,21 +104,11 @@ export const InvitationShow = () => (
   <Show>
     <SimpleShowLayout>
       <TextField label="ID" source="id" />
-      <TextField label="User ID" source="user_id" />
-      {/* Right now we can't look up other users, we don't have access */}
-      {/*<ReferenceField*/}
-      {/*  label="User"*/}
-      {/*  source="user_id"*/}
-      {/*  reference="users"*/}
-      {/*  link="show"*/}
-      {/*/>*/}
-      <ReferenceField
-        label="Organization"
-        source="organization_id"
-        reference="organizations"
-        link="show"
-      />
-      <TextField label="Expires" source="expiry" />
+      <TextField label="From" source="from.full_name" />
+      <TextField label="To" source="email" />
+      <TextField label="Organization" source="organization.name" />
+      <TextField label="Expires At" source="expires_at" />
+      <AcceptInvitationField />
     </SimpleShowLayout>
   </Show>
 );
@@ -151,11 +129,19 @@ export const InvitationCreate = () => {
           fullWidth
         />
         <ReferenceInput
-          label="User Name"
+          label="Organization"
           name="organization_id"
           source="organization_id"
           reference="organizations"
           filter={{ owner_id: identity.id }}
+        >
+          <AutocompleteInput fullWidth />
+        </ReferenceInput>
+        <DateTimeInput
+          label="Expires At"
+          name="expires_at"
+          source="expires_at"
+          fullWidth
         />
       </SimpleForm>
     </Create>

--- a/ui/src/pages/RegKeys.tsx
+++ b/ui/src/pages/RegKeys.tsx
@@ -87,7 +87,7 @@ export const RegKeyShow = () => (
         link="show"
       />
       <BooleanField label="Single Use" source="device_id" looseValue={true} />
-      <TextField label="Expiration" source="expiration" />
+      <DateField label="Expiration" source="expiration" showTime={true} />
       <TextField label="Description" source="description" />
       <JsonField label="Settings" source="settings" />
     </SimpleShowLayout>

--- a/ui/src/providers/AuthProvider.tsx
+++ b/ui/src/providers/AuthProvider.tsx
@@ -171,7 +171,7 @@ export const goOidcAgentAuthProvider = (api: string): AuthProvider => ({
 
   getIdentity: async (): Promise<UserIdentity> => {
     console.log("Get Identity Called");
-    const request = new Request(`${api}/web/user_info`, {
+    const request = new Request(`${api}/api/users/me`, {
       credentials: "include",
     });
     let id;
@@ -180,8 +180,8 @@ export const goOidcAgentAuthProvider = (api: string): AuthProvider => ({
       const data = await response.json();
       if (response && data) {
         id = {
-          id: data.sub,
-          fullName: data.preferred_username,
+          id: data.id,
+          fullName: data.full_name,
           avatar: data.picture,
           email: data.email,
         } as UserIdentity;


### PR DESCRIPTION
* added a from_id col to the Invitations table so that a receiver can know who is inviting him.
* added full_name and picture col to the Users table.
* give the admin user the admin@example.com email address to make doing invitation demos easier with him.
* Invitation json rest responses now include the organization and from fields since a receiver can’t look the related records up by id.
* UI uses /api/users/me to get the current user identity
* update the keycloak config: drop the from_google attribute, but bring in the picture attribute.
* when a user logs in, update the user record’s full_name, picture and associated email from the OAuth claims
* improve the UI invitations page.  Allow a user to accept an invitation in Show page.
* improve the nexctl invitations listing.