### PR TITLE
fix: Add patch version to go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nexodus-io/nexodus
 
-go 1.22
+go 1.22.5
 
 require (
 	github.com/Nerzal/gocloak/v13 v13.9.0


### PR DESCRIPTION
Without this go1.22 on Linux complains that it can't download the correct version of Go.