### PR TITLE
deployment: attempt to fix the nexodus monitoring stack on qa/prod

### DIFF
--- a/deploy/nexodus-monitoring/overlays/rosa/grafana/rolebinding.yaml
+++ b/deploy/nexodus-monitoring/overlays/rosa/grafana/rolebinding.yaml
@@ -4,7 +4,6 @@ metadata:
   namespace: nexodus-monitoring
   name: grafana-proxy
 roleRef:
-  kind: Role
   name: grafana-proxy
 subjects:
   - kind: ServiceAccount


### PR DESCRIPTION
* argo kept saying the the MonitoringStack resource was OutOfSync due To the namespaceSelector getting clear out by something else.