### PR TITLE
ui: Disable react-admin telemetry

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -58,6 +58,7 @@ const App = () => {
       menu={CustomMenu}
       darkTheme={darkTheme}
       requireAuth
+      disableTelemetry
     >
       <Resource
         name="users"


### PR DESCRIPTION
https://marmelab.com/blog/2021/02/02/react-admin-february-2021-update.html#domain-telemetry

I think someone installing their own Nexodus service would be
surprised to find it was sending telemetry to a 3rd party. We could
document it and describe how to disable it, but it's just easier to
disable it by default.

Signed-off-by: Russell Bryant <russell.bryant@gmail.com>
