### PR TITLE
deployment: attempt to fix the nexodus monitoring stack on qa/prod

### DIFF
--- a/deploy/nexodus-monitoring/overlays/rosa/monitoringstack.yaml
+++ b/deploy/nexodus-monitoring/overlays/rosa/monitoringstack.yaml
@@ -5,11 +5,6 @@ metadata:
 spec:
   logLevel: info
   retention: 2d
-  namespaceSelector:
-    matchNames:
-      - nexodus-monitoring
-      - nexodus-qa
-      - nexodus
   resourceSelector:
     matchLabels:
       team: nexodus


### PR DESCRIPTION
* argo kept saying the the MonitoringStack resource was OutOfSync due To the namespaceSelector getting clear out by something else.