### PR TITLE
Ensure device symmetricNAT field is updated

### DIFF
--- a/integration-tests/features/device-api.feature
+++ b/integration-tests/features/device-api.feature
@@ -202,6 +202,55 @@ Feature: Device API
       }
       """
 
+    # Bob can update if device is no more behind symmetric NAT.
+    When I PATCH path "/api/devices/${device_id}" with json body:
+      """
+      {
+        "symmetric_nat": false
+      }
+      """
+    Then the response code should be 200
+    And the response should match json:
+      """
+      {
+        "allowed_ips": [
+          "${response.allowed_ips[0]}",
+          "${response.allowed_ips[1]}"
+        ],
+        "online": false,
+        "online_at": null,
+        "advertise_cidrs": null,
+        "endpoints": [{
+          "source": "local",
+          "address": "172.17.0.3:58664"
+        }, {
+          "source": "stun:stun1.l.google.com:19302",
+          "address": "172.17.0.3:58664"
+        }],
+        "hostname": "kittenhome",
+        "id": "${device_id}",
+        "vpc_id": "${vpc_id}",
+        "os": "linux",
+        "public_key": "${public_key}",
+        "relay": true,
+        "revision": ${response.revision},
+        "symmetric_nat": false,
+        "ipv4_tunnel_ips": [
+          {
+            "address": "${response.ipv4_tunnel_ips[0].address}",
+            "cidr": "${response.ipv4_tunnel_ips[0].cidr}"
+          }
+        ],
+        "ipv6_tunnel_ips": [
+          {
+            "address": "${response.ipv6_tunnel_ips[0].address}",
+            "cidr": "${response.ipv6_tunnel_ips[0].cidr}"
+          }
+        ],        "owner_id": "${user_id}",
+        "security_group_id": "${response.security_group_id}"
+      }
+      """
+
     # Bob gets the devices and should see 1 device in the device listing..
     When I GET path "/api/devices"
     Then the response code should be 200
@@ -230,7 +279,7 @@ Feature: Device API
           "public_key": "${public_key}",
           "relay": true,
           "revision": ${response[0].revision},
-          "symmetric_nat": true,
+          "symmetric_nat": false,
           "security_group_id": "${response[0].security_group_id}",
           "ipv4_tunnel_ips": [
             {
@@ -313,7 +362,7 @@ Feature: Device API
         "public_key": "",
         "relay": true,
         "revision": ${response.revision},
-        "symmetric_nat": true,
+        "symmetric_nat": false,
         "ipv4_tunnel_ips": [
           {
             "address": "${response.ipv4_tunnel_ips[0].address}",

--- a/internal/handlers/device.go
+++ b/internal/handlers/device.go
@@ -587,6 +587,11 @@ func (api *API) CreateDevice(c *gin.Context) {
 			return err
 		}
 
+		var symmetricNat bool
+		if request.SymmetricNat != nil {
+			symmetricNat = *request.SymmetricNat
+		}
+
 		device = models.Device{
 			Base: models.Base{
 				ID: deviceId,
@@ -611,7 +616,7 @@ func (api *API) CreateDevice(c *gin.Context) {
 			},
 			AdvertiseCidrs:  request.AdvertiseCidrs,
 			Relay:           request.Relay,
-			SymmetricNat:    request.SymmetricNat,
+			SymmetricNat:    symmetricNat,
 			Hostname:        request.Hostname,
 			Os:              request.Os,
 			SecurityGroupId: vpc.ID,

--- a/internal/handlers/device_test.go
+++ b/internal/handlers/device_test.go
@@ -16,8 +16,9 @@ func (suite *HandlerTestSuite) TestCreateGetDevice() {
 	require := suite.Require()
 	assert := suite.Assert()
 	newDevice := models.AddDevice{
-		VpcID:     suite.testUserID,
-		PublicKey: "atestpubkey",
+		VpcID:        suite.testUserID,
+		PublicKey:    "atestpubkey",
+		SymmetricNat: suite.SymmetricNat,
 	}
 
 	resBody, err := json.Marshal(newDevice)

--- a/internal/handlers/handlers_test.go
+++ b/internal/handlers/handlers_test.go
@@ -35,12 +35,13 @@ const (
 
 type HandlerTestSuite struct {
 	suite.Suite
-	logger      *zap.SugaredLogger
-	ipam        *http.Server
-	wg          *sync.WaitGroup
-	api         *API
-	testUserID  uuid.UUID
-	testUser2ID uuid.UUID
+	logger       *zap.SugaredLogger
+	ipam         *http.Server
+	wg           *sync.WaitGroup
+	api          *API
+	testUserID   uuid.UUID
+	testUser2ID  uuid.UUID
+	SymmetricNat *bool
 }
 
 func (suite *HandlerTestSuite) SetupSuite() {
@@ -52,6 +53,7 @@ func (suite *HandlerTestSuite) SetupSuite() {
 	suite.ipam = ipam.NewTestIPAMServer()
 	suite.wg = &sync.WaitGroup{}
 	suite.wg.Add(1)
+	suite.SymmetricNat = new(bool)
 
 	listener, err := net.Listen("tcp", "[::1]:49090")
 	suite.Require().NoError(err)

--- a/internal/models/device.go
+++ b/internal/models/device.go
@@ -39,7 +39,7 @@ type AddDevice struct {
 	AdvertiseCidrs  []string   `json:"advertise_cidrs" example:"172.16.42.0/24"`
 	IPv4TunnelIPs   []TunnelIP `json:"ipv4_tunnel_ips" gorm:"type:JSONB; serializer:json"`
 	Relay           bool       `json:"relay"`
-	SymmetricNat    bool       `json:"symmetric_nat"`
+	SymmetricNat    *bool      `json:"symmetric_nat"`
 	Hostname        string     `json:"hostname" example:"myhost"`
 	Endpoints       []Endpoint `json:"endpoints" gorm:"type:JSONB; serializer:json"`
 	Os              string     `json:"os"`


### PR DESCRIPTION
with add/update device requests

Openapi client generates the model with json tag
omitempty, that removes the symmetricNAT flag in
the json request body if it's false.

Fixes: #1956 