### PR TITLE
Remove vscode devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,0 @@
-{
-  "name": "nexodus build tools",
-  "build": {
-    "dockerfile": "../Containerfile.dev"
-  }
-}

--- a/.dockerignore
+++ b/.dockerignore
@@ -35,4 +35,3 @@ docs/
 # dotfiles and ci workflows
 .github/
 .vscode/
-.devcontainer/

--- a/Makefile
+++ b/Makefile
@@ -481,25 +481,6 @@ run-nexd-container: image-nexd ## Run a container that you can run nexodus in
 		--mount type=bind,source=$(shell pwd)/.certs,target=/.certs,readonly \
 		quay.io/nexodus/nexd:latest /update-ca.sh
 
-.dev-container: Containerfile.dev
-	$(CMD_PREFIX) docker build -f Containerfile.dev -t quay.io/nexodus/dev:latest .
-	$(CMD_PREFIX) touch $@
-
-.PHONY: run-dev-container
-run-dev-container: .dev-container ## Run docker container that you can develop and run nexodus in
-	$(CMD_PREFIX) docker run --rm -it --network bridge \
-		--cap-add SYS_MODULE \
-		--cap-add NET_ADMIN \
-		--cap-add NET_RAW \
-		--add-host try.nexodus.127.0.0.1.nip.io:$(NEXODUS_LOCAL_IP) \
-		--add-host api.try.nexodus.127.0.0.1.nip.io:$(NEXODUS_LOCAL_IP) \
-		--add-host auth.try.nexodus.127.0.0.1.nip.io:$(NEXODUS_LOCAL_IP) \
-		--mount type=bind,source=$(shell pwd)/.certs,target=/.certs,readonly \
-		-v /var/run/docker.sock:/var/run/docker.sock \
-		-v $(CURDIR):$(CURDIR) \
-		--workdir $(CURDIR) \
-		quay.io/nexodus/dev:latest
-
 .PHONY: run-sql-apiserver
 run-sql-apiserver: ## runs a command line SQL client to interact with the apiserver database
 ifeq ($(OVERLAY),dev)

--- a/docs/development/tooling.md
+++ b/docs/development/tooling.md
@@ -29,18 +29,6 @@ Use the `--force` option if you want to reinstall them in case you think the ver
 
 ## IDE Tips
 
-### Dev Containers
-
-If you only have `make` and `docker` installed, your can run a container that has all the needed development tooling by running:
-
-    make run-dev-container
-
-__NOTE: Currently, this does not support starting the Nexodus service in kind.__
-
-#### VS Code
-
-The [Dev Container](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) plugin supports automatically running VSCode in the development container that has all the need development tooling
-
 ### [VSCode](https://code.visualstudio.com/)
 
 Recommended plugins:


### PR DESCRIPTION
This feature is not actively used and has caused some confusion with
new contributors trying to run the full test stack in the dev
container, which we don't expect to work.

Signed-off-by: Russell Bryant <russell.bryant@gmail.com>
