### PR TITLE
deploy: Request 1 GB for postgres

### DIFF
--- a/deploy/nexodus/base/database/postgres.yaml
+++ b/deploy/nexodus/base/database/postgres.yaml
@@ -20,7 +20,7 @@ spec:
           memory: 2Gi
         requests:
           cpu: 500m
-          memory: 2Gi
+          memory: 1Gi
       sidecars:
         replicaCertCopy:
           resources:


### PR DESCRIPTION
We previously requested 2 GB for postgres, but thaut's breaking some
development environments that are memory constrained. Request a
minimum of 1 GB instead.

Signed-off-by: Russell Bryant <russell.bryant@gmail.com>
