### PR TITLE
Revert "deployment: fix grafana host name "

### DIFF
--- a/deploy/nexodus-monitoring/overlays/rosa/grafana-patch.yaml
+++ b/deploy/nexodus-monitoring/overlays/rosa/grafana-patch.yaml
@@ -25,7 +25,7 @@ spec:
       header_property: username
       header_name: X-Forwarded-User
     server:
-      root_url: https://nexodus-grafana.apps.platform-sts.pcbk.p1.openshiftapps.com
+      root_url: https://nexodus-grafana.apps.open-svc-sts.k1wl.p1.openshiftapps.com
   containers:
     - args:
         - '-provider=openshift'

--- a/deploy/nexodus-monitoring/overlays/rosa/grafana/route.yaml
+++ b/deploy/nexodus-monitoring/overlays/rosa/grafana/route.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     service.beta.openshift.io/serving-cert-secret-name: grafana-tls
 spec:
-  host: nexodus-grafana.apps.platform-sts.pcbk.p1.openshiftapps.com
+  host: nexodus-grafana.apps.open-svc-sts.k1wl.p1.openshiftapps.com
   port:
     targetPort: https
   tls:


### PR DESCRIPTION
This reverts commit 4f96ab6c15391c061b1a6f0148028591c7daf13e.