### PR TITLE
DERP docs

### DIFF
--- a/docs/user-guide/relay-nodes.md
+++ b/docs/user-guide/relay-nodes.md
@@ -77,10 +77,10 @@ Create an extension file
 authorityKeyIdentifier=keyid,issuer
 basicConstraints=CA:FALSE
 keyUsage = digitalSignature, nonRepudiation, keyEncipherment, dataEncipherment
-subjectAltName = <relay-private-domain-name>
+subjectAltName = DNS:<relay-private-domain-name>
 ```
 
-Set `subjectAltName` to the private DNS name (e.g. `xyz.relay.io`) that user wants to use for the relay node.
+Set `subjectAltName` to the private DNS name (e.g. `DNS:xyz.relay.io`) that user wants to use for the relay node.
 
 Run the following command to sign and generate the server certificate
 
@@ -99,7 +99,7 @@ cp server.crt xyz.relay.io.crt
 Now you can use the private DNS name and the key/certificates to onboard the relay. Use the following command to onboard the relay node:
 
 ```sh
-sudo nexd relayderp --hostname xyz.relay.io -a ":443" --certmode manual --certdir "<certificate-directory-path>"  --onboard
+sudo nexd relayderp --hostname xyz.relay.io --addr ":443" --certmode manual --certdir "<certificate-directory-path>"  --onboard
 ```
 
 In this scenario, the user needs to install the root CA key (rootCA.key) to all the nodes that need to be connected through this onboard relay. Copy the file to each node and run the following command to install the root CA key:


### PR DESCRIPTION
Modified the cert extension file portion.

Without the DNS tag I get the following:

```
$ openssl x509 -req -in server.csr -CA rootCA.pem -CAkey rootCA.key -CAcreateserial -out server.crt -days 800 -sha256 -extfile v3.ext
Error checking extension section default
800B98CFFF7E0000:error:1100007C:X509 V3 routines:v2i_GENERAL_NAME_ex:missing value:../crypto/x509/v3_san.c:611:
800B98CFFF7E0000:error:11000080:X509 V3 routines:X509V3_EXT_nconf_int:error in extension:../crypto/x509/v3_conf.c:48:section=default, name=subjectAltName, value=xyz.relay.io
```