### PR TITLE
Run make cacerts in derpcerts Makefule section if .certs is not present

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -790,6 +790,10 @@ cacerts: ## Install the Self-Signed CA Certificate
 
 .PHONY: derpcerts
 derpcerts: ## Create and fetch the Self-Signed CA Certificate for derp relay from the cluster
+	@if [ ! -d "$(CURDIR)/.certs" ]; then \
+		echo ".certs directory does not exist, running make cacerts..."; \
+		make cacerts; \
+	fi
 	$(CMD_PREFIX) ./hack/relayderp-certs.sh
 	$(CMD_PREFIX) $(kubectl) get secret nexodus-derp-relay-cert -o json | jq -r '.data."tls.crt"' | base64 -d > $(CURDIR)/.certs/relay.nexodus.io.crt
 	$(CMD_PREFIX) $(kubectl) get secret nexodus-derp-relay-cert -o json | jq -r '.data."tls.key"' | base64 -d > $(CURDIR)/.certs/relay.nexodus.io.key


### PR DESCRIPTION

```
ubuntu@ip-172-31-78-221:~/nexodus$ NEX_TEST=TestFeatures/webui make e2e
.certs directory does not exist, running make cacerts...
make[1]: Entering directory '/home/ubuntu/nexodus'
The local CA is already installed in the system trust store! 👍
```