### PR TITLE
fix for smtp-from flag

### DIFF
--- a/cmd/apiserver/main.go
+++ b/cmd/apiserver/main.go
@@ -272,9 +272,9 @@ func main() {
 				Required: false,
 				Sources:  cli.EnvVars("NEXAPI_SMTP_TLS"),
 			},
-			&cli.BoolFlag{
+			&cli.StringFlag{
 				Name:     "smtp-from",
-				Usage:    "The form address to use for emails",
+				Usage:    "The from address to use for emails",
 				Required: false,
 				Sources:  cli.EnvVars("NEXAPI_SMTP_FROM"),
 			},


### PR DESCRIPTION
enabled argo-cd sync for nexodus-qa and apiserver was failing with following error 
```2023/12/15 05:39:53 could not parse "no-reply@nexodus.io" as bool value from environment variable "NEXAPI_SMTP_FROM" for flag smtp-from: parse error```
