### PR TITLE
Reduce dependabot PR churn

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,18 +5,38 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      production-dependencies:
+        dependency-type: "production"
+      development-dependencies:
+        dependency-type: "development"
   # Maintain dependencies for NodeJS
   - package-ecosystem: "npm"
     directory: "/ui"
     schedule:
       interval: "weekly"
+    groups:
+      node-production-dependencies:
+        dependency-type: "production"
+      node-development-dependencies:
+        dependency-type: "development"
   # Maintain dependencies for Go
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      production-dependencies:
+        dependency-type: "production"
+      development-dependencies:
+        dependency-type: "development"
   # Maintain dependencies for Docker
   - package-ecosystem: "docker"
     directory: "/deploy"
     schedule:
       interval: "weekly"
+    groups:
+      production-dependencies:
+        dependency-type: "production"
+      development-dependencies:
+        dependency-type: "development"


### PR DESCRIPTION
This groups dependency updates into:
- development deps: github actions updates
- production deps: gomod and/or docker image changes
- nodejs production deps
- nodejs development deps

This should result in no more than 4 PRs each Monday 😏 With less chance of introducing merge conflicts.