### PR TITLE
Fixes e2e failures on mac

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -391,8 +391,10 @@ dist/.generate: $(SWAGGER_YAML) $(PRIVATE_SWAGGER_YAML) dist/.ui-fmt docs/user-g
 	$(CMD_PREFIX) [ -z "$(shell gofmt -l .)" ] || gofmt -w .
 	$(CMD_PREFIX) touch $@
 
+.PHONEY:e2e-setup
+ e2e-setup: e2eprereqs dist/nexd dist/nexctl image-nexd image-playwright derpcerts
 .PHONY: e2e
-e2e: e2eprereqs dist/nexd dist/nexctl image-nexd image-playwright derpcerts ## Run e2e verbose tests
+e2e: e2e-setup ## Run e2e verbose tests
 	CGO_ENABLED=1 gotestsum --format $(GOTESTSUM_FMT) -- \
 		-race --tags=integration ./integration-tests/... $(shell [ -z "$$NEX_TEST" ] || echo "-run $$NEX_TEST" )
 

--- a/go.mod
+++ b/go.mod
@@ -77,7 +77,6 @@ require (
 )
 
 require (
-	github.com/txn2/txeh v1.5.4
 	go4.org/mem v0.0.0-20220726221520-4f986261bf13
 	golang.org/x/time v0.5.0
 	nhooyr.io/websocket v1.8.10

--- a/go.sum
+++ b/go.sum
@@ -556,8 +556,6 @@ github.com/tklauser/numcpus v0.6.1 h1:ng9scYS7az0Bk4OZLvrNXNSAO2Pxr1XXRAPyjhIx+F
 github.com/tklauser/numcpus v0.6.1/go.mod h1:1XfjsgE2zo8GVw7POkMbHENHzVg3GzmoZ9fESEdAacY=
 github.com/twitchyliquid64/golang-asm v0.15.1 h1:SU5vSMR7hnwNxj24w34ZyCi/FmDZTkS4MhqMhdFk5YI=
 github.com/twitchyliquid64/golang-asm v0.15.1/go.mod h1:a1lVb/DtPvCB8fslRZhAngC2+aY1QWCk3Cedj/Gdt08=
-github.com/txn2/txeh v1.5.4 h1:ZL9o3e7S8RnduFhUl42/wn//Aq/uWI9Md8MluSRUvN8=
-github.com/txn2/txeh v1.5.4/go.mod h1:qYzGG9kCzeVEI12geK4IlanHWY8X4uy/I3NcW7mk8g4=
 github.com/ugorji/go/codec v1.2.11 h1:BMaWp1Bb6fHwEtbplGBGJ498wD+LKlNSl25MjdZY4dU=
 github.com/ugorji/go/codec v1.2.11/go.mod h1:UNopzCgEMSXjBc6AOMqYvWC1ktqTAfzJZUZgYf6w6lg=
 github.com/uptrace/opentelemetry-go-extra/otelgorm v0.2.3 h1:girTS67d1m8+XUJLbNBDjCSH8BtujWFoI93W1OUjFIc=

--- a/internal/nexodus/derp.go
+++ b/internal/nexodus/derp.go
@@ -226,6 +226,7 @@ func (nr *nexRelay) derpWriteChanOfAddr(addr netip.AddrPort, peer key.NodePublic
 	dc.NotePreferred(nr.myDerp == regionID)
 	dc.SetAddressFamilySelector(derpAddrFamSelector{nr})
 	dc.DNSCache = dnscache.Get()
+	dc.DNSCache.LookupIPFallback = nr.inMemResolver.LookupIP
 
 	ctx, cancel := context.WithCancel(nr.connCtx)
 	ch := make(chan derpWriteRequest, bufferedDerpWritesBeforeDrop())

--- a/internal/nexodus/in_mem_resolver.go
+++ b/internal/nexodus/in_mem_resolver.go
@@ -1,0 +1,39 @@
+package nexodus
+
+import (
+	"context"
+	"fmt"
+	"net/netip"
+	"sync"
+)
+
+type InMemResolver struct {
+	mu    sync.RWMutex
+	hosts map[string][]netip.Addr
+}
+
+func NewInMemResolver() *InMemResolver {
+	return &InMemResolver{
+		hosts: map[string][]netip.Addr{},
+	}
+}
+func (r *InMemResolver) LookupIP(ctx context.Context, host string) ([]netip.Addr, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if r, found := r.hosts[host]; found {
+		return r, nil
+	}
+	return nil, fmt.Errorf("not found")
+}
+
+func (r *InMemResolver) Set(host string, addrs []netip.Addr) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.hosts[host] = addrs
+}
+
+func (r *InMemResolver) Delete(host string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.hosts, host)
+}

--- a/internal/nexodus/nexodus.go
+++ b/internal/nexodus/nexodus.go
@@ -872,7 +872,7 @@ func (nx *Nexodus) Stop() {
 	}
 	if nx.nexRelay.derpProxy != nil {
 		nx.logger.Info("Stopping HTTPS/TLS Derp Server Proxy")
-		nx.nexRelay.derpProxy.stopDerpProxy()
+		nx.nexRelay.derpProxy.Stop()
 	}
 }
 
@@ -1239,9 +1239,9 @@ func (nx *Nexodus) reconcileDeviceCache() error {
 			if nx.nexRelay.derpProxy == nil {
 				// Start Derp Proxy if we have a Derp Map and a Derp ID
 				nx.nexRelay.derpProxy = NewDerpUserSpaceProxy(nx.logger, &nx.nexRelay)
-				nx.nexRelay.derpProxy.startDerpProxy()
+				nx.nexRelay.derpProxy.Start()
 			} else if nx.nexRelay.derpProxy.port != nx.nexRelay.myDerp {
-				nx.nexRelay.derpProxy.restartDerpProxy()
+				nx.nexRelay.derpProxy.Restart()
 			}
 		}
 	}

--- a/internal/nexodus/nexodus.go
+++ b/internal/nexodus/nexodus.go
@@ -136,6 +136,9 @@ type nexRelay struct {
 	// derpRecvCh is used by receiveDERP to read DERP messages.
 	// It must have buffer size > 0; see issue 3736.
 	derpRecvCh chan derpReadResult
+
+	// this is used to provide fallback IP resolution for derp servers.
+	inMemResolver *InMemResolver
 }
 
 type peerHealth struct {
@@ -221,6 +224,7 @@ type Nexodus struct {
 	regKey                  string
 	relay                   bool
 	relayDerp               bool
+	relayOnly               bool
 	requestedIP             string
 	stateDir                string
 	stateStore              state.Store
@@ -308,6 +312,7 @@ func New(o Options) (*Nexodus, error) {
 		networkRouterDisableNAT: o.NetworkRouterDisableNAT,
 		apiURL:                  o.ApiURL,
 		symmetricNat:            o.RelayOnly,
+		relayOnly:               o.RelayOnly,
 		logger:                  o.Logger,
 		logLevel:                o.LogLevel,
 		version:                 o.Version,
@@ -334,6 +339,7 @@ func New(o Options) (*Nexodus, error) {
 			peerLastDerp:  make(map[key.NodePublic]int),
 			logf:          tlogger.WithPrefix(log.Printf, "nexodus-derp: "),
 			logger:        o.Logger,
+			inMemResolver: NewInMemResolver(),
 		},
 		exitNode: exitNode{
 			exitNodeClientEnabled: o.ExitNodeClientEnabled,

--- a/internal/nexodus/nexodus.go
+++ b/internal/nexodus/nexodus.go
@@ -932,7 +932,7 @@ func (nx *Nexodus) reconcileSecurityGroups(ctx context.Context) {
 		return
 	}
 
-	nx.logger.Debugf("Security Group change detected: %+v", responseSecGroup)
+	nx.logger.Debugf("Security Group change detected: %+v", util.JsonStringer(responseSecGroup))
 	oldSecGroup := nx.securityGroup
 	nx.securityGroup = &responseSecGroup
 
@@ -1043,7 +1043,7 @@ func (nx *Nexodus) reconcileStun(deviceID string) error {
 			nx.nodeReflexiveAddressIPv4 = reflexiveIP
 			// reinitialize peers if the NAT binding has changed for the node
 			if err = nx.reconcileDeviceCache(); err != nil {
-				nx.logger.Debugf("reconcile failed %v", res)
+				nx.logger.Debugf("reconcile failed %v", util.JsonStringer(res))
 			}
 		}
 	}
@@ -1177,7 +1177,7 @@ func (nx *Nexodus) reconcileDeviceCache() error {
 					p.GetHostname(), p.GetPublicKey(), err)
 			} else {
 				existing.metadata = metadata
-				nx.logger.Debugf("successfully fetched device metadata: %v", existing.metadata)
+				nx.logger.Debugf("successfully fetched device metadata: %s", util.JsonStringer(existing.metadata))
 			}
 			nx.relayWgIP = p.AllowedIps[0]
 		}

--- a/internal/nexodus/nexodus_darwin.go
+++ b/internal/nexodus/nexodus_darwin.go
@@ -109,7 +109,7 @@ func (nx *Nexodus) findLocalIP() (string, error) {
 func (nx *Nexodus) configureLoopback(ip string) error {
 	_, err := RunCommand("ifconfig", "lo0", "alias", ip, "up")
 	if err != nil {
-		nx.logger.Errorf("failed to setup loopback alias for ip %s : %v\n", dev, err)
+		nx.logger.Errorf("failed to setup loopback alias for ip %v: %v\n", dev, err)
 		return fmt.Errorf("%w", interfaceErr)
 	}
 	return nil

--- a/internal/nexodus/utils.go
+++ b/internal/nexodus/utils.go
@@ -13,8 +13,6 @@ import (
 	"strings"
 
 	"github.com/nexodus-io/nexodus/internal/stun"
-	"github.com/txn2/txeh"
-
 	"go.uber.org/zap"
 )
 
@@ -280,32 +278,4 @@ func ResolveURLToIP(rawURL string) ([]net.IP, error) {
 	}
 
 	return ips, nil
-}
-
-func SetLocalDerpDnsEntry(ip string, domain string) error {
-	hosts, err := txeh.NewHostsDefault()
-	if err != nil {
-		return fmt.Errorf("failed to read hosts file : %w", err)
-	}
-
-	hosts.AddHost(ip, domain)
-	err = hosts.Save()
-	if err != nil {
-		return fmt.Errorf("failed to save hosts file : %w", err)
-	}
-	return nil
-}
-
-func RemoveLocalDerpDnsEntry(domain string) error {
-	hosts, err := txeh.NewHostsDefault()
-	if err != nil {
-		return fmt.Errorf("failed to read hosts file : %w", err)
-	}
-
-	hosts.RemoveHost(domain)
-	err = hosts.Save()
-	if err != nil {
-		return fmt.Errorf("failed to save hosts file : %w", err)
-	}
-	return nil
 }

--- a/internal/nexodus/wg_peers.go
+++ b/internal/nexodus/wg_peers.go
@@ -259,7 +259,7 @@ func (nx *Nexodus) buildPeersConfig() map[string]client.ModelsDevice {
 
 		if hostname != "" && derpAddr != "" {
 			if nx.nexRelay.myDerp == DefaultDerpRegionID {
-				nx.logger.Debugf("User on-boarded derp relay is available, switching to on-boarded relay from public relay. : [ %v] ", nx.nexRelay.derpMap.Regions[CustomDerpRegionID])
+				nx.logger.Debugf("User on-boarded derp relay is available, switching to on-boarded relay from public relay.")
 				nx.nexRelay.closeDerpLocked(nx.nexRelay.myDerp, "switching to custom DERP map")
 			}
 			if nx.nexRelay.myDerp == 0 {

--- a/internal/nexodus/wg_peers_test.go
+++ b/internal/nexodus/wg_peers_test.go
@@ -20,18 +20,27 @@ func TestRebuildPeerConfig(t *testing.T) {
 		},
 		nodeReflexiveAddressIPv4: netip.MustParseAddrPort("1.1.1.1:1234"),
 		logger:                   testLogger,
+		nexRelay: nexRelay{
+			derpIpMapping: NewDerpIpMapping(),
+		},
 	}
 	nxRelay := &Nexodus{
 		vpc:                      nxBase.vpc,
 		relay:                    true,
 		nodeReflexiveAddressIPv4: netip.MustParseAddrPort("1.1.1.1:1234"),
 		logger:                   testLogger,
+		nexRelay: nexRelay{
+			derpIpMapping: NewDerpIpMapping(),
+		},
 	}
 	nxSymmetricNAT := &Nexodus{
 		vpc:                      nxBase.vpc,
 		symmetricNat:             true,
 		nodeReflexiveAddressIPv4: netip.MustParseAddrPort("1.1.1.1:1234"),
 		logger:                   testLogger,
+		nexRelay: nexRelay{
+			derpIpMapping: NewDerpIpMapping(),
+		},
 	}
 	nxDerpRelay := &Nexodus{
 		vpc:                      nxBase.vpc,
@@ -97,7 +106,7 @@ func TestRebuildPeerConfig(t *testing.T) {
 		},
 		{
 			// Ensure we choose reflexive peering when the reflexive IPs are different
-			name:           "reflexive peering",
+			name:           "reflexive peering with relay",
 			nx:             nxBase,
 			peerLocalIP:    "192.168.10.50:5678",
 			peerStunIP:     "2.2.2.2:4321",
@@ -159,8 +168,8 @@ func TestRebuildPeerConfig(t *testing.T) {
 			peerLocalIP:    "192.168.10.50:5678",
 			peerStunIP:     "1.1.1.1:4321",
 			expectedMethod: peeringMethodDirectLocal,
-			secondMethod:   peeringMethodDirectLocal, // our only choice without a relay
-			thirdMethod:    peeringMethodDirectLocal, // our only choice without a relay
+			secondMethod:   peeringMethodViaDerpRelay, // our only choice without a wg relay
+			thirdMethod:    peeringMethodDirectLocal,  // roll back around to first option.
 		},
 		{
 			// No peering method available when we are behind symmetric NAT and we


### PR DESCRIPTION
* e2e: avoid using os.env to configure test options as that can cause a data race in concurrent tests.
* add make e2e-setup target that gets you setup to run e2e tests.
* don’t allow direct local connections when the `--peer-only` cli option is used.
* fx data races in derp proxy restart